### PR TITLE
Bugfix/duplicates in guardian assignment mapping series.

### DIFF
--- a/src/vivarium_census_prl_synth_pop/components/population.py
+++ b/src/vivarium_census_prl_synth_pop/components/population.py
@@ -639,6 +639,7 @@ class Population:
             mothers_households.loc[mother_partner_idx.intersection(ref_person_idx)]
             .reset_index()
             .set_index("mother_id")["person_id"]
+            .drop_duplicates()  # Checks for duplicates caused by twins in new_births
         )
         new_births.loc[
             new_births["parent_id"].isin(reference_person_ids.index), "guardian_2"


### PR DESCRIPTION
## Bugfix/duplicates in guardian mapping series for new births.

### Handles bug caused by twins being born on a time step.  This result in a series of reference person ids that had duplicates.
- *JIRA issue*: [MIC-3664](https://jira.ihme.washington.edu/browse/MIC-3664)
- *Research reference*: N/A

### Changes and notes
-Drops duplicates in series to prevent possible duplicates that would throw an error.

### Verification and Testing
Successfully ran simulation with guardian columns being correctly updated.
