### PR TITLE
Bugfix/perturb age mask

### DIFF
--- a/src/vivarium_census_prl_synth_pop/components/population.py
+++ b/src/vivarium_census_prl_synth_pop/components/population.py
@@ -91,7 +91,9 @@ class Population:
 
     def _load_population_data(self, builder: Builder):
         households = builder.data.load(data_keys.POPULATION.HOUSEHOLDS)
-        persons = builder.data.load(data_keys.POPULATION.PERSONS)[metadata.PERSONS_COLUMNS_TO_INITIALIZE]
+        persons = builder.data.load(data_keys.POPULATION.PERSONS)[
+            metadata.PERSONS_COLUMNS_TO_INITIALIZE
+        ]
         return {"households": households, "persons": persons}
 
     def initialize_simulants(self, pop_data: SimulantData) -> None:

--- a/src/vivarium_census_prl_synth_pop/components/population.py
+++ b/src/vivarium_census_prl_synth_pop/components/population.py
@@ -897,7 +897,7 @@ class Population:
         # todo: Consider changing this function to build a distribution for each simulan instead of resampling.
 
         # Get age shift and redraw for simulants who get negative ages
-        to_shift = pd.Index(pop.index)
+        to_shift = pop.index
         max_iterations = 10
         for i in range(max_iterations):
             if to_shift.empty:
@@ -914,11 +914,9 @@ class Population:
 
             # Calculate shifted ages and see if any are negative and need to be resampled.
             shifted_ages = pop.loc[to_shift, "age"] + age_shift
-            positive_ages_idx = shifted_ages.loc[shifted_ages >= 0].index
-            pop.loc[positive_ages_idx, "age"] = shifted_ages.loc[positive_ages_idx]
-            to_shift = shifted_ages.loc[
-                shifted_ages.index.difference(positive_ages_idx)
-            ].index
+            non_negative_ages_idx = shifted_ages.loc[shifted_ages >= 0].index
+            pop.loc[non_negative_ages_idx, "age"] = shifted_ages.loc[non_negative_ages_idx]
+            to_shift = shifted_ages.index.difference(non_negative_ages_idx)
 
         # Check if any simulants did not have their age shifted
         if len(to_shift) > 0:


### PR DESCRIPTION
## Bugfix/age perturbation for individuals

### Fixes bug caused by boolean mask not having same index as population table.
- *Category*: Bugfix
- *JIRA issue*: [MIC-3691](https://jira.ihme.washington.edu/browse/MIC-3691)
- *Research reference*: N/A

### Changes and notes
-Changes implementation in function to use indexes instead of masks

### Verification and Testing
Successfully ran simulation for population sizes of 2,000, 20,000, and 200,000.

