### PR TITLE
implement base observer class

### DIFF
--- a/src/vivarium_census_prl_synth_pop/components/__init__.py
+++ b/src/vivarium_census_prl_synth_pop/components/__init__.py
@@ -2,7 +2,7 @@ from vivarium_census_prl_synth_pop.components.businesses import Businesses
 from vivarium_census_prl_synth_pop.components.fertility import Fertility
 from vivarium_census_prl_synth_pop.components.household import HouseholdMigration
 from vivarium_census_prl_synth_pop.components.mortality import Mortality
-from vivarium_census_prl_synth_pop.components.observers import Observers
+from vivarium_census_prl_synth_pop.components.observers import TestObserver, Observers
 from vivarium_census_prl_synth_pop.components.person import PersonMigration
 from vivarium_census_prl_synth_pop.components.population import Population
 from vivarium_census_prl_synth_pop.components.synthetic_pii import Address

--- a/src/vivarium_census_prl_synth_pop/components/__init__.py
+++ b/src/vivarium_census_prl_synth_pop/components/__init__.py
@@ -2,7 +2,7 @@ from vivarium_census_prl_synth_pop.components.businesses import Businesses
 from vivarium_census_prl_synth_pop.components.fertility import Fertility
 from vivarium_census_prl_synth_pop.components.household import HouseholdMigration
 from vivarium_census_prl_synth_pop.components.mortality import Mortality
-from vivarium_census_prl_synth_pop.components.observers import TestObserver, Observers
+from vivarium_census_prl_synth_pop.components.observers import Observers
 from vivarium_census_prl_synth_pop.components.person import PersonMigration
 from vivarium_census_prl_synth_pop.components.population import Population
 from vivarium_census_prl_synth_pop.components.synthetic_pii import Address

--- a/src/vivarium_census_prl_synth_pop/components/observers.py
+++ b/src/vivarium_census_prl_synth_pop/components/observers.py
@@ -93,54 +93,6 @@ class BaseObserver(ABC):
         pass
 
 
-class TestObserver(BaseObserver):
-    """test"""
-
-    def __repr__(self):
-        return "TestObserver()"
-
-    ##############
-    # Properties #
-    ##############
-
-    @property
-    def name(self):
-        return "test_observer"
-
-    #################
-    # Setup methods #
-    #################
-
-    def get_output_filename(self):
-        return "test_file.hdf"
-
-    def setup(self, builder: Builder):
-        super().setup(builder)
-
-    def get_population_view(self, builder) -> PopulationView:
-        """Returns the population view of interest to the observer"""
-        population_view = builder.population.get_view(columns=[])
-        return population_view
-
-    def get_responses(self) -> pd.DataFrame:
-        """Returns the response schema"""
-        pass
-
-    ########################
-    # Event-driven methods #
-    ########################
-    
-    def do_observation(self, event) -> None:
-        """Define the observations in the concrete class"""
-        new_responses = self.population_view.get(event.index)[0:2]
-        new_responses['response_date'] = event.time.date()
-        self.responses = pd.concat([self.responses, new_responses])
-
-    def get_hdf_key(self) -> "str":
-        """Define the output hdf key in the concrete class"""
-        return "test_observation"
-
-
 # FIXME: give this a more descriptive name (eg CensusObserver)
 class Observers:
     # FIXME: the docstring is no longer correct; update it

--- a/src/vivarium_census_prl_synth_pop/components/observers.py
+++ b/src/vivarium_census_prl_synth_pop/components/observers.py
@@ -1,12 +1,149 @@
-from pathlib import Path
+from abc import ABC, abstractmethod
 
+import pandas as pd
 from vivarium.framework.engine import Builder
 from vivarium.framework.event import Event
+from vivarium.framework.population import PopulationView
 
 from vivarium_census_prl_synth_pop.constants import data_values, metadata
+from vivarium_census_prl_synth_pop.utilities import build_output_dir
 
 
+class BaseObserver(ABC):
+    """Base class for observing and recording relevant state table results. It
+    maintains a separate dataset per concrete observation class and allows for
+    recording/updating on some subset of timesteps (including every time step)
+    and then writing out the results at the end of the sim.
+    """
+
+    ##############
+    # Properties #
+    ##############
+
+    @property
+    def name(self):
+        return "base_observer"
+
+    #################
+    # Setup methods #
+    #################
+
+    def setup(self, builder: Builder):
+        # FIXME: move filepaths to data container
+        # FIXME: settle on output dirs
+        self.output_dir = build_output_dir(builder, subdir="observers")
+        self.output_filename = self.get_output_filename()
+        self.population_view = self.get_population_view(builder)
+        self.responses = self.get_responses()
+        
+        # Register the listener to update the responses
+        builder.event.register_listener(
+            "collect_metrics",
+            self.on_collect_metrics,
+        )
+        
+        # Register the listener for final write-out
+        builder.event.register_listener(
+        	"simulation_end",
+        	self.on_simulation_end,
+        )
+
+    @abstractmethod
+    def get_output_filename(self) -> str:
+        """Define the output filename in the concrete class"""
+        pass
+
+    @abstractmethod
+    def get_population_view(self, builder) -> PopulationView:
+        """Define the population view to use in the concrete class"""
+        pass
+
+    @abstractmethod
+    def get_responses(self) -> pd.DataFrame:
+        """Define responses dataset schema to be used in the concrete class"""
+        pass
+
+    ########################
+    # Event-driven methods #
+    ########################
+
+    def on_collect_metrics(self, event: Event) -> None:
+        if self.to_observe():
+            self.do_observation(event)
+        
+    def to_observe(self) -> bool:
+        """If True, will make an observation. This defaults to always True
+        (ie record at every time step) and should be overwritten in each
+        concrete observer as appropriate
+        """
+        return True
+
+    @abstractmethod
+    def do_observation(self) -> None:
+        """Define the observations in the concrete class"""
+        pass
+
+    def on_simulation_end(self, event: Event) -> None:
+        key = self.get_hdf_key()
+        self.responses.to_hdf(self.output_dir / self.output_filename, key=key)
+
+    @abstractmethod
+    def get_hdf_key(self) -> "str":
+        """Define the output hdf key in the concrete class"""
+        pass
+
+
+class TestObserver(BaseObserver):
+    """test"""
+
+    def __repr__(self):
+        return "TestObserver()"
+
+    ##############
+    # Properties #
+    ##############
+
+    @property
+    def name(self):
+        return "test_observer"
+
+    #################
+    # Setup methods #
+    #################
+
+    def get_output_filename(self):
+        return "test_file.hdf"
+
+    def setup(self, builder: Builder):
+        super().setup(builder)
+
+    def get_population_view(self, builder) -> PopulationView:
+        """Returns the population view of interest to the observer"""
+        population_view = builder.population.get_view(columns=[])
+        return population_view
+
+    def get_responses(self) -> pd.DataFrame:
+        """Returns the response schema"""
+        pass
+
+    ########################
+    # Event-driven methods #
+    ########################
+    
+    def do_observation(self, event) -> None:
+        """Define the observations in the concrete class"""
+        new_responses = self.population_view.get(event.index)[0:2]
+        new_responses['response_date'] = event.time.date()
+        self.responses = pd.concat([self.responses, new_responses])
+
+    def get_hdf_key(self) -> "str":
+        """Define the output hdf key in the concrete class"""
+        return "test_observation"
+
+
+# FIXME: give this a more descriptive name (eg CensusObserver)
 class Observers:
+    # FIXME: the docstring is no longer correct; update it
     """
     at the start of simulant initialization:
     save population table with / key = date
@@ -35,8 +172,8 @@ class Observers:
         self.end_date = builder.configuration.time.end
         self.clock = builder.time.clock()
         self.counter = 0
-        self.output_path = self._build_output_root(builder) / "state_table.hdf"
-        self.decennial_path = self._build_output_root(builder) / "decennial_census.hdf"
+        self.output_path = build_output_dir(builder, subdir="population_table") / "state_table.hdf"
+        self.decennial_path = build_output_dir(builder, subdir="observers") / "decennial_census.hdf"
 
         self.randomness = builder.randomness.get_stream(self.name)
         self.population_view = builder.population.get_view(columns=[])
@@ -44,6 +181,7 @@ class Observers:
             data=data_values.RESPONSE_PROBABILITY_DECENNIAL
         )
 
+        # FIXME: register to happen "on_collect_metrics" (end of time step)
         builder.event.register_listener("time_step__prepare", self.on_time_step__prepare)
         builder.event.register_listener("simulation_end", self.on_simulation_end)
 
@@ -77,17 +215,3 @@ class Observers:
         )
 
         respondents.to_hdf(self.decennial_path, hdf_key)
-
-    ###########
-    # Helpers #
-    ###########
-
-    @staticmethod
-    def _build_output_root(builder: Builder) -> Path:
-        results_root = builder.configuration.output_data.results_directory
-        output_root = Path(results_root) / "population_table"
-
-        from vivarium_cluster_tools import mkdir
-
-        mkdir(output_root, exists_ok=True)
-        return output_root

--- a/src/vivarium_census_prl_synth_pop/model_specifications/model_spec.yaml
+++ b/src/vivarium_census_prl_synth_pop/model_specifications/model_spec.yaml
@@ -9,7 +9,6 @@ components:
             - Mortality()
             - Fertility()
             - Businesses()
-            - TestObserver()  # FIXME: Replace with actual observer
 
 configuration:
     input_data:

--- a/src/vivarium_census_prl_synth_pop/model_specifications/model_spec.yaml
+++ b/src/vivarium_census_prl_synth_pop/model_specifications/model_spec.yaml
@@ -9,6 +9,7 @@ components:
             - Mortality()
             - Fertility()
             - Businesses()
+            - TestObserver()  # FIXME: Replace with actual observer
 
 configuration:
     input_data:

--- a/src/vivarium_census_prl_synth_pop/utilities.py
+++ b/src/vivarium_census_prl_synth_pop/utilities.py
@@ -1,14 +1,15 @@
 from pathlib import Path
-from typing import Any, List, Tuple, Union
-
+from typing import Any, List, Optional, Tuple, Union
 import click
 import numpy as np
 import pandas as pd
 from loguru import logger
 from scipy import stats
+from vivarium.framework.engine import Builder
 from vivarium.framework.lookup import LookupTable
 from vivarium.framework.randomness import Array, RandomnessStream, get_hash
 from vivarium.framework.values import Pipeline
+from vivarium_cluster_tools import mkdir
 from vivarium_public_health.risks.data_transformations import pivot_categorical
 
 from vivarium_census_prl_synth_pop.constants import metadata
@@ -273,3 +274,11 @@ def filter_by_rate(
         entity_to_filter, rate_producer(idx), additional_key
     )
     return filtered_sims
+
+
+def build_output_dir(builder: Builder, subdir: Optional[Union[str, Path]] = None) -> Path:
+    output_dir = Path(builder.configuration.output_data.results_directory)
+    if subdir:
+        output_dir = output_dir / subdir
+    mkdir(output_dir, exists_ok=True)
+    return output_dir

--- a/tests/components/test_observers.py
+++ b/tests/components/test_observers.py
@@ -1,0 +1,9 @@
+import pytest
+
+from vivarium_census_prl_synth_pop.components import observers
+
+def test_instantiate_base_observer():
+    """Expact a TypeError when trying to instantiate an abc"""
+    with pytest.raises(Exception):
+        observers.BaseObserver()
+


### PR DESCRIPTION
## Title: Implement base observer class

### Description
- *Category*: implementation; observer
- *JIRA issue*: [MIC-3668](https://jira.ihme.washington.edu/browse/MIC-3668)
- *Research reference*: n/a

### Changes and notes
This implements an abstract base class to be inherited by future observers
(e.g. household survey and census observers). There is no test suite built up
yet and so I for now
1. Added a not-so-useful pytest that ensures the user cannot instantiate the ABC
2. Implemented as a pseudo-test a very basic "TestObserver" class that inherits
    from the base class and records two rows from the state table at each time step.
    Refer to commit 12164bcc36802b1cbf7965762ac69ef5362822f4.


### Verification and Testing
Refer to #2 above - I ran a small sim and ensured observations are being
recorded.

