### PR TITLE
Implement logic for GQ person moves

### DIFF
--- a/src/vivarium_census_prl_synth_pop/constants/data_values.py
+++ b/src/vivarium_census_prl_synth_pop/constants/data_values.py
@@ -13,6 +13,10 @@ NONINSTITUTIONAL_GROUP_QUARTER_IDS = {
     "Military": 4,
     "Other non-institutional": 5,
 }
+GROUP_QUARTER_IDS = {
+    "Institutionalized GQ pop": INSTITUTIONAL_GROUP_QUARTER_IDS,
+    "Noninstitutionalized GQ pop": NONINSTITUTIONAL_GROUP_QUARTER_IDS,
+}
 GQ_HOUSING_TYPE_MAP = {
     0: "Carceral",
     1: "Nursing home",


### PR DESCRIPTION
## Implement logic for GQ person moves

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: implementation
- *JIRA issue*: [MIC-3674](https://jira.ihme.washington.edu/browse/MIC-3674)
- *Research reference*: https://vivarium-research.readthedocs.io/en/latest/models/concept_models/vivarium_census_synthdata/concept_model.html#gq-person-moves

### Changes and notes

I did the sampling of GQ type in the opposite order to what I wrote in the ticket: first choose the GQ housing type category (institutional or non-institutional) then choose the specific housing type (carceral, nursing home, etc). This will be easier to upgrade if we go on to implement a correlation between demographics and GQ housing type category.

### Verification and Testing

Ran simulation, stepped through and verified sims were moving to GQ and had correct address IDs and housing types.
