### PR TITLE
Adding additional key for last name generation

### DIFF
--- a/src/vivarium_census_prl_synth_pop/components/household.py
+++ b/src/vivarium_census_prl_synth_pop/components/household.py
@@ -3,7 +3,6 @@ from vivarium.framework.engine import Builder
 from vivarium.framework.event import Event
 from vivarium.framework.population import SimulantData
 from vivarium.framework.time import get_time_stamp
-from vivarium.framework.values import Pipeline
 
 from vivarium_census_prl_synth_pop.components.synthetic_pii import (
     update_address_and_zipcode,

--- a/src/vivarium_census_prl_synth_pop/components/synthetic_pii.py
+++ b/src/vivarium_census_prl_synth_pop/components/synthetic_pii.py
@@ -284,7 +284,7 @@ class NameGenerator(GenericGenerator):
         last_names = pd.Series(index=df_in.index, dtype=str)
         for race_eth, df_race_eth in df_in.groupby("race_ethnicity"):
             last_names.loc[df_race_eth.index] = self.random_last_names(
-                self.randomness, race_eth, len(df_race_eth)
+                self.randomness, race_eth, len(df_race_eth), "last_name"
             )
         # TODO: include household structure
         return pd.DataFrame(last_names, columns=["last_name"])

--- a/src/vivarium_census_prl_synth_pop/utilities.py
+++ b/src/vivarium_census_prl_synth_pop/utilities.py
@@ -8,6 +8,7 @@ from loguru import logger
 from scipy import stats
 from vivarium.framework.lookup import LookupTable
 from vivarium.framework.randomness import Array, RandomnessStream, get_hash
+from vivarium.framework.values import Pipeline
 from vivarium_public_health.risks.data_transformations import pivot_categorical
 
 from vivarium_census_prl_synth_pop.constants import metadata
@@ -246,7 +247,7 @@ def random_integers(
 def filter_by_rate(
     entity_to_filter: Union[pd.Index, pd.Series],
     randomness: RandomnessStream,
-    rate_producer: LookupTable,
+    rate_producer: Union[LookupTable, Pipeline],
     additional_key: Any = None,
 ) -> pd.Index:
     """


### PR DESCRIPTION
## Update/additional key for last name generation

### Adds a additional key to the call for last name generation for simulants.
- *Category*: Other
- *JIRA issue*: [MIC-3481](https://jira.ihme.washington.edu/browse/MIC-3481)
- *Research reference*: N/A

-Added additional key to calls for last name generation in synthetic_pii module.
-Fixed typing and imports

### Verification and Testing
Successfully ran simulation.  Everything looks as expected.  This was already working but has been verified to be working correctly until we implement changed to names from new RT documentation.  Additional key should prevent any bugs in the future.
<img width="391" alt="last_names" src="https://user-images.githubusercontent.com/37345113/195699901-9ee9e73b-f901-40a2-b6e8-76a6f3ba7a7a.PNG">


