### PR TITLE
Logging/business names generation

### DIFF
--- a/src/vivarium_census_prl_synth_pop/data/generate_business_names.py
+++ b/src/vivarium_census_prl_synth_pop/data/generate_business_names.py
@@ -35,7 +35,7 @@ def generate_business_names_data(n_total_names: str):
             bigrams, n_needed, data_values.BUSINESS_NAMES_MAX_TOKENS_LENGTH
         )
         generation_time = time.time() - start_time
-        logger.info(f"Total time for {cycles} iteration of name sample was {generation_time}.")
+        logger.info(f"Total time to sample {n_needed} names for {cycles} iteration of name sample was {generation_time}.")
 
         # Check for duplicates
         duplicate_processing_start_time = time.time()


### PR DESCRIPTION
## Improve Logging for

### Adds more robust logging for business name generation to find points of contention in runtime.
- *Category*: Test
- *JIRA issue*: [MIC-3437](https://jira.ihme.washington.edu/browse/MIC-3437)
- *Research reference*: N/A

-Adds logging to capture number of duplicates generated each time business names are generated
-Adds logging to capture time it takes to generated names
-Adds logging to capture time it takes to process duplicates

### Verification and Testing
Ran script and produced desired log outputs.

