### PR TITLE
Refactor/household structure for guardians

### DIFF
--- a/src/vivarium_census_prl_synth_pop/components/population.py
+++ b/src/vivarium_census_prl_synth_pop/components/population.py
@@ -1,3 +1,8 @@
+from typing import (
+    Dict,
+    List,
+    Union,
+)
 import numpy as np
 import pandas as pd
 from vivarium.framework.engine import Builder
@@ -236,6 +241,7 @@ class Population:
         parent_ids_idx = pop_data.user_data["parent_ids"]
         pop_index = pop_data.user_data["current_population_index"]
         mothers = self.population_view.get(parent_ids_idx.unique())
+        # todo: find intelligent way to pass necessary columns without loading all of state table
         households = self.population_view.subview(
             ["household_id", "relation_to_household_head"]
         ).get(pop_index)
@@ -583,6 +589,7 @@ class Population:
                 "relation_to_household_head_y": "member_relation_to_household_head",
             }
         ).droplevel("household_id")
+        # todo: move this out of here
         household_structure["age_difference"] = (
             household_structure["member_age"] - household_structure["child_age"]
         )
@@ -695,6 +702,71 @@ class Population:
 
         return mother_households
 
+    @staticmethod
+    def get_household_structure(
+            pop: pd.DataFrame,
+            query_sims: Union[pd.Series, pd.Index],
+            key_columns: List,
+            column_names: Dict,
+            lookup_id_level_name: str
+    ) -> pd.DataFrame:
+        """
+
+        Parameters
+        ----------
+        pop: population state table
+        query_sims: Series that will be used for a lookup to subset the state table.  This will create one of the
+          dataframes we will merge to create our multi-index dataframe
+        key_columns: columns to subset pop
+        column_names: Dictionary to map columns and their new names to
+        lookup_id_level_name: Name for index level that will be first level of final dataframe.  This will be the index
+          of the simulant for the "left" portion of our dataframe.
+
+        Returns
+        -------
+        Multi-index dataframe with 2 levels - first being the index (id) of simulants who will be the left portion of
+          our dataframe.  These ids are the same as query_sims.  Level 2 will be person_id which will be the index of
+          the other members in that household.
+
+        The following example is how we will construct a dataframe for children under 18.
+        # Columns will contain data for child alongside each household member
+        # This will allow us to do lookups related to both a child and other household members.
+        pd.Dataframe = child_age | child_relation_to_household_head | member_age | member_relation_to_household_head | age_difference
+        child_id person_id|
+            0        0    |  11              "Biological child               11            "Biological child           0
+            0        1    |  11              "Biological child               35            "Reference person"          24
+            0        2    |  11              "Biological child               7             "Adopted child"             -4
+            2        0    |  7               "Adopted child                  11            "Biological child"           4
+            2        1    |  7               "Adopted child                  35            "Reference person"          28
+            2        2    |  7               "Adopted child                  7             "Adopted child"              0
+
+        Note: For every household with a child under 18, there N * X number of rows per household in the dataframe where
+          N = number of simulants under 18 and X is the number of members in that household.  The above example is for a
+          three person household with 2 children resulting in 6 rows.  This allows us to (eventually) lookup an the
+          index for each child's guardian, which in this case would be [(0, 1), (2, 1)].
+
+        # This function allows us to subset the state table to necessary columns and do more complicated lookups based
+          on household structures in a vectorized way to improve performance.
+        """
+        lookup_sims = (
+            pop.loc[query_sims, key_columns]
+            .reset_index()
+            .rename(columns={"index": lookup_id_level_name})
+            .set_index(["household_id", lookup_id_level_name])
+        )
+        household_info = (
+            pop[key_columns]
+            .reset_index()
+            .rename(columns={"index": "person_id"})
+            .set_index(["household_id", "person_id"])
+        )
+
+        household_structure = lookup_sims.merge(household_info, left_index=True, right_index=True)
+        household_structure = household_structure.rename(
+            columns=column_names
+        ).droplevel("household_id")
+
+        return household_structure
 
 # Family/household relationships helper lists
 non_relatives = ["Roommate", "Other nonrelative"]

--- a/src/vivarium_census_prl_synth_pop/components/population.py
+++ b/src/vivarium_census_prl_synth_pop/components/population.py
@@ -1,8 +1,5 @@
-from typing import (
-    Dict,
-    List,
-    Union,
-)
+from typing import Dict, List, Union
+
 import numpy as np
 import pandas as pd
 from vivarium.framework.engine import Builder
@@ -372,8 +369,7 @@ class Population:
         # Non-GQ population
         gen_population = pop.loc[~pop["household_id"].isin(data_values.GQ_HOUSING_TYPE_MAP)]
         under_18_idx = pop.loc[
-            (pop["age"] < 18) &
-            (~pop["household_id"].isin(data_values.GQ_HOUSING_TYPE_MAP))
+            (pop["age"] < 18) & (~pop["household_id"].isin(data_values.GQ_HOUSING_TYPE_MAP))
         ].index
         new_column_names = {
             "age_x": "child_age",
@@ -391,7 +387,9 @@ class Population:
             lookup_id_level_name="child_id",
         )
         # Add age difference column to lookup age bounds for potential guardians
-        child_households["age_difference"] = child_households["member_age"] - child_households["child_age"]
+        child_households["age_difference"] = (
+            child_households["member_age"] - child_households["child_age"]
+        )
 
         # Children helper index groups
         # Ref_person = "Reference person"
@@ -586,9 +584,9 @@ class Population:
         new_births["guardian_2"] = data_values.UNKNOWN_GUARDIAN_IDX
         key_cols = ["household_id", "relation_to_household_head"]
         new_column_names = {
-                "relation_to_household_head_x": "mother_relation_to_household_head",
-                "relation_to_household_head_y": "member_relation_to_household_head",
-            }
+            "relation_to_household_head_x": "mother_relation_to_household_head",
+            "relation_to_household_head_y": "member_relation_to_household_head",
+        }
         mothers_households = self.get_household_structure(
             households,
             query_sims=new_births["parent_id"],
@@ -621,9 +619,11 @@ class Population:
                 new_births["parent_id"].isin(partner_ids.index), "guardian_2"
             ] = new_births["parent_id"].map(partner_ids)
 
-        reference_person_ids = mothers_households.loc[
-            mother_partner_idx.intersection(ref_person_idx)
-        ].reset_index().set_index("mother_id")["person_id"]
+        reference_person_ids = (
+            mothers_households.loc[mother_partner_idx.intersection(ref_person_idx)]
+            .reset_index()
+            .set_index("mother_id")["person_id"]
+        )
         new_births.loc[
             new_births["parent_id"].isin(reference_person_ids.index), "guardian_2"
         ] = new_births["parent_id"].map(reference_person_ids)
@@ -632,11 +632,11 @@ class Population:
 
     @staticmethod
     def get_household_structure(
-            pop: pd.DataFrame,
-            query_sims: Union[pd.Series, pd.Index],
-            key_columns: List,
-            column_names: Dict,
-            lookup_id_level_name: str
+        pop: pd.DataFrame,
+        query_sims: Union[pd.Series, pd.Index],
+        key_columns: List,
+        column_names: Dict,
+        lookup_id_level_name: str,
     ) -> pd.DataFrame:
         """
 
@@ -692,10 +692,12 @@ class Population:
             .set_index(["household_id", "person_id"])
         )
 
-        household_structure = lookup_sims.merge(household_info, left_index=True, right_index=True)
-        household_structure = household_structure.rename(
-            columns=column_names
-        ).droplevel("household_id")
+        household_structure = lookup_sims.merge(
+            household_info, left_index=True, right_index=True
+        )
+        household_structure = household_structure.rename(columns=column_names).droplevel(
+            "household_id"
+        )
 
         return household_structure
 


### PR DESCRIPTION
## Refactor of get_household_structure.

### Refactors duplicated code that is use to create dataframe structure for households when looking up guardians for assignment.
- *Category*: Refactor
- *JIRA issue*: [MIC-3606](https://jira.ihme.washington.edu/browse/MIC-3606)
- *Research reference*: https://vivarium-research.readthedocs.io/en/latest/concept_models/vivarium_census_synthdata/concept_model.html#initializing-guardian-s-for-all-simulants

-Gets rid of multiple functions with similar code providing the same functionality and puts it into a more versatile function

### Verification and Testing
-Ran simulation and saw expected and correct updates for guardian_1 and guardian_2 columns.  See example for new_births.

<img width="401" alt="new_births" src="https://user-images.githubusercontent.com/37345113/203635298-cf8c0e13-eb2b-4d25-a4c4-787a0f57fd88.PNG">

