### PR TITLE
change class names to PEP8 style

### DIFF
--- a/src/vivarium_census_prl_synth_pop/synthetic_pii.py
+++ b/src/vivarium_census_prl_synth_pop/synthetic_pii.py
@@ -4,7 +4,7 @@ synthetically, e.g. name, address, social-security number
 import pandas as pd
 import numpy as np
 
-class generic_generator:
+class GenericGenerator:
     def __init__(self, seed : int):
         self._rng = np.random.default_rng(seed)
 
@@ -15,7 +15,7 @@ class generic_generator:
         return df
 
 
-class dob_generator(generic_generator):
+class DOBGenerator(GenericGenerator):
     def generate(self, df_in : pd.DataFrame) -> pd.DataFrame:
         """Generate synthetic Date of Birth
 
@@ -49,7 +49,7 @@ class dob_generator(generic_generator):
         return df
 
 
-class ssn_generator(generic_generator):
+class SSNGenerator(GenericGenerator):
     def generate(self, df_in : pd.DataFrame) -> pd.DataFrame:
         """Generate synthetic Social Security Numbers
 
@@ -204,7 +204,7 @@ def random_last_names(rng, race_eth, size):
     return s_last
 
 
-class name_generator(generic_generator):
+class NameGenerator(GenericGenerator):
     def generate(self, df_in : pd.DataFrame) -> pd.DataFrame:
         """Generate synthetic names for individuals
 

--- a/tests/test_synthetic_pii.py
+++ b/tests/test_synthetic_pii.py
@@ -4,7 +4,7 @@ import numpy as np, pandas as pd
 from vivarium_census_prl_synth_pop import synthetic_pii
 
 def test_generic():
-    g = synthetic_pii.generic_generator(1234)
+    g = synthetic_pii.GenericGenerator(1234)
 
     index = [1, 2, 4, 8]
     df_in = pd.DataFrame(index=index)
@@ -17,7 +17,7 @@ def test_generic():
     assert np.all(df.index == df2.index) and np.all(df.columns == df2.columns), "expect noise to leave dataframe index and columns unchanged"
 
 def test_dob():
-    g = synthetic_pii.dob_generator(1234)
+    g = synthetic_pii.DOBGenerator(1234)
 
     index = range(10)
     df_in = pd.DataFrame(index=index)
@@ -32,7 +32,7 @@ def test_dob():
     assert np.all(df.index == df2.index) and np.all(df.columns == df2.columns), "expect noise to leave dataframe index and columns unchanged"
 
 def test_ssn():
-    g = synthetic_pii.ssn_generator(1234)
+    g = synthetic_pii.SSNGenerator(1234)
 
     index = range(10)
     df_in = pd.DataFrame(index=index)
@@ -51,7 +51,7 @@ def test_ssn():
 
 
 def test_name():
-    g = synthetic_pii.name_generator(1234)
+    g = synthetic_pii.NameGenerator(1234)
 
     all_race_eth_values = ['White', 'Latino', 'Black', 'Asian', 'Multiracial or Other', 'AIAN', 'NHOPI']
     index = range(len(all_race_eth_values))


### PR DESCRIPTION
## Title: Change class names to PEP8 style
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: refactor
- *JIRA issue*: none
- *Research reference*: none

Rename synthetic PII classes to use CapCase, as is the python custom 

### Verification and Testing
updated automatic tests all pass

