### PR TITLE
Use binary search for vectorized_choice

### DIFF
--- a/src/vivarium_census_prl_synth_pop/components/population.py
+++ b/src/vivarium_census_prl_synth_pop/components/population.py
@@ -194,18 +194,17 @@ class Population:
         return chosen_persons
 
     def choose_group_quarters(self, target_number_sims: int) -> pd.Series:
-        group_quarters = self.population_data["households"]["census_household_id"]
-        group_quarters = group_quarters.loc[
-            ["GQ" in household_id for household_id in group_quarters]
-        ]
+        group_quarters = self.population_data["households"].pipe(
+            lambda df: df[df["census_household_id"].str.contains("GQ")]
+        )
 
         # group quarters each house one person per census_household_id
         # they have NA household weights, but appropriately weighted person weights.
         chosen_units = vectorized_choice(
-            options=group_quarters,
+            options=group_quarters["census_household_id"],
             n_to_choose=target_number_sims,
             randomness_stream=self.randomness,
-            weights=self.population_data["households"]["person_weight"],
+            weights=group_quarters["person_weight"],
         )
 
         # get simulants per GQ unit

--- a/src/vivarium_census_prl_synth_pop/components/population.py
+++ b/src/vivarium_census_prl_synth_pop/components/population.py
@@ -205,7 +205,7 @@ class Population:
             options=group_quarters,
             n_to_choose=target_number_sims,
             randomness_stream=self.randomness,
-            weights=self.population_data["households"][["person_weight"]],
+            weights=self.population_data["households"]["person_weight"],
         )
 
         # get simulants per GQ unit

--- a/src/vivarium_census_prl_synth_pop/utilities.py
+++ b/src/vivarium_census_prl_synth_pop/utilities.py
@@ -214,7 +214,7 @@ def vectorized_choice(
     cdf = np.cumsum(pmf)
 
     # for each p_i in probs, count how many elements of cdf for which p_i >= cdf_i
-    chosen_indices = np.searchsorted(cdf[~pd.isnull(cdf)], probs, side="right")
+    chosen_indices = np.searchsorted(cdf, probs, side="right")
     return np.take(options, chosen_indices)
 
 

--- a/src/vivarium_census_prl_synth_pop/utilities.py
+++ b/src/vivarium_census_prl_synth_pop/utilities.py
@@ -214,8 +214,7 @@ def vectorized_choice(
     cdf = np.cumsum(pmf)
 
     # for each p_i in probs, count how many elements of cdf for which p_i >= cdf_i
-    vect_find_index = np.vectorize(lambda p_i: (p_i >= cdf).sum())
-    chosen_indices = vect_find_index(probs)
+    chosen_indices = np.searchsorted(cdf[~pd.isnull(cdf)], probs, side="right")
     return np.take(options, chosen_indices)
 
 


### PR DESCRIPTION
## Use binary search for vectorized_choice

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: performance
- *JIRA issue*: [MIC-3569](https://jira.ihme.washington.edu/browse/MIC-3569)
- *Research reference*: none

### Changes and notes

Note that I have made this drop-in replacement without diving too deep into the behavior of vectorized_choice. In particular, I find its handling of Pandas indexes quite confusing.

### Verification and Testing

Stepped through and verified that the old code and new code would get the same results for actual inputs.

This change has a relatively small impact on runtime with small populations, because in small populations the timestep runtime dominates the total runtime -- I am guessing because there is some constant overhead to each timestep, while population creation scales more exactly with population size.

Performance for a 250k population, before:

<pre><code>
2022-12-21 14:59:05.745 | vivarium.framework.engine:report:203 - 
              Event  Count  Mean time (s)  Std. dev. time (s)  Total time (s)  % Total time
     initialization      1           0.55                0.00            0.55          0.05
              setup      1           7.63                0.00            7.63          0.76
         post_setup      1           0.00                0.00            0.00          0.00
<b>population_creation      1         134.24                0.00          134.24         13.39</b>
 time_step__prepare    132           0.03                0.00            3.62          0.36
          time_step    132           6.21                0.21          819.96         81.78
 time_step__cleanup    132           0.21                0.02           27.36          2.73
    collect_metrics    132           0.06                0.10            7.87          0.78
     simulation_end      1           1.48                0.00            1.48          0.15
              total      1        1002.69                0.00         1002.69        100.00
</pre></code>

After:

<pre><code>
2022-12-21 15:17:57.076 | vivarium.framework.engine:report:203 - 
              Event  Count  Mean time (s)  Std. dev. time (s)  Total time (s)  % Total time
     initialization      1           0.97                0.00            0.97          0.11
              setup      1           7.29                0.00            7.29          0.80
         post_setup      1           0.00                0.00            0.00          0.00
<b>population_creation      1          18.35                0.00           18.35          2.01</b>
 time_step__prepare    132           0.03                0.01            3.77          0.41
          time_step    132           6.42                0.24          847.21         92.61
 time_step__cleanup    132           0.21                0.01           28.05          3.07
    collect_metrics    132           0.06                0.10            7.78          0.85
     simulation_end      1           1.44                0.00            1.44          0.16
              total      1         914.86                0.00          914.86        100.00
</pre></code>

Note that both of these runs included the change in #114.

I expect the speedup to become even more dramatic as we further increase population size, and as we expand from Florida to the full US for our input data.