### PR TITLE
Feature/matching last names

### DIFF
--- a/src/vivarium_census_prl_synth_pop/components/population.py
+++ b/src/vivarium_census_prl_synth_pop/components/population.py
@@ -913,19 +913,15 @@ class Population:
         pop["last_name_id"] = pop.index
 
         # Match last names for relatives of reference person
-        relatives_idx = pop.loc[
-            (~pop["relation_to_household_head"].isin(NON_RELATIVES))
+        relatives_idx = pop.index[
+            (~pop["relation_to_household_head"].isin(NON_RELATIVES + ["Reference person"]))
             & (~pop["household_id"].isin(data_values.GQ_HOUSING_TYPE_MAP))
-        ].index
+        ]
         # Get series to map to with household_ids and reference person last name id
-        reference_person_last_name_ids = (
-            pop.loc[
-                pop["relation_to_household_head"] == "Reference person",
-                ["household_id", "last_name_id"],
-            ]
-            .reset_index()
-            .set_index("household_id")["last_name_id"]
-        )
+        reference_person_last_name_ids = pop.loc[
+            pop["relation_to_household_head"] == "Reference person",
+            ["household_id", "last_name_id"],
+        ].set_index("household_id")["last_name_id"]
         pop.loc[relatives_idx, "last_name_id"] = pop["household_id"].map(
             reference_person_last_name_ids
         )

--- a/src/vivarium_census_prl_synth_pop/components/population.py
+++ b/src/vivarium_census_prl_synth_pop/components/population.py
@@ -118,7 +118,6 @@ class Population:
         pop["first_name_id"] = pop.index
         pop["middle_name_id"] = pop.index
         pop["last_name_id"] = self.assign_last_name_ids(pop)
-        # Todo: Match names for family members: MIC-3529
 
         pop["age"] = pop["age"].astype("float64")
         # Shift age so all households do not have the same birthday


### PR DESCRIPTION
## Matching last name ids.

### Adds function to have relatives of reference person in standard households have matching last name ids.
- *Category*: Feature
- *JIRA issue*: [MIC-3529](https://jira.ihme.washington.edu/browse/MIC-3529)
- *Research reference*: https://vivarium-research.readthedocs.io/en/latest/models/concept_models/vivarium_census_synthdata/concept_model.html#component-13-names

### Changes and notes
-Adds function to map reference person last name id to relatives within the same household. 

### Verification and Testing
Successfully ran simulation and saw relatives to reference person have matching last name ids.

