### PR TITLE
moving relation to household head datatype back from category to object

### DIFF
--- a/src/vivarium_census_prl_synth_pop/components/migration/person.py
+++ b/src/vivarium_census_prl_synth_pop/components/migration/person.py
@@ -69,10 +69,7 @@ class PersonMigration:
             new_household_data,
             on='household_id'
         )
-        persons_who_move['relation_to_household_head'] = pd.Categorical(
-            ["Other nonrelative"]*len(persons_who_move),
-            categories=list(metadata.RELATIONSHIP_TO_HOUSEHOLD_HEAD_MAP.values()) + ['NA']
-        )
+        persons_who_move['relation_to_household_head'] = "Other nonrelative"
 
         self.population_view.update(
             persons_who_move

--- a/src/vivarium_census_prl_synth_pop/components/population.py
+++ b/src/vivarium_census_prl_synth_pop/components/population.py
@@ -137,12 +137,6 @@ class Population:
         chosen_persons['state'] = chosen_persons['state'].astype('int64')
         for col in ['sex', 'race_ethnicity']:
             chosen_persons[col] = chosen_persons[col].astype('category')
-
-        chosen_persons['relation_to_household_head'] = pd.Categorical(
-            chosen_persons['relation_to_household_head'],
-            categories=list(metadata.RELATIONSHIP_TO_HOUSEHOLD_HEAD_MAP.values()) + ['NA']
-        )
-
         chosen_persons = chosen_persons.set_index(pop_data.index)
         self.population_view.update(
             chosen_persons
@@ -167,9 +161,8 @@ class Population:
         new_births = new_births.merge(
             mothers[inherited_traits], left_on='parent_id', right_index=True
         )
-        new_births['relation_to_household_head'] = pd.Categorical(
-            new_births['relation_to_household_head'].map(metadata.NEWBORNS_RELATION_TO_HOUSEHOLD_HEAD_MAP),
-            categories=list(metadata.RELATIONSHIP_TO_HOUSEHOLD_HEAD_MAP.values()) + ['NA']
+        new_births['relation_to_household_head'] = new_births['relation_to_household_head'].map(
+            metadata.NEWBORNS_RELATION_TO_HOUSEHOLD_HEAD_MAP
         )
 
         # assign babies uninherited traits


### PR DESCRIPTION
## Change "relation to household head" column from category to object
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
Change "relation to household head" column from category to object
- *Category*: bugfix / refactor
- *JIRA issue*: [MIC-3271](https://jira.ihme.washington.edu/browse/MIC-3271)
- *Research reference*: NA

(the category typing resulted in vivarium throwing too many fits)

### Verification and Testing
Made sure didn't break sim, and outputs still look correct.
