### PR TITLE
Feature/sbachmei/mic 3669 household survey observer implementation

### DIFF
--- a/src/vivarium_census_prl_synth_pop/components/__init__.py
+++ b/src/vivarium_census_prl_synth_pop/components/__init__.py
@@ -2,7 +2,10 @@ from vivarium_census_prl_synth_pop.components.businesses import Businesses
 from vivarium_census_prl_synth_pop.components.fertility import Fertility
 from vivarium_census_prl_synth_pop.components.household import HouseholdMigration
 from vivarium_census_prl_synth_pop.components.mortality import Mortality
-from vivarium_census_prl_synth_pop.components.observers import DecennialCensusObserver, Observers
+from vivarium_census_prl_synth_pop.components.observers import (
+    DecennialCensusObserver,
+    HouseholdSurveyObserver,
+)
 from vivarium_census_prl_synth_pop.components.person import PersonMigration
 from vivarium_census_prl_synth_pop.components.population import Population
 from vivarium_census_prl_synth_pop.components.synthetic_pii import Address

--- a/src/vivarium_census_prl_synth_pop/components/__init__.py
+++ b/src/vivarium_census_prl_synth_pop/components/__init__.py
@@ -2,7 +2,7 @@ from vivarium_census_prl_synth_pop.components.businesses import Businesses
 from vivarium_census_prl_synth_pop.components.fertility import Fertility
 from vivarium_census_prl_synth_pop.components.household import HouseholdMigration
 from vivarium_census_prl_synth_pop.components.mortality import Mortality
-from vivarium_census_prl_synth_pop.components.observers import DecennialCensusObserver
+from vivarium_census_prl_synth_pop.components.observers import DecennialCensusObserver, Observers
 from vivarium_census_prl_synth_pop.components.person import PersonMigration
 from vivarium_census_prl_synth_pop.components.population import Population
 from vivarium_census_prl_synth_pop.components.synthetic_pii import Address

--- a/src/vivarium_census_prl_synth_pop/components/observers.py
+++ b/src/vivarium_census_prl_synth_pop/components/observers.py
@@ -5,6 +5,7 @@ import pandas as pd
 from vivarium.framework.engine import Builder
 from vivarium.framework.event import Event
 from vivarium.framework.population import PopulationView
+from vivarium_public_health.utilities import DAYS_PER_YEAR
 
 from vivarium_census_prl_synth_pop import utilities
 from vivarium_census_prl_synth_pop.constants import data_values
@@ -197,7 +198,7 @@ class HouseholdSurveyObserver(BaseObserver):
             ]  # households per month
             * 12  # months per year
             * builder.configuration.time.step_size  # days per timestep
-            / data_values.DAYS_PER_YEAR  # days per year
+            / DAYS_PER_YEAR  # days per year
             * builder.configuration.population.population_size  # sim population
             / data_values.US_POPULATION  # US population
         )

--- a/src/vivarium_census_prl_synth_pop/constants/data_values.py
+++ b/src/vivarium_census_prl_synth_pop/constants/data_values.py
@@ -1,8 +1,14 @@
 from typing import NamedTuple
 
+
+DAYS_PER_YEAR = 365.25
+
 #########################
 # Population parameters #
 #########################
+
+# TODO: implement gbd call (vivarium_inputs.get_population_structure("United States"))
+US_POPULATION = 333339776
 
 PROP_POPULATION_IN_GQ = 0.03
 PROBABILITY_OF_TWINS = 0.04

--- a/src/vivarium_census_prl_synth_pop/constants/data_values.py
+++ b/src/vivarium_census_prl_synth_pop/constants/data_values.py
@@ -1,8 +1,5 @@
 from typing import NamedTuple
 
-
-DAYS_PER_YEAR = 365.25
-
 #########################
 # Population parameters #
 #########################

--- a/src/vivarium_census_prl_synth_pop/constants/metadata.py
+++ b/src/vivarium_census_prl_synth_pop/constants/metadata.py
@@ -220,21 +220,6 @@ US_STATE_ABBRV_MAP = {
 
 P_GROUP_QUARTERS = 0.03
 
-DECENNIAL_CENSUS_COLUMNS_USED = [
-    "first_name",
-    "middle_name",
-    "last_name",
-    "age",
-    "date_of_birth",
-    "address_id",
-    "relation_to_household_head",
-    "sex",
-    "race_ethnicity",
-    "guardian_1",
-    "guardian_2",
-    "housing_type",
-]
-
 
 class __Scenarios(NamedTuple):
     baseline: str = "baseline"

--- a/src/vivarium_census_prl_synth_pop/model_specifications/model_spec.yaml
+++ b/src/vivarium_census_prl_synth_pop/model_specifications/model_spec.yaml
@@ -32,8 +32,8 @@ configuration:
             month: 4
             day: 1
         end:
-            year: 2020
-            month: 6
+            year: 2030
+            month: 5
             day: 1
         step_size: 28 # Days
     population:

--- a/src/vivarium_census_prl_synth_pop/model_specifications/model_spec.yaml
+++ b/src/vivarium_census_prl_synth_pop/model_specifications/model_spec.yaml
@@ -5,10 +5,13 @@ components:
             - Address()
             - HouseholdMigration()
             - PersonMigration()
-            - DecennialCensusObserver()
             - Mortality()
             - Fertility()
             - Businesses()
+
+            - DecennialCensusObserver()
+            - HouseholdSurveyObserver("ACS")
+            - HouseholdSurveyObserver("CPS")
 
 configuration:
     input_data:
@@ -29,8 +32,8 @@ configuration:
             month: 4
             day: 1
         end:
-            year: 2030
-            month: 5
+            year: 2020
+            month: 6
             day: 1
         step_size: 28 # Days
     population:

--- a/src/vivarium_census_prl_synth_pop/model_specifications/model_spec.yaml
+++ b/src/vivarium_census_prl_synth_pop/model_specifications/model_spec.yaml
@@ -9,7 +9,6 @@ components:
             - Mortality()
             - Fertility()
             - Businesses()
-            - TestObserver()  # FIXME: Replace with actual observer
 
 configuration:
     input_data:

--- a/src/vivarium_census_prl_synth_pop/model_specifications/model_spec.yaml
+++ b/src/vivarium_census_prl_synth_pop/model_specifications/model_spec.yaml
@@ -9,6 +9,7 @@ components:
             - Mortality()
             - Fertility()
             - Businesses()
+            - TestObserver()  # FIXME: Replace with actual observer
 
 configuration:
     input_data:

--- a/src/vivarium_census_prl_synth_pop/utilities.py
+++ b/src/vivarium_census_prl_synth_pop/utilities.py
@@ -381,6 +381,7 @@ def update_address_id_for_unit_and_sims(
 def add_guardian_address_ids(pop: pd.DataFrame) -> pd.DataFrame:
     """Map the address ids of guardians to each simulant's guardian address columns"""
     for i in [1, 2]:
+        breakpoint()
         s_guardian_id = pop[f"guardian_{i}"].dropna()
         s_guardian_id = s_guardian_id[
             s_guardian_id != -1

--- a/src/vivarium_census_prl_synth_pop/utilities.py
+++ b/src/vivarium_census_prl_synth_pop/utilities.py
@@ -381,7 +381,7 @@ def update_address_id_for_unit_and_sims(
 def add_guardian_address_ids(pop: pd.DataFrame) -> pd.DataFrame:
     """Map the address ids of guardians to each simulant's guardian address columns"""
     for i in [1, 2]:
-        s_guardian_id = pop[f"guardian_{i}"].dropna()
+        s_guardian_id = pop[f"guardian_{i}"]
         s_guardian_id = s_guardian_id[
             s_guardian_id != -1
         ]  # is it faster to remove the negative values?

--- a/src/vivarium_census_prl_synth_pop/utilities.py
+++ b/src/vivarium_census_prl_synth_pop/utilities.py
@@ -381,7 +381,6 @@ def update_address_id_for_unit_and_sims(
 def add_guardian_address_ids(pop: pd.DataFrame) -> pd.DataFrame:
     """Map the address ids of guardians to each simulant's guardian address columns"""
     for i in [1, 2]:
-        breakpoint()
         s_guardian_id = pop[f"guardian_{i}"].dropna()
         s_guardian_id = s_guardian_id[
             s_guardian_id != -1

--- a/src/vivarium_census_prl_synth_pop/utilities.py
+++ b/src/vivarium_census_prl_synth_pop/utilities.py
@@ -380,9 +380,19 @@ def update_address_id_for_unit_and_sims(
 
 def add_guardian_address_ids(pop: pd.DataFrame) -> pd.DataFrame:
     """Map the address ids of guardians to each simulant's guardian address columns"""
-    for i in [1,2]:
+    for i in [1, 2]:
         s_guardian_id = pop[f"guardian_{i}"].dropna()
-        s_guardian_id = s_guardian_id[s_guardian_id != -1] # is it faster to remove the negative values?
+        s_guardian_id = s_guardian_id[
+            s_guardian_id != -1
+        ]  # is it faster to remove the negative values?
         pop[f"guardian_{i}_address_id"] = s_guardian_id.map(pop["address_id"])
-        
-        return pop
+    return pop
+
+
+def convert_middle_name_to_initial(pop: pd.DataFrame) -> pd.DataFrame:
+    """Converts middle names to middle initials. Note that this drops
+    the 'middle_name' column altogether and replaces it with 'middle_initial'
+    """
+    pop["middle_initial"] = pop["middle_name"].str[0]
+    pop = pop.drop(columns="middle_name")
+    return pop

--- a/src/vivarium_census_prl_synth_pop/utilities.py
+++ b/src/vivarium_census_prl_synth_pop/utilities.py
@@ -376,3 +376,13 @@ def update_address_id_for_unit_and_sims(
         pop.loc[rows_changing_address_id_idx, address_id_col_name] = updated_address_ids
 
     return pop, moving_units, total_address_id_count
+
+
+def add_guardian_address_ids(pop: pd.DataFrame) -> pd.DataFrame:
+    """Map the address ids of guardians to each simulant's guardian address columns"""
+    for i in [1,2]:
+        s_guardian_id = pop[f"guardian_{i}"].dropna()
+        s_guardian_id = s_guardian_id[s_guardian_id != -1] # is it faster to remove the negative values?
+        pop[f"guardian_{i}_address_id"] = s_guardian_id.map(pop["address_id"])
+        
+        return pop

--- a/tests/components/observers/test_household_survey_observers.py
+++ b/tests/components/observers/test_household_survey_observers.py
@@ -1,0 +1,65 @@
+import pytest
+import tempfile
+from types import MethodType
+from functools import partial
+
+import numpy as np
+import pandas as pd
+
+from vivarium_census_prl_synth_pop.components import observers
+from vivarium_census_prl_synth_pop.components.observers import HouseholdSurveyObserver
+
+
+# TODO: Think about broader pytest coverage
+# Things to consider: setup; schema are enforced; responses are concatenated at each time step
+
+@pytest.fixture
+def observer(mocker):
+    """Generate post-setup observer with mocked methods to patch as necessary"""
+    observer = HouseholdSurveyObserver("ACS")
+    builder = mocker.MagicMock()
+
+    # create a temp directory so setup can generate an output directory
+    tmpdir = tempfile.TemporaryDirectory()
+    builder.configuration.output_data.results_directory = tmpdir.name
+    observer.setup(builder)
+    tmpdir.cleanup()
+    
+    return observer
+
+@pytest.fixture
+def mocked_pop_view():
+    """Generate a state table view"""
+    cols = HouseholdSurveyObserver.INPUT_COLS
+    df = pd.DataFrame(np.random.randint(0, 100, size=(2, len(cols))), columns=cols)
+    df["alive"] = "alive"
+    
+    return df
+
+
+def test_instantiate(observer):
+    assert str(observer) == "HouseholdSurveyObserver(ACS)"
+
+def test_responses_schema(observer):
+    """Is the initial self.responses (after setup) the expected schema
+    (pd.DataFrame with correct columns)?
+    """
+    expected = pd.DataFrame(columns=HouseholdSurveyObserver.OUTPUT_COLS)
+    pd.testing.assert_frame_equal(expected, observer.responses)
+
+def test_1(observer, mocked_pop_view, mocker):
+    """Are new responses correctly concatenated to self.responses?"""
+    event = mocker.MagicMock()
+    event.time = pd.to_datetime("2021-01-01")
+    event.index = pd.Index([0,1])
+    
+    # mocker.patch.object(observer.population_view, "get")
+    # observer.population_view.get = mocked_pop_view  # FIXME: This returns mocked_pop_view regardless of event.index or alive status
+    observer.population_view.get.return_value = mocked_pop_view
+    breakpoint()
+
+
+    mocker.patch("vivarium_census_prl_synth_pop.components.observers.vectorized_choice", return_value=list(mocked_pop_view["household_id"]))
+    
+    observer.do_observation(event)
+    breakpoint()

--- a/tests/components/observers/test_household_survey_observers.py
+++ b/tests/components/observers/test_household_survey_observers.py
@@ -1,17 +1,13 @@
-import pytest
 import tempfile
-from types import MethodType
-from functools import partial
 
 import numpy as np
 import pandas as pd
+import pytest
 
-from vivarium_census_prl_synth_pop.components import observers
 from vivarium_census_prl_synth_pop.components.observers import HouseholdSurveyObserver
 
+# TODO: Broader test coverage
 
-# TODO: Think about broader pytest coverage
-# Things to consider: setup; schema are enforced; responses are concatenated at each time step
 
 @pytest.fixture
 def observer(mocker):
@@ -24,8 +20,8 @@ def observer(mocker):
     builder.configuration.output_data.results_directory = tmpdir.name
     observer.setup(builder)
     tmpdir.cleanup()
-    
     return observer
+
 
 @pytest.fixture
 def mocked_pop_view():
@@ -33,12 +29,17 @@ def mocked_pop_view():
     cols = HouseholdSurveyObserver.INPUT_COLS
     df = pd.DataFrame(np.random.randint(0, 100, size=(2, len(cols))), columns=cols)
     df["alive"] = "alive"
-    
+    df[["first_name", "middle_name", "last_name"]] = (
+        ["Alex", "J", "Honnold"],
+        ["Carolynn", "Marie", "Hill"],
+    )
+
     return df
 
 
 def test_instantiate(observer):
     assert str(observer) == "HouseholdSurveyObserver(ACS)"
+
 
 def test_responses_schema(observer):
     """Is the initial self.responses (after setup) the expected schema
@@ -47,19 +48,16 @@ def test_responses_schema(observer):
     expected = pd.DataFrame(columns=HouseholdSurveyObserver.OUTPUT_COLS)
     pd.testing.assert_frame_equal(expected, observer.responses)
 
-def test_1(observer, mocked_pop_view, mocker):
-    """Are new responses correctly concatenated to self.responses?"""
+
+def test_do_observation(observer, mocked_pop_view, mocker):
+    """Are responses recorded and with the the required columns?"""
     event = mocker.MagicMock()
     event.time = pd.to_datetime("2021-01-01")
-    event.index = pd.Index([0,1])
-    
-    # mocker.patch.object(observer.population_view, "get")
-    # observer.population_view.get = mocked_pop_view  # FIXME: This returns mocked_pop_view regardless of event.index or alive status
-    observer.population_view.get.return_value = mocked_pop_view
-    breakpoint()
-
-
-    mocker.patch("vivarium_census_prl_synth_pop.components.observers.vectorized_choice", return_value=list(mocked_pop_view["household_id"]))
-    
+    event.index = pd.Index([0, 1])
+    observer.population_view.get.return_value = mocked_pop_view  # FIXME: This returns mocked_pop_view regardless of event.index or alive status
+    mocker.patch(
+        "vivarium_census_prl_synth_pop.components.observers.utilities.vectorized_choice",
+        return_value=list(mocked_pop_view["household_id"]),
+    )
     observer.do_observation(event)
-    breakpoint()
+    assert set(observer.responses.columns) == set(HouseholdSurveyObserver.OUTPUT_COLS)

--- a/tests/components/observers/test_household_survey_observers.py
+++ b/tests/components/observers/test_household_survey_observers.py
@@ -27,6 +27,8 @@ def mocked_pop_view(observer):
         ["Alex", "J", "Honnold"],
         ["Carolynn", "Marie", "Hill"],
     )
+    # Ensure there are no guardians in this dataset
+    df[["guardian_1", "guardian_2"]] = np.random.randint(len(df), 100, size=(len(df), 2))
 
     return df
 

--- a/tests/components/test_observers.py
+++ b/tests/components/test_observers.py
@@ -1,9 +1,0 @@
-import pytest
-
-from vivarium_census_prl_synth_pop.components import observers
-
-def test_instantiate_base_observer():
-    """Expact a TypeError when trying to instantiate an abc"""
-    with pytest.raises(Exception):
-        observers.BaseObserver()
-


### PR DESCRIPTION
## Title: Implement household survey observer

### Description
- *Category*: implementation
- *JIRA issue*: [MIC-3669](https://jira.ihme.washington.edu/browse/MIC-3669)
- *Research reference*: https://vivarium-research.readthedocs.io/en/latest/models/concept_models/vivarium_census_synthdata/concept_model.html#household-surveys

### Changes and notes
Adds house hold survey observer using the base observer class. Note that this
does NOT implement non-responses yet; that will be done when the RT
has finalized the approach (and might be implemented in pseudo-people
anyway)

I also added a few pytests, though we should probably discuss coverage requirements
and create a separate ticket for that.

### Verification and Testing
* ran a short sim and ensured datasets are being generated
* pytests are passing

