### PR TITLE
Bugfix/guardians missing

### DIFF
--- a/src/vivarium_census_prl_synth_pop/components/population.py
+++ b/src/vivarium_census_prl_synth_pop/components/population.py
@@ -752,11 +752,27 @@ class Population:
                     households_guardian_types[guardian_type]["race_ethnicity"] == race,
                     "reference_person_id",
                 ]
-                race_guardian_ids = self.randomness.choice(
-                    race_college_sims_with_guardian_idx,
-                    choices=race_reference_person_ids,
-                    additional_key=f"{race}_{guardian_type}_guardian_ids",
-                )
+                if race_reference_person_ids.empty & len(race_college_sims_with_guardian_idx) > 0:
+                    # Get ids of for all other race reference persons if guardian type has no reference persons
+                    # This handles an unlikely edge case
+                    race_reference_person_ids = pd.concat(
+                        [df for gt, df in households_guardian_types.items() if gt != guardian_type]
+                    )
+                    race_reference_person_ids = race_reference_person_ids.loc[
+                        race_reference_person_ids["race_ethnicity"] == race,
+                        "reference_person_id",
+                    ]
+                    race_guardian_ids = self.randomness.choice(
+                        race_college_sims_with_guardian_idx,
+                        choices=race_reference_person_ids,
+                        additional_key=f"{race}_combined_guardian_ids",
+                    )
+                else:
+                    race_guardian_ids = self.randomness.choice(
+                        race_college_sims_with_guardian_idx,
+                        choices=race_reference_person_ids,
+                        additional_key=f"{race}_{guardian_type}_guardian_ids",
+                    )
 
                 pop.loc[race_guardian_ids.index, "guardian_1"] = race_guardian_ids
 

--- a/src/vivarium_census_prl_synth_pop/components/population.py
+++ b/src/vivarium_census_prl_synth_pop/components/population.py
@@ -753,11 +753,11 @@ class Population:
                     "reference_person_id",
                 ]
                 if (
-                    race_reference_person_ids.empty & len(race_college_sims_with_guardian_idx)
+                    race_reference_person_ids.empty and len(race_college_sims_with_guardian_idx)
                     > 0
                 ):
-                    # Get ids of for all other race reference persons if guardian type has no reference persons
-                    # This handles an unlikely edge case
+                    # Get all ids for race reference person who are not guardian_type
+                    # This handles an unlikely edge case - leaving additional key attached to guardian_type
                     race_reference_person_ids = pd.concat(
                         [
                             df
@@ -769,17 +769,11 @@ class Population:
                         race_reference_person_ids["race_ethnicity"] == race,
                         "reference_person_id",
                     ]
-                    race_guardian_ids = self.randomness.choice(
-                        race_college_sims_with_guardian_idx,
-                        choices=race_reference_person_ids,
-                        additional_key=f"{race}_combined_guardian_ids",
-                    )
-                else:
-                    race_guardian_ids = self.randomness.choice(
-                        race_college_sims_with_guardian_idx,
-                        choices=race_reference_person_ids,
-                        additional_key=f"{race}_{guardian_type}_guardian_ids",
-                    )
+                race_guardian_ids = self.randomness.choice(
+                    race_college_sims_with_guardian_idx,
+                    choices=race_reference_person_ids,
+                    additional_key=f"{race}_{guardian_type}_guardian_ids",
+                )
 
                 pop.loc[race_guardian_ids.index, "guardian_1"] = race_guardian_ids
 

--- a/src/vivarium_census_prl_synth_pop/components/population.py
+++ b/src/vivarium_census_prl_synth_pop/components/population.py
@@ -752,11 +752,18 @@ class Population:
                     households_guardian_types[guardian_type]["race_ethnicity"] == race,
                     "reference_person_id",
                 ]
-                if race_reference_person_ids.empty & len(race_college_sims_with_guardian_idx) > 0:
+                if (
+                    race_reference_person_ids.empty & len(race_college_sims_with_guardian_idx)
+                    > 0
+                ):
                     # Get ids of for all other race reference persons if guardian type has no reference persons
                     # This handles an unlikely edge case
                     race_reference_person_ids = pd.concat(
-                        [df for gt, df in households_guardian_types.items() if gt != guardian_type]
+                        [
+                            df
+                            for gt, df in households_guardian_types.items()
+                            if gt != guardian_type
+                        ]
                     )
                     race_reference_person_ids = race_reference_person_ids.loc[
                         race_reference_person_ids["race_ethnicity"] == race,


### PR DESCRIPTION
## Handle college guardian assignment severe edge case.

### Handles edge case in guardian assignment where the desired guardian type for assignment has no choices for the randomness stream.
- *Category*: Bufix
- *JIRA issue*: [MIC-3689](https://jira.ihme.washington.edu/browse/MIC-3689)
- *Research reference*: N/A

### Changes and notes
-Adds check to see if we are trying to assign college sims to an empty series of guardian types for a particular race/ethnicity.

### Verification and Testing
Ran simulation.

