### PR TITLE
Move zipcode and address to migration.household

### DIFF
--- a/src/vivarium_census_prl_synth_pop/components/migration/household.py
+++ b/src/vivarium_census_prl_synth_pop/components/migration/household.py
@@ -40,19 +40,23 @@ class HouseholdMigration:
         self.config = builder.configuration
         self.location = builder.data.load(data_keys.POPULATION.LOCATION)
         self.start_time = get_time_stamp(builder.configuration.time.start)
+
+        move_rate_data = builder.lookup.build_table(data_values.HOUSEHOLD_MOVE_RATE_YEARLY)
+        self.household_move_rate = builder.value.register_rate_producer(f'{self.name}.move_rate', source=move_rate_data)
+
         self.randomness = builder.randomness.get_stream(self.name)
         self.fake = faker.Faker()
         faker.Faker.seed(self.config.randomness.random_seed)
         self.provider = faker.providers.address.en_US.Provider(faker.Generator())
 
-        self.columns_needed = ['household_id', 'address', 'zipcode']
-        self.population_view = builder.population.get_view(self.columns_needed)
-        move_rate_data = builder.lookup.build_table(data_values.HOUSEHOLD_MOVE_RATE_YEARLY)
-        self.household_move_rate = builder.value.register_rate_producer(f'{self.name}.move_rate', source=move_rate_data)
+        self.columns_created = ['address', 'zipcode']
+        self.columns_used = ['household_id', 'address', 'zipcode', 'tracked']
+        self.population_view = builder.population.get_view(self.columns_used)
 
         builder.population.initializes_simulants(
             self.on_initialize_simulants,
-            requires_columns=self.columns_needed,
+            requires_columns=['household_id'],
+            creates_columns=self.columns_created
         )
         builder.event.register_listener("time_step", self.on_time_step)
 
@@ -65,13 +69,32 @@ class HouseholdMigration:
         add addresses to each household in the population table
         """
         if pop_data.creation_time < self.start_time:
-            households = self.population_view.subview(['household_id']).get(pop_data.index)
-            address_assignments = self._generate_addresses(list(households.drop_duplicates().squeeze()))
+            households = self.population_view.subview(['household_id', 'tracked']).get(pop_data.index)
+            address_assignments = self._generate_addresses(list(households['household_id'].drop_duplicates().squeeze()))
             households['address'] = households['household_id'].map(address_assignments['address'])
             households['zipcode'] = households['household_id'].map(address_assignments['zipcode'])
+
+            households.loc[households.household_id == 'NA', 'address'] = 'NA'
+            households.loc[households.household_id == 'NA', 'zipcode'] = 'NA'
+
             self.population_view.update(
                 households
             )
+        else:
+            parent_ids = pop_data.user_data['parent_ids']
+            mothers = self.population_view.get(parent_ids.unique())
+            new_births = pd.DataFrame(data={
+                'parent_id': parent_ids
+            }, index=pop_data.index)
+
+            # assign babies inherited traits
+            new_births = new_births.merge(
+                mothers[self.columns_created], left_on='parent_id', right_index=True
+            )
+            self.population_view.update(
+                new_births[self.columns_created]
+            )
+
 
     def on_time_step(self, event: Event):
         """

--- a/src/vivarium_census_prl_synth_pop/components/population.py
+++ b/src/vivarium_census_prl_synth_pop/components/population.py
@@ -24,8 +24,6 @@ class Population:
 
         self.columns_created = [
             'household_id',
-            'address',
-            'zipcode',
             'state',
             'puma',
             'relation_to_household_head',
@@ -102,8 +100,6 @@ class Population:
 
         # format
         n_chosen = chosen_persons.shape[0]
-        chosen_persons['address'] = 'NA'
-        chosen_persons['zipcode'] = 'NA'
         chosen_persons['entrance_time'] = pop_data.creation_time
         chosen_persons['exit_time'] = pd.NaT
         chosen_persons['alive'] = 'alive'
@@ -115,8 +111,6 @@ class Population:
             extras = pd.DataFrame(
                 data={
                     'household_id': ['NA'],
-                    'address': ['NA'],
-                    'zipcode': ['NA'],
                     'state': [-1],
                     'puma': ['NA'],
                     'age': [np.NaN],
@@ -151,8 +145,6 @@ class Population:
         }, index=pop_data.index)
 
         inherited_traits = ['household_id',
-                            'address',
-                            'zipcode',
                             'state',
                             'puma',
                             'race_ethnicity',


### PR DESCRIPTION
## Move zipcode and address to migration.household
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
Move columns zipcode and address such that they are initialized by `migration.household` instead of `population`
- *Category*: refactor
- *JIRA issue*: [MIC-3221](https://jira.ihme.washington.edu/browse/MIC-3221)
- *Research reference*: <!--Link to research documentation for code -->

<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 

### Verification and Testing
Checked simulation didn't break / still runs

