### PR TITLE
Implement logic for new-household moves

### DIFF
--- a/src/vivarium_census_prl_synth_pop/components/businesses.py
+++ b/src/vivarium_census_prl_synth_pop/components/businesses.py
@@ -165,7 +165,7 @@ class Businesses:
             pop,
             moving_units=self.businesses,
             units_that_move_ids=businesses_that_move_idx,
-            total_address_id_count=self.employer_address_id_count,
+            starting_address_id=self.employer_address_id_count,
             unit_id_col_name="employer_id",
             address_id_col_name="employer_address_id",
         )

--- a/src/vivarium_census_prl_synth_pop/components/household.py
+++ b/src/vivarium_census_prl_synth_pop/components/household.py
@@ -161,7 +161,7 @@ class HouseholdMigration:
         max_household_address_id = pop["address_id"].max()
 
         # Update both state tables and address_id tracker.
-        (pop, households, _,) = update_address_id_for_unit_and_sims(
+        (pop, _, _,) = update_address_id_for_unit_and_sims(
             pop,
             moving_units=households,
             units_that_move_ids=domestic_households_idx,

--- a/src/vivarium_census_prl_synth_pop/components/person.py
+++ b/src/vivarium_census_prl_synth_pop/components/person.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pandas as pd
 from vivarium.framework.engine import Builder
 from vivarium.framework.event import Event
@@ -6,7 +7,7 @@ from vivarium.framework.utilities import from_yearly
 from vivarium.framework.values import Pipeline
 
 from vivarium_census_prl_synth_pop.constants import data_values, paths
-from vivarium_census_prl_synth_pop.utilities import filter_by_rate
+from vivarium_census_prl_synth_pop.utilities import update_address_id
 
 
 class PersonMigration:
@@ -41,8 +42,6 @@ class PersonMigration:
             "household_id",
             "relation_to_household_head",
             "address_id",
-            "exit_time",
-            "tracked",
             "housing_type",
         ]
         self.population_view = builder.population.get_view(self.columns_needed)
@@ -98,7 +97,12 @@ class PersonMigration:
             p=move_type_probabilities.values,
         )
 
-        domestic_movers_idx = pop.index[move_types_chosen != "no_move"]
+        pop = self._perform_new_household_moves(
+            pop, pop.index[move_types_chosen == "new_household"]
+        )
+
+        # TODO: This old code currently handles all of the *other* types of domestic moves.
+        domestic_movers_idx = pop.index[~move_types_chosen.isin(["no_move", "new_household"])]
 
         # TODO: Handle move types correctly -- this is code from the previous migration implementation
         # which only had a single type of individual move.
@@ -108,10 +112,7 @@ class PersonMigration:
 
         # get address_id for new households being moved to
         new_household_data = (
-            self.population_view.subview(["household_id", "address_id"])
-            .get(index=event.index)
-            .drop_duplicates()
-            .set_index("household_id")
+            pop[["household_id", "address_id"]].drop_duplicates().set_index("household_id")
         )
 
         # update household data for domestic movers
@@ -169,6 +170,27 @@ class PersonMigration:
     ##################
     # Helper methods #
     ##################
+
+    def _perform_new_household_moves(
+        self, pop: pd.DataFrame, movers: pd.Index
+    ) -> pd.DataFrame:
+        """
+        Create a new single-person household for each person in movers and move them to it.
+        """
+        first_new_household_id = pop["household_id"].max() + 1
+        first_new_household_address_id = pop["address_id"].max() + 1
+
+        new_household_ids = first_new_household_id + np.arange(len(movers))
+
+        pop.loc[movers, "household_id"] = new_household_ids
+        pop = update_address_id(
+            pop, movers, starting_address_id=first_new_household_address_id
+        )
+
+        pop.loc[movers, "relation_to_household_head"] = "Reference person"
+        pop.loc[movers, "housing_type"] = "Standard"
+
+        return pop
 
     def _get_new_household_ids(self, pop: pd.DataFrame, sims_who_move: pd.Index) -> pd.Series:
         households = pop["household_id"]

--- a/src/vivarium_census_prl_synth_pop/utilities.py
+++ b/src/vivarium_census_prl_synth_pop/utilities.py
@@ -320,7 +320,7 @@ def update_address_id_for_unit_and_sims(
     pop: pd.DataFrame,
     moving_units: pd.DataFrame,
     units_that_move_ids: pd.Index,
-    total_address_id_count: int,
+    starting_address_id: int,
     unit_id_col_name: str,
     address_id_col_name: str,
 ) -> Tuple[pd.DataFrame, pd.DataFrame, int]:
@@ -332,7 +332,7 @@ def update_address_id_for_unit_and_sims(
     pop: population table
     moving_units: Dataframe with column address_id_col_name.
     units_that_move_ids: IDs of moving units.  This is a subset of moving_units.index
-    total_address_id_count: Tracking number to update to preserver unique address_ids.
+    starting_address_id: Integer at which to start generating new address_ids, to prevent collisions.
     unit_id_col_name: Column name in state table where ids for the unit are stored.
     address_id_col_name: Column name in state table where address_id for the unit is stored.
 
@@ -340,7 +340,7 @@ def update_address_id_for_unit_and_sims(
     -------
     pop: Updated version of the state table.
     moving_units: Updated version of units dataframe.  This is done for the purpose of the businesses table.
-    total_address_id_count: Updated tracking number for address_id.
+    starting_address_id: Updated integer at which to start when generating more address_ids.
     """
 
     if len(units_that_move_ids) > 0:
@@ -350,10 +350,10 @@ def update_address_id_for_unit_and_sims(
         moving_units = update_address_id(
             df=moving_units,
             rows_to_update=units_that_move_ids,
-            starting_address_id=total_address_id_count,
+            starting_address_id=starting_address_id,
             address_id_col_name=address_id_col_name,
         )
-        total_address_id_count += len(units_that_move_ids)
+        starting_address_id += len(units_that_move_ids)
 
         # update address_id column in the pop table
         rows_changing_address_id_idx = pop.loc[
@@ -375,4 +375,4 @@ def update_address_id_for_unit_and_sims(
         pop = pop.set_index("simulant_id")
         pop.loc[rows_changing_address_id_idx, address_id_col_name] = updated_address_ids
 
-    return pop, moving_units, total_address_id_count
+    return pop, moving_units, starting_address_id


### PR DESCRIPTION
## Implement logic for new-household moves

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: implementation
- *JIRA issue*: [MIC-3673](https://jira.ihme.washington.edu/browse/MIC-3673)
- *Research reference*: https://vivarium-research.readthedocs.io/en/latest/models/concept_models/vivarium_census_synthdata/concept_model.html#new-household-moves

### Changes and notes

### Verification and Testing
Ran simulation without error; stepped through and inspected newly generated household IDs and address IDs; checked that household ID -> address ID was still a 1-to-1 mapping.
