### PR TITLE
Feature/guardian initialization

### DIFF
--- a/src/vivarium_census_prl_synth_pop/components/population.py
+++ b/src/vivarium_census_prl_synth_pop/components/population.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pandas as pd
-
 from vivarium.framework.engine import Builder
 from vivarium.framework.event import Event
 from vivarium.framework.population import SimulantData
@@ -237,7 +236,7 @@ class Population:
         parent_ids_idx = pop_data.user_data["parent_ids"]
         pop_index = pop_data.user_data["current_population_index"]
         mothers = self.population_view.get(parent_ids_idx.unique())
-        ssns = self.population_view.subview(['ssn']).get(pop_index).squeeze()
+        ssns = self.population_view.subview(["ssn"]).get(pop_index).squeeze()
         new_births = pd.DataFrame(data={"parent_id": parent_ids_idx}, index=pop_data.index)
 
         inherited_traits = [
@@ -262,16 +261,24 @@ class Population:
         # birthday map between parent_ids and DOB (so twins get same bday)
         # note we use np.floor to guarantee birth at midnight
         dob_map = {
-            parent: dob for (parent, dob) in zip(
+            parent: dob
+            for (parent, dob) in zip(
                 parent_ids_idx.unique(),
-                pop_data.creation_time + pd.to_timedelta(
-                    np.floor(self.randomness.get_draw(parent_ids_idx.unique(), "dob") * self.step_size_days), unit="days"
-                )
+                pop_data.creation_time
+                + pd.to_timedelta(
+                    np.floor(
+                        self.randomness.get_draw(parent_ids_idx.unique(), "dob")
+                        * self.step_size_days
+                    ),
+                    unit="days",
+                ),
             )
         }
         new_births["date_of_birth"] = new_births["parent_id"].map(dob_map)
 
-        new_births["age"] = (pop_data.creation_time - new_births["date_of_birth"]).dt.days / DAYS_PER_YEAR
+        new_births["age"] = (
+            pop_data.creation_time - new_births["date_of_birth"]
+        ).dt.days / DAYS_PER_YEAR
 
         # add some noise because our randomness keys on entrance time and age,
         # so don't want people born same day to have same exact age
@@ -328,7 +335,9 @@ class Population:
         event : vivarium.framework.event.Event
 
         """
-        population = self.population_view.subview(["age"]).get(event.index, query="alive == 'alive'")
+        population = self.population_view.subview(["age"]).get(
+            event.index, query="alive == 'alive'"
+        )
         population["age"] += to_years(event.step_size)
         self.population_view.update(population)
 

--- a/src/vivarium_census_prl_synth_pop/components/population.py
+++ b/src/vivarium_census_prl_synth_pop/components/population.py
@@ -238,10 +238,9 @@ class Population:
     def initialize_newborns(self, pop_data: SimulantData) -> None:
         parent_ids_idx = pop_data.user_data["parent_ids"]
         pop_index = pop_data.user_data["current_population_index"]
-
-        mothers = self.population_view.get(parent_ids.unique())
-        ssns = self.population_view.subview(["ssn"]).get(pop_index).squeeze()
-        new_births = pd.DataFrame(data={"parent_id": parent_ids}, index=pop_data.index)
+        mothers = self.population_view.get(parent_ids_idx.unique())
+        ssns = self.population_view.subview(['ssn']).get(pop_index).squeeze()
+        new_births = pd.DataFrame(data={"parent_id": parent_ids_idx}, index=pop_data.index)
 
         inherited_traits = [
             "household_id",

--- a/src/vivarium_census_prl_synth_pop/components/population.py
+++ b/src/vivarium_census_prl_synth_pop/components/population.py
@@ -351,6 +351,13 @@ class Population:
         relatives_of_rp_idx = household_structure.loc[
             ~household_structure["relation_to_household_head_y"].isin(non_relatives)
         ].index
+        non_relative_of_rp_idx = household_structure.loc[
+            household_structure["relation_to_household_head_y"].isin(non_relatives)
+        ].index
+        age_bound_idx = household_structure.loc[
+            (household_structure["age_difference"] >= 20) &
+            (household_structure["age_difference"] < 46) &
+        ].index
 
         # Children of reference person - red box
         children_of_rp = household_structure.loc[

--- a/src/vivarium_census_prl_synth_pop/components/population.py
+++ b/src/vivarium_census_prl_synth_pop/components/population.py
@@ -317,8 +317,8 @@ class Population:
         # typing
         new_births["household_id"] = new_births["household_id"].astype(int)
         # todo: Update guardian columns MIC-3595
-        new_births["guardian_1"] = -1
-        new_births["guardian_2"] = -1
+        new_births["guardian_1"] = data_values.UNKNOWN_GUARDIAN_IDX
+        new_births["guardian_2"] = data_values.UNKNOWN_GUARDIAN_IDX
 
         self.population_view.update(new_births[self.columns_created])
 
@@ -348,8 +348,8 @@ class Population:
         """
         start_time = time.time()
         # Initialize column
-        pop["guardian_1"] = -1
-        pop["guardian_2"] = -1
+        pop["guardian_1"] = data_values.UNKNOWN_GUARDIAN_IDX
+        pop["guardian_2"] = data_values.UNKNOWN_GUARDIAN_IDX
         # Helper lists
         non_relatives = ["Roommate", "Other nonrelative"]
         children = ["Biological child", "Adopted child", "Foster child", "Stepchild"]

--- a/src/vivarium_census_prl_synth_pop/components/population.py
+++ b/src/vivarium_census_prl_synth_pop/components/population.py
@@ -410,30 +410,6 @@ class Population:
             )
             pop.loc[partners_of_rp_parent_ids.index, "guardian_2"] = partners_of_rp_parent_ids
 
-        # Children are relative of reference person with no age bound relative(s) - yellow box
-        relative_ids = (
-            household_structure.loc[
-                child_relative_of_rp_idx
-                .intersection(rp_idx)
-            ]
-            .reset_index()
-            .set_index("child_id")["person_id"]
-        )
-        pop.loc[relative_ids.index, "guardian_1"] = relative_ids
-        # Assign guardian to spouse/partner of reference person
-        relative_with_rp_partner_guardian_ids = household_structure.loc[
-            child_relative_of_rp_idx
-            .intersection(partners_idx)
-        ]
-        if len(relative_with_rp_partner_guardian_ids) > 0:
-            relative_with_rp_partner_guardian_ids = (
-                relative_with_rp_partner_guardian_ids
-                .reset_index()
-                .groupby(["child_id"])["person_id"]
-                .apply(np.random.choice)
-            )
-            pop.loc[relative_with_rp_partner_guardian_ids.index, "guardian_2"] = relative_with_rp_partner_guardian_ids
-
         # Children are relative of reference person with relative(s) in age bound - orange box
         relatives_with_guardian = household_structure.loc[
             child_relative_of_rp_idx
@@ -450,7 +426,32 @@ class Population:
             pop.loc[
                 relatives_with_guardian_ids.index, "guardian_1"
             ] = relatives_with_guardian_ids
-            pop.loc[relatives_with_guardian_ids.index, "guardian_2"] = -1
+
+        # Children are relative of reference person with no age bound relative(s) - yellow box
+        relative_ids = (
+            household_structure.loc[
+                child_relative_of_rp_idx
+                .drop(relatives_with_guardian.index.unique("child_id"), level="child_id")
+                .intersection(rp_idx)
+            ]
+            .reset_index()
+            .set_index("child_id")["person_id"]
+        )
+        pop.loc[relative_ids.index, "guardian_1"] = relative_ids
+        # Assign guardian to spouse/partner of reference person
+        relative_with_rp_partner_guardian_ids = household_structure.loc[
+            child_relative_of_rp_idx
+            .drop(relatives_with_guardian.index.unique("child_id"), level="child_id")
+            .intersection(partners_idx)
+        ]
+        if len(relative_with_rp_partner_guardian_ids) > 0:
+            relative_with_rp_partner_guardian_ids = (
+                relative_with_rp_partner_guardian_ids
+                .reset_index()
+                .groupby(["child_id"])["person_id"]
+                .apply(np.random.choice)
+            )
+            pop.loc[relative_with_rp_partner_guardian_ids.index, "guardian_2"] = relative_with_rp_partner_guardian_ids
 
         # Children are reference person and have a parent in household - green box
         child_rp_with_parent = household_structure.loc[

--- a/src/vivarium_census_prl_synth_pop/components/population.py
+++ b/src/vivarium_census_prl_synth_pop/components/population.py
@@ -1,8 +1,6 @@
-import time
-
 import numpy as np
 import pandas as pd
-from loguru import logger
+
 from vivarium.framework.engine import Builder
 from vivarium.framework.event import Event
 from vivarium.framework.population import SimulantData
@@ -346,7 +344,7 @@ class Population:
         pd.Dataframe that will be pop with an additional guardians column containing the index for that simulant's
           guardian..
         """
-        start_time = time.time()
+
         # Initialize column
         pop["guardian_1"] = data_values.UNKNOWN_GUARDIAN_IDX
         pop["guardian_2"] = data_values.UNKNOWN_GUARDIAN_IDX

--- a/src/vivarium_census_prl_synth_pop/components/population.py
+++ b/src/vivarium_census_prl_synth_pop/components/population.py
@@ -360,6 +360,7 @@ class Population:
         # Helper lists
         non_relatives = ["Roommate", "Other nonrelative"]
         children = ["Biological child", "Adopted child", "Foster child", "Stepchild"]
+        children_relatives = ["Sibling", "Other relative", "Grandchild", "Child-in-law"]
         parents = ["Parent", "Parent-in-law"]
         partners = [
             "Opp-sex spouse",
@@ -379,9 +380,7 @@ class Population:
             child_households["child_relation_to_household_head"].isin(children)
         ].index
         child_relative_of_ref_person_idx = child_households.loc[
-            child_households["child_relation_to_household_head"].isin(
-                ["Sibling", "Other relative", "Grandchild", "Child-in-law"]
-            )
+            child_households["child_relation_to_household_head"].isin(children_relatives)
         ].index
         child_non_relative_of_ref_person_idx = child_households.loc[
             child_households["child_relation_to_household_head"].isin(non_relatives)
@@ -429,23 +428,23 @@ class Population:
         ]
         if len(partners_of_ref_person_parent_ids) > 0:
             # Select random partner of reference person and assign as second guardian
-            partners_of_ref_person_parent_ids = (
-                self.choose_random_guardian(partners_of_ref_person_parent_ids)
+            partners_of_ref_person_parent_ids = self.choose_random_guardian(
+                partners_of_ref_person_parent_ids
             )
-            pop.loc[partners_of_ref_person_parent_ids.index, "guardian_2"] = partners_of_ref_person_parent_ids
+            pop.loc[
+                partners_of_ref_person_parent_ids.index, "guardian_2"
+            ] = partners_of_ref_person_parent_ids
 
         # Children are relative of reference person with relative(s) in age bound, assign to random age bound
         # relative - orange box
         relatives_with_guardian = child_households.loc[
-            child_relative_of_ref_person_idx.intersection(relatives_of_ref_person_idx).intersection(
-                age_bound_idx
-            )
+            child_relative_of_ref_person_idx.intersection(
+                relatives_of_ref_person_idx
+            ).intersection(age_bound_idx)
         ]
         if len(relatives_with_guardian) > 0:
             # Select random relative if multiple and assign as guardian
-            relatives_with_guardian_ids = (
-                self.choose_random_guardian(relatives_with_guardian)
-            )
+            relatives_with_guardian_ids = self.choose_random_guardian(relatives_with_guardian)
             pop.loc[
                 relatives_with_guardian_ids.index, "guardian_1"
             ] = relatives_with_guardian_ids
@@ -469,8 +468,8 @@ class Population:
         ]
         if len(relative_with_ref_person_partner_guardian_ids) > 0:
             # Select random partner of reference person and assign as second guardian
-            relative_with_ref_person_partner_guardian_ids = (
-                self.choose_random_guardian(relative_with_ref_person_partner_guardian_ids)
+            relative_with_ref_person_partner_guardian_ids = self.choose_random_guardian(
+                relative_with_ref_person_partner_guardian_ids
             )
             pop.loc[
                 relative_with_ref_person_partner_guardian_ids.index, "guardian_2"
@@ -481,21 +480,25 @@ class Population:
             child_ref_person_idx.intersection(parents_of_ref_person_idx)
         ]
         if len(child_ref_person_with_parent) > 0:
-            child_ref_person_with_parent_ids = (
-                self.choose_random_guardian(child_ref_person_with_parent())
+            child_ref_person_with_parent_ids = self.choose_random_guardian(
+                child_ref_person_with_parent
             )
-            pop.loc[child_ref_person_with_parent_ids.index, "guardian_1"] = child_ref_person_with_parent_ids
+            pop.loc[
+                child_ref_person_with_parent_ids.index, "guardian_1"
+            ] = child_ref_person_with_parent_ids
 
         # Child is reference person with no parent, assign to age bound relative - blue box
         child_ref_person_with_relative_ids = child_households.loc[
-            child_ref_person_idx.drop(child_ref_person_with_parent.index.unique("child_id"), level="child_id")
+            child_ref_person_idx.drop(
+                child_ref_person_with_parent.index.unique("child_id"), level="child_id"
+            )
             .intersection(relatives_of_ref_person_idx)
             .intersection(age_bound_idx)
         ]
         if len(child_ref_person_with_relative_ids) > 0:
             # Select random relative if multiple and assign as guardian
-            child_ref_person_with_relative_ids = (
-                self.choose_random_guardian(child_ref_person_with_relative_ids)
+            child_ref_person_with_relative_ids = self.choose_random_guardian(
+                child_ref_person_with_relative_ids
             )
             pop.loc[
                 child_ref_person_with_relative_ids.index, "guardian_1"
@@ -503,15 +506,13 @@ class Population:
 
         # Child is not related to and is not reference person, assign to age bound non-relative - blurple box
         non_relative_guardian = child_households.loc[
-            child_non_relative_of_ref_person_idx.intersection(non_relatives_of_ref_person_idx).intersection(
-                age_bound_idx
-            )
+            child_non_relative_of_ref_person_idx.intersection(
+                non_relatives_of_ref_person_idx
+            ).intersection(age_bound_idx)
         ]
         if len(non_relative_guardian) > 0:
             # Select random non-relative if multiple and assign to guardian
-            non_relative_guardian_ids = (
-                self.choose_random_guardian(non_relative_guardian)
-            )
+            non_relative_guardian_ids = self.choose_random_guardian(non_relative_guardian)
             pop.loc[non_relative_guardian_ids.index, "guardian_1"] = non_relative_guardian_ids
 
         # Child is not reference person with no age bound non-relative, assign to adult non-relative - purple box
@@ -524,8 +525,8 @@ class Population:
         ]
         if len(other_non_relative_guardian_ids) > 0:
             # Select random non-relative if multiple and assign to guardian
-            other_non_relative_guardian_ids = (
-                self.choose_random_guardian(other_non_relative_guardian_ids)
+            other_non_relative_guardian_ids = self.choose_random_guardian(
+                other_non_relative_guardian_ids
             )
             pop.loc[
                 other_non_relative_guardian_ids.index, "guardian_1"
@@ -577,12 +578,14 @@ class Population:
             household_info, left_index=True, right_index=True
         )
         household_structure = household_structure.droplevel("household_id")
-        household_structure.rename(columns={
-            "age_x": "child_age",
-            "relation_to_household_head_x": "child_relation_to_household_head",
-            "age_y": "member_age",
-            "relation_to_household_head_y": "member_relation_to_household_head",
-        }, inplace=True
+        household_structure.rename(
+            columns={
+                "age_x": "child_age",
+                "relation_to_household_head_x": "child_relation_to_household_head",
+                "age_y": "member_age",
+                "relation_to_household_head_y": "member_relation_to_household_head",
+            },
+            inplace=True,
         )
         household_structure["age_difference"] = (
             household_structure["member_age"] - household_structure["child_age"]

--- a/src/vivarium_census_prl_synth_pop/components/population.py
+++ b/src/vivarium_census_prl_synth_pop/components/population.py
@@ -135,8 +135,8 @@ class Population:
         pop["state"] = pop["state"].astype("int64")
         pop = pop.set_index(pop_data.index)
 
-        # todo: initialize guardians for simulants: Should this be the last thing we do in initialize simulants?
         pop = self.assign_gen_pop_guardians(pop)
+        # todo: Assign GQ-college guardians - MIC-3597
 
         self.population_view.update(pop)
 
@@ -317,7 +317,7 @@ class Population:
 
         # typing
         new_births["household_id"] = new_births["household_id"].astype(int)
-        # todo: Update guardian columns
+        # todo: Update guardian columns MIC-3595
         new_births["guardian_1"] = -1
         new_births["guardian_2"] = -1
 

--- a/src/vivarium_census_prl_synth_pop/components/population.py
+++ b/src/vivarium_census_prl_synth_pop/components/population.py
@@ -60,6 +60,7 @@ class Population:
             "entrance_time",
             "exit_time",
             "housing_type",
+            "guardians"
         ]
         self.register_simulants = builder.randomness.register_simulants
         self.population_view = builder.population.get_view(self.columns_created)
@@ -129,6 +130,9 @@ class Population:
         # add typing
         pop["state"] = pop["state"].astype("int64")
         pop = pop.set_index(pop_data.index)
+
+        # todo: initialize guardians for simulants: Should this be the last thing we do in initialize simulants?
+        pop = self.assign_guardians(pop)
 
         self.population_view.update(pop)
 
@@ -307,3 +311,43 @@ class Population:
         population = self.population_view.get(event.index, query="alive == 'alive'")
         population["age"] += to_years(event.step_size)
         self.population_view.update(population)
+
+    def assign_guardians(self, pop: pd.DataFrame) -> pd.DataFrame:
+        """
+
+        Parameters
+        ----------
+        pop: State stable of simulants
+
+        Returns
+        -------
+        pd.Dataframe that will be pop with an additional guardians column which will be a list of one or two indexes or
+            "N/A" for that simulant's guaridans.
+        """
+
+        pop["guardians"] = [[] for _ in range(len(pop))]
+        # Grab indexes for 2 groups that will separate how we process different simulants who will have guardians
+        minors_general_pop_idx = pop.loc[
+            (pop["age"] < 18) & (~pop["household_id"].isin(data_values.GQ_HOUSING_TYPE_MAP))
+        ].index
+        # Get series of household_ids that have a minor living in them.
+        household_ids = pop.loc[minors_general_pop_idx, "household_id"].unique()
+        college_gq_idx = pop.loc[
+            (pop["age"] < 24) & (pop["household_id"] == data_values.NONINSTITUTIONAL_GROUP_QUARTER_IDS["College"])
+        ].index
+        # Should this age be lower bound?
+
+        # todo: Work through decision tree for < 18 year olds not in GQ
+        # Child is a biological, adopted, foster, or step child, assign to reference person
+        pop.loc[
+            minors_general_pop_idx.intersection(pop["relation_to_household_head"].isin(
+                ["Biological child", "Adopted child", "Foster child", "Stepchild"]).index
+            ), "guardians"] = pop.loc[
+            (pop["household_id"].isin(household_ids)) & (pop["relation_to_household_head"] == "Reference person")
+            ].index
+        # These can be different lengths
+
+
+        # todo: Add spouse as guardian
+
+        # todo: Work through decision tree for < 24 year olds in GQ

--- a/src/vivarium_census_prl_synth_pop/components/population.py
+++ b/src/vivarium_census_prl_synth_pop/components/population.py
@@ -414,16 +414,6 @@ class Population:
             child_households["member_relation_to_household_head"].isin(partners)
         ].index
 
-        # Helper function
-        def choose_random_guardian(member_ids: pd.DataFrame) -> pd.Series:
-            # member_ids is a subset of child_households dataframe
-            member_ids = (
-                    member_ids.reset_index()
-                .groupby(["child_id"])["person_id"]
-                .apply(np.random.choice)
-                )
-            return member_ids
-
         # Assign guardians across groups
         # Children of reference person, assign reference person as guardian - red box
         ref_person_parent_ids = (
@@ -440,7 +430,7 @@ class Population:
         if len(partners_of_ref_person_parent_ids) > 0:
             # Select random partner of reference person and assign as second guardian
             partners_of_ref_person_parent_ids = (
-                choose_random_guardian(partners_of_ref_person_parent_ids)
+                self.choose_random_guardian(partners_of_ref_person_parent_ids)
             )
             pop.loc[partners_of_ref_person_parent_ids.index, "guardian_2"] = partners_of_ref_person_parent_ids
 
@@ -454,7 +444,7 @@ class Population:
         if len(relatives_with_guardian) > 0:
             # Select random relative if multiple and assign as guardian
             relatives_with_guardian_ids = (
-                choose_random_guardian(relatives_with_guardian)
+                self.choose_random_guardian(relatives_with_guardian)
             )
             pop.loc[
                 relatives_with_guardian_ids.index, "guardian_1"
@@ -480,7 +470,7 @@ class Population:
         if len(relative_with_ref_person_partner_guardian_ids) > 0:
             # Select random partner of reference person and assign as second guardian
             relative_with_ref_person_partner_guardian_ids = (
-                choose_random_guardian(relative_with_ref_person_partner_guardian_ids)
+                self.choose_random_guardian(relative_with_ref_person_partner_guardian_ids)
             )
             pop.loc[
                 relative_with_ref_person_partner_guardian_ids.index, "guardian_2"
@@ -492,7 +482,7 @@ class Population:
         ]
         if len(child_ref_person_with_parent) > 0:
             child_ref_person_with_parent_ids = (
-                choose_random_guardian(child_ref_person_with_parent())
+                self.choose_random_guardian(child_ref_person_with_parent())
             )
             pop.loc[child_ref_person_with_parent_ids.index, "guardian_1"] = child_ref_person_with_parent_ids
 
@@ -505,7 +495,7 @@ class Population:
         if len(child_ref_person_with_relative_ids) > 0:
             # Select random relative if multiple and assign as guardian
             child_ref_person_with_relative_ids = (
-                choose_random_guardian(child_ref_person_with_relative_ids)
+                self.choose_random_guardian(child_ref_person_with_relative_ids)
             )
             pop.loc[
                 child_ref_person_with_relative_ids.index, "guardian_1"
@@ -520,7 +510,7 @@ class Population:
         if len(non_relative_guardian) > 0:
             # Select random non-relative if multiple and assign to guardian
             non_relative_guardian_ids = (
-                choose_random_guardian(non_relative_guardian)
+                self.choose_random_guardian(non_relative_guardian)
             )
             pop.loc[non_relative_guardian_ids.index, "guardian_1"] = non_relative_guardian_ids
 
@@ -535,7 +525,7 @@ class Population:
         if len(other_non_relative_guardian_ids) > 0:
             # Select random non-relative if multiple and assign to guardian
             other_non_relative_guardian_ids = (
-                choose_random_guardian(other_non_relative_guardian_ids)
+                self.choose_random_guardian(other_non_relative_guardian_ids)
             )
             pop.loc[
                 other_non_relative_guardian_ids.index, "guardian_1"
@@ -546,7 +536,6 @@ class Population:
     @staticmethod
     def get_household_structure(pop: pd.DataFrame) -> pd.DataFrame:
         """
-
         Parameters
         ----------
         pop: population state table
@@ -600,3 +589,13 @@ class Population:
         )
 
         return household_structure
+
+    @staticmethod
+    def choose_random_guardian(member_ids: pd.DataFrame) -> pd.Series:
+        # member_ids is a subset of child_households dataframe
+        member_ids = (
+            member_ids.reset_index()
+            .groupby(["child_id"])["person_id"]
+            .apply(np.random.choice)
+        )
+        return member_ids

--- a/src/vivarium_census_prl_synth_pop/constants/data_values.py
+++ b/src/vivarium_census_prl_synth_pop/constants/data_values.py
@@ -26,6 +26,8 @@ PROPORTION_NEWBORNS_NO_SSN = 0.10
 PROPORTION_PERSONS_LEAVING_COUNTRY = 0.05
 PROPORTION_HOUSEHOLDS_LEAVING_COUNTRY = 0.05
 
+UNKNOWN_GUARDIAN_IDX = -1
+
 #########################
 # Synthetic Name Inputs #
 #########################

--- a/src/vivarium_census_prl_synth_pop/model_specifications/branches/scenarios.yaml
+++ b/src/vivarium_census_prl_synth_pop/model_specifications/branches/scenarios.yaml
@@ -1,7 +1,7 @@
-input_draw_count: 10
-random_seed_count: 5
+input_draw_count: 1
+random_seed_count: 1
 
 branches:
 # TODO change to name of intervention
-  - placeholder_branch_name:
-      scenario: ['baseline']
+  - population:
+      population_size: [1_000, 10_000, 50_000, 100_000, 500_000, 1_000_000, 5_000_000]

--- a/src/vivarium_census_prl_synth_pop/model_specifications/branches/scenarios.yaml
+++ b/src/vivarium_census_prl_synth_pop/model_specifications/branches/scenarios.yaml
@@ -3,5 +3,5 @@ random_seed_count: 1
 
 branches:
 # TODO change to name of intervention
-  - population:
-      population_size: [1_000, 10_000, 50_000, 100_000, 500_000, 1_000_000, 5_000_000]
+  - placeholder_branch_name:
+      scenario: [ 'baseline' ]


### PR DESCRIPTION
## Guardian initialization for general population under 18.

### Initializes guardians for simulants under 18 not living in group quarters.
- *Category*: Feature
- *JIRA issue*: [MIC-3540](https://jira.ihme.washington.edu/browse/MIC-3540)
- *Research reference*:  https://vivarium-research.readthedocs.io/en/latest/concept_models/vivarium_census_synthdata/concept_model.html#initializing-guardian-s-for-all-simulants

-Creates household structure dataframe to make household lookups easier (see docstring)
-Creates guardian_1 and guardian_2 columns in the state table with value -1 (N/A). 
-If a simulant is determined to have a guardian(s) (see research documentation for diagram), the guardian columns will be filled with values of the index for that simulants guardians.


### Verification and Testing
-Successfully ran simulation
-Saw updated guardian_1 and guardian_2 columns for simulants who have guardians.
<img width="510" alt="orange_box" src="https://user-images.githubusercontent.com/37345113/202561522-4ccdebff-d508-4cbd-970f-ec33b6b09cba.PNG">
<img width="465" alt="red_box" src="https://user-images.githubusercontent.com/37345113/202561526-e6d5ce1b-77a9-4528-a6ca-a86466b76b62.PNG">
<img width="480" alt="yellow_box" src="https://user-images.githubusercontent.com/37345113/202561528-f6ce4a31-0e16-486a-a23d-c4773d70ff9d.PNG">
<img width="503" alt="blurple_box" src="https://user-images.githubusercontent.com/37345113/202561552-64200963-b51d-42be-a920-b3b5adc9e3a6.PNG">
<img width="425" alt="under_18_general_pop" src="https://user-images.githubusercontent.com/37345113/202561753-56683733-79ca-4abd-a966-220515363503.PNG">


