### PR TITLE
Remove references to unused address component

### DIFF
--- a/src/vivarium_census_prl_synth_pop/components/businesses.py
+++ b/src/vivarium_census_prl_synth_pop/components/businesses.py
@@ -77,7 +77,6 @@ class Businesses:
             f"{self.name}.move_rate", source=move_rate_data
         )
 
-        self.addresses = builder.components.get_component("Address")
         builder.population.initializes_simulants(
             self.on_initialize_simulants,
             requires_columns=["age"],

--- a/src/vivarium_census_prl_synth_pop/components/person.py
+++ b/src/vivarium_census_prl_synth_pop/components/person.py
@@ -33,7 +33,6 @@ class PersonMigration:
 
     def setup(self, builder: Builder):
         self.randomness = builder.randomness.get_stream(self.name)
-        self.addresses = builder.components.get_component("Address")
         self.columns_needed = [
             "household_id",
             "relation_to_household_head",

--- a/src/vivarium_census_prl_synth_pop/model_specifications/model_spec.yaml
+++ b/src/vivarium_census_prl_synth_pop/model_specifications/model_spec.yaml
@@ -2,7 +2,6 @@ components:
     vivarium_census_prl_synth_pop:
         components:
             - Population()
-            - Address()
             - HouseholdMigration()
             - PersonMigration()
             - DecennialCensusObserver()


### PR DESCRIPTION
## Remove references to unused address component

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: bugfix
- *JIRA issue*: none
- *Research reference*: none

### Changes and notes

I noticed that because we were still referencing the Address component, the sim was still loading the address data every time. This only eliminates a constant from the runtime but it significantly improves quality of life for debugging with small populations!

### Verification and Testing

Ran simulation to completion; searched for references to the removed component.

On my setup (results may vary), with 2k population, before:

<pre><code>
2022-12-21 14:06:39.497 | vivarium.framework.engine:report:203 - 
              Event  Count  Mean time (s)  Std. dev. time (s)  Total time (s)  % Total time
     initialization      1           0.82                0.00            0.82          0.29
              <b>setup      1         149.84                0.00          149.84         53.74</b>
         post_setup      1           0.00                0.00            0.00          0.00
population_creation      1           2.69                0.00            2.69          0.96
 time_step__prepare    132           0.00                0.00            0.09          0.03
          time_step    132           0.92                0.08          120.94         43.38
 time_step__cleanup    132           0.02                0.00            2.65          0.95
    collect_metrics    132           0.01                0.03            1.22          0.44
     simulation_end      1           0.54                0.00            0.54          0.19
              total      1         278.80                0.00          278.80        100.00
</pre></code>

After:

<pre><code>
2022-12-21 14:11:35.644 | vivarium.framework.engine:report:203 - 
              Event  Count  Mean time (s)  Std. dev. time (s)  Total time (s)  % Total time
     initialization      1           1.42                0.00            1.42          0.97
              <b>setup      1          16.15                0.00           16.15         11.05</b>
         post_setup      1           0.00                0.00            0.00          0.00
population_creation      1           2.66                0.00            2.66          1.82
 time_step__prepare    132           0.00                0.00            0.09          0.06
          time_step    132           0.92                0.10          121.58         83.18
 time_step__cleanup    132           0.02                0.00            2.65          1.82
    collect_metrics    132           0.01                0.03            1.32          0.90
     simulation_end      1           0.30                0.00            0.30          0.20
              total      1         146.18                0.00          146.18        100.00
</pre></code>