### PR TITLE
Feature/perturb household age

### DIFF
--- a/src/vivarium_census_prl_synth_pop/components/population.py
+++ b/src/vivarium_census_prl_synth_pop/components/population.py
@@ -844,7 +844,7 @@ class Population:
         # Takes dataframe of households and returns a series with an applied age shift for each household.
         household_ids = simulants.loc[
             simulants["relation_to_household_head"] == "Reference person", "household_id"
-        ]  # Series with index for each refernce person and value is household id
+        ]  # Series with index for each reference person and value is household id
         # Flip index and values to map age shift later
         reference_person_ids = pd.Series(data=household_ids.index, index=household_ids)
         age_shift_propensity = self.randomness.get_draw(
@@ -863,7 +863,7 @@ class Population:
 
         simulants["age"] = simulants["age"] + mapped_age_shift
 
-        # Clip ages at 0 and 125
+        # Clip ages at 0 and 99
         simulants.loc[simulants["age"] < 0, "age"] = 0
         simulants.loc[simulants["age"] > 99, "age"] = 99
 

--- a/src/vivarium_census_prl_synth_pop/components/population.py
+++ b/src/vivarium_census_prl_synth_pop/components/population.py
@@ -852,5 +852,6 @@ class Population:
         # Convert to normal distribution with mean=0 and sd=10
         perturbed_age = stats.norm.ppf(age_shift, loc=0, scale=10)
         simulants["age"] = simulants["age"] + perturbed_age
+        #todo: Add age bound checks
 
         return simulants["age"]

--- a/src/vivarium_census_prl_synth_pop/components/population.py
+++ b/src/vivarium_census_prl_synth_pop/components/population.py
@@ -131,6 +131,7 @@ class Population:
         pop = pd.concat([pop, first_and_middle, last_names], axis=1)
 
         pop["age"] = pop["age"].astype("float64")
+        #todo: the below line can be dropped after we perturb age
         pop["age"] = pop["age"] + self.randomness.get_draw(pop.index, "age")
         pop["date_of_birth"] = self.start_time - pd.to_timedelta(
             np.round(pop["age"] * 365.25), unit="days"
@@ -171,6 +172,7 @@ class Population:
                 ),
             }
         )
+        #todo: Perturb age for household here with new column
 
         # get all simulants per household
         chosen_persons = pd.merge(
@@ -188,8 +190,8 @@ class Population:
         chosen_persons = chosen_persons.loc[
             ~chosen_persons["household_id"].isin(households_to_discard)
         ]
-
         chosen_persons["housing_type"] = "Standard"
+        #todo: Use age shift to perturb age and drop column.
 
         return chosen_persons
 
@@ -244,6 +246,7 @@ class Population:
         group_quarters["housing_type"] = group_quarters["household_id"].map(
             data_values.GQ_HOUSING_TYPE_MAP
         )
+        # todo: Add function that perturbs age for indvidisual that will also be used for immigrants.
 
         return group_quarters
 


### PR DESCRIPTION
## Perturb household age
### Perturbation for age amongst simulants in standard households.
- *Category*: Feature
- *JIRA issue*: [MIC-3618](https://jira.ihme.washington.edu/browse/MIC-3618)
- *Research reference*: https://vivarium-research.readthedocs.io/en/latest/models/concept_models/vivarium_census_synthdata/concept_model.html#households

### Changes and notes
-Adds function that takes a draw and shifts age by household based on a normal distribution.

### Verification and Testing
-Successfully ran a simulation and saw an equal age shift for members in that same households.
<img width="219" alt="perturbed_age" src="https://user-images.githubusercontent.com/37345113/206017081-6ec46427-fc3e-4b14-81e7-f20810192a9c.PNG">
<img width="353" alt="age_shift" src="https://user-images.githubusercontent.com/37345113/206017097-fa2d0698-ad94-4430-bc07-241280083a4d.PNG">

