### PR TITLE
Implement household survey observer and refactor others

### DIFF
--- a/src/vivarium_census_prl_synth_pop/components/__init__.py
+++ b/src/vivarium_census_prl_synth_pop/components/__init__.py
@@ -4,6 +4,7 @@ from vivarium_census_prl_synth_pop.components.household import HouseholdMigratio
 from vivarium_census_prl_synth_pop.components.mortality import Mortality
 from vivarium_census_prl_synth_pop.components.observers import (
     DecennialCensusObserver,
+    HouseholdSurveyObserver,
     WICObserver,
 )
 from vivarium_census_prl_synth_pop.components.person import PersonMigration

--- a/src/vivarium_census_prl_synth_pop/constants/data_values.py
+++ b/src/vivarium_census_prl_synth_pop/constants/data_values.py
@@ -4,6 +4,9 @@ from typing import NamedTuple
 # Population parameters #
 #########################
 
+# TODO: implement gbd call (vivarium_inputs.get_population_structure("United States"))
+US_POPULATION = 333339776
+
 PROP_POPULATION_IN_GQ = 0.03
 PROBABILITY_OF_TWINS = 0.04
 N_GROUP_QUARTER_TYPES = 6

--- a/src/vivarium_census_prl_synth_pop/constants/metadata.py
+++ b/src/vivarium_census_prl_synth_pop/constants/metadata.py
@@ -230,28 +230,6 @@ US_STATE_ABBRV_MAP = {
 
 P_GROUP_QUARTERS = 0.03
 
-CORE_OBSERVER_COLUMNS = [
-    "first_name_id",
-    "middle_name_id",
-    "last_name_id",
-    "age",
-    "date_of_birth",
-    "address_id",
-    "sex",
-    "race_ethnicity",
-    "guardian_1",
-    "guardian_2",
-]
-
-DECENNIAL_CENSUS_COLUMNS_USED = CORE_OBSERVER_COLUMNS + [
-    "relation_to_household_head",
-    "housing_type",
-]
-
-WIC_OBSERVER_COLUMNS_USED = CORE_OBSERVER_COLUMNS + [
-    "income",
-]
-
 NATIVITY_MAP = {1: True, 2: False}
 
 MIGRATION_MAP = {1.0: False, 2.0: True, 3.0: False}

--- a/src/vivarium_census_prl_synth_pop/model_specifications/model_spec.yaml
+++ b/src/vivarium_census_prl_synth_pop/model_specifications/model_spec.yaml
@@ -5,11 +5,14 @@ components:
             - Address()
             - HouseholdMigration()
             - PersonMigration()
-            - DecennialCensusObserver()
-            - WICObserver()
             - Mortality()
             - Fertility()
             - Businesses()
+
+            - DecennialCensusObserver()
+            - HouseholdSurveyObserver("acs")
+            - HouseholdSurveyObserver("cps")
+            - WICObserver()
 
 configuration:
     input_data:

--- a/src/vivarium_census_prl_synth_pop/utilities.py
+++ b/src/vivarium_census_prl_synth_pop/utilities.py
@@ -382,3 +382,23 @@ def update_address_id_for_unit_and_sims(
         pop.loc[rows_changing_address_id_idx, address_id_col_name] = updated_address_ids
 
     return pop, moving_units, total_address_id_count
+
+
+def add_guardian_address_ids(pop: pd.DataFrame) -> pd.DataFrame:
+    """Map the address ids of guardians to each simulant's guardian address columns"""
+    for i in [1, 2]:
+        s_guardian_id = pop[f"guardian_{i}"]
+        s_guardian_id = s_guardian_id[
+            s_guardian_id != -1
+        ]  # is it faster to remove the negative values?
+        pop[f"guardian_{i}_address_id"] = s_guardian_id.map(pop["address_id"])
+    return pop
+
+
+def convert_middle_name_to_initial(pop: pd.DataFrame) -> pd.DataFrame:
+    """Converts middle names to middle initials. Note that this drops
+    the 'middle_name' column altogether and replaces it with 'middle_initial'
+    """
+    pop["middle_initial"] = pop["middle_name"].str[0]
+    pop = pop.drop(columns="middle_name")
+    return pop

--- a/tests/components/observers/test_household_survey_observers.py
+++ b/tests/components/observers/test_household_survey_observers.py
@@ -1,0 +1,82 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from vivarium_census_prl_synth_pop.components.observers import HouseholdSurveyObserver
+
+# TODO: Broader test coverage
+
+
+@pytest.fixture
+def observer(mocker, tmp_path):
+    """Generate post-setup observer with mocked methods to patch as necessary"""
+    observer = HouseholdSurveyObserver("acs")
+    builder = mocker.MagicMock()
+    builder.configuration.output_data.results_directory = tmp_path
+    observer.setup(builder)
+    return observer
+
+
+@pytest.fixture
+def mocked_pop_view(observer):
+    """Generate a state table view"""
+    cols = observer.input_columns
+    df = pd.DataFrame(np.random.randint(0, 100, size=(2, len(cols))), columns=cols)
+    df["alive"] = "alive"
+    df[["first_name", "middle_name", "last_name"]] = (
+        ["Alex", "J", "Honnold"],
+        ["Carolynn", "Marie", "Hill"],
+    )
+    # Ensure there are no guardians in this dataset
+    df[["guardian_1", "guardian_2"]] = np.random.randint(len(df), 100, size=(len(df), 2))
+
+    return df
+
+
+def test_instantiate(observer):
+    assert str(observer) == "HouseholdSurveyObserver(acs)"
+
+
+def test_responses_schema(observer):
+    """Is the initial self.responses (after setup) the expected schema
+    (pd.DataFrame with correct columns)?
+    """
+    pd.testing.assert_frame_equal(
+        pd.DataFrame(columns=observer.output_columns), observer.responses
+    )
+
+
+def test_on_simulation_end(observer, mocker):
+    """Are the final results written out to the expected directory?"""
+    event = mocker.MagicMock()
+    observer.on_simulation_end(event)
+    assert (observer.output_dir / observer.output_filename).is_file()
+
+
+def test_do_observation(observer, mocked_pop_view, mocker):
+    """Are responses recorded correctly (including concatenation after time steps?"""
+    sim_start_date = "2021-01-01"
+    # Simulate first time step
+    event = mocker.MagicMock()
+    event.time = pd.to_datetime(sim_start_date)
+    event.index = pd.Index([0, 1])
+    observer.population_view.get.return_value = mocked_pop_view  # FIXME: This returns mocked_pop_view regardless of event.index or alive status
+    mocker.patch(
+        "vivarium_census_prl_synth_pop.components.observers.utilities.vectorized_choice",
+        return_value=list(mocked_pop_view["household_id"]),
+    )
+    observer.do_observation(event)
+    # Simulate second time step
+    event.time = event.time + pd.Timedelta(28, "days")
+    observer.do_observation(event)
+
+    expected = pd.concat([mocked_pop_view] * 2)
+    expected["middle_initial"] = ["J", "M"] * 2
+    expected[["guardian_1_address_id", "guardian_2_address_id"]] = np.nan
+    expected["survey_date"] = [pd.to_datetime(sim_start_date).date()] * 2 + [
+        event.time.date()
+    ] * 2
+
+    pd.testing.assert_frame_equal(
+        expected[observer.output_columns], observer.responses, check_dtype=False
+    )

--- a/tests/components/test_observers.py
+++ b/tests/components/test_observers.py
@@ -1,9 +1,0 @@
-import pytest
-
-from vivarium_census_prl_synth_pop.components import observers
-
-
-def test_instantiate_base_observer():
-    """Expact a TypeError when trying to instantiate an abc"""
-    with pytest.raises(Exception):
-        observers.BaseObserver()


### PR DESCRIPTION
## Implement household survey observer and refactor others

### Description
- *Category*: implementation
- *JIRA issue*: 
  - Implement household survey observer: [MIC-3669](https://jira.ihme.washington.edu/browse/MIC-3669)
  - Refactor wic observer: [MIC-3692](https://jira.ihme.washington.edu/browse/MIC-3692)
- *Research reference*: https://vivarium-research.readthedocs.io/en/latest/models/concept_models/vivarium_census_synthdata/concept_model.html#household-surveys

### Changes and notes
Releases into main the following:
* household survey observers
* Refactor of census and wic observers due to updates to base observer class
* merge conflict resolution due to changing names to name IDs

### Verification and Testing
Ran a small sim and ensured no breaks and outputs were generated.

