### PR TITLE
defer creation of results directory to the end of the simulation

### DIFF
--- a/src/vivarium_census_prl_synth_pop/components/observers.py
+++ b/src/vivarium_census_prl_synth_pop/components/observers.py
@@ -1,5 +1,6 @@
 import datetime as dt
 from abc import ABC, abstractmethod
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -80,7 +81,7 @@ class BaseObserver(ABC):
     def setup(self, builder: Builder):
         # FIXME: move filepaths to data container
         # FIXME: settle on output dirs
-        self.output_dir = utilities.build_output_dir(builder, subdir="results")
+        self.output_dir = Path(builder.configuration.output_data.results_directory)
         self.population_view = self.get_population_view(builder)
         self.responses = self.get_response_schema()
 
@@ -137,7 +138,8 @@ class BaseObserver(ABC):
 
     # TODO: consider using compressed csv instead of hdf
     def on_simulation_end(self, event: Event) -> None:
-        self.responses.to_hdf(self.output_dir / self.output_filename, key="data")
+        output_dir = utilities.build_output_dir(self.output_dir, subdir="results")
+        self.responses.to_hdf(output_dir / self.output_filename, key="data")
 
 
 class HouseholdSurveyObserver(BaseObserver):

--- a/src/vivarium_census_prl_synth_pop/utilities.py
+++ b/src/vivarium_census_prl_synth_pop/utilities.py
@@ -284,8 +284,7 @@ def filter_by_rate(
     return filtered_sims
 
 
-def build_output_dir(builder: Builder, subdir: Optional[Union[str, Path]] = None) -> Path:
-    output_dir = Path(builder.configuration.output_data.results_directory)
+def build_output_dir(output_dir: Path, subdir: Optional[Union[str, Path]] = None) -> Path:
     if subdir:
         output_dir = output_dir / subdir
 

--- a/tests/components/observers/test_household_survey_observers.py
+++ b/tests/components/observers/test_household_survey_observers.py
@@ -50,7 +50,7 @@ def test_on_simulation_end(observer, mocker):
     """Are the final results written out to the expected directory?"""
     event = mocker.MagicMock()
     observer.on_simulation_end(event)
-    assert (observer.output_dir / observer.output_filename).is_file()
+    assert (observer.output_dir / "results" / observer.output_filename).is_file()
 
 
 def test_do_observation(observer, mocked_pop_view, mocker):


### PR DESCRIPTION
## Title: Summary, imperative, start upper case, don't end with a period
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: bugfix
- *JIRA issue*: [MIC-3702](https://jira.ihme.washington.edu/browse/MIC-3702)
- *Research reference*: N/A

### Changes and notes
Create results directory on simulation end rather than during setup.

### Verification and Testing
Ran simulation and verified that directory was not created prior to simulation end.
Automated test suite passes

