### PR TITLE
Feature/sbachmei/mic 3690 stop ci building python 3.6

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # default owners
-* @albrja @beatrixkh @collijk @hussain-jafari @mattkappel @ramittal @rmudambi @stevebachmeier
+* @albrja @collijk @hussain-jafari @mattkappel @ramittal @rmudambi @stevebachmeier

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     defaults:
       run:
         shell: bash -le {0}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9, 3.10]
     defaults:
       run:
         shell: bash -le {0}


### PR DESCRIPTION
## Title: CI build python 3.9 and 3.10

### Description
- *Category*: misc
- *JIRA issue*: [MIC-3690](https://jira.ihme.washington.edu/browse/MIC-3690)
- *Research reference*: n/a

### Changes and notes
@zmbc previously removed 3.6 from the python build list, but we also now
want to build 3.9 and 3.10.

This also removes Beatrix from the CODEOWNERS :(

### Verification and Testing
Ensured builds complete

