### PR TITLE
fix future warning in fertility

### DIFF
--- a/src/vivarium_census_prl_synth_pop/components/fertility.py
+++ b/src/vivarium_census_prl_synth_pop/components/fertility.py
@@ -54,7 +54,7 @@ class Fertility(FertilityAgeSpecificRates):
         rate_series = self.fertility_rate(eligible_women.index)
         had_children = self.randomness.filter_for_rate(eligible_women, rate_series).copy()
 
-        had_children.loc[:, "last_birth_time"] = event.time
+        had_children["last_birth_time"] = event.time
         self.population_view.update(had_children["last_birth_time"])
 
         # decide which births are twins


### PR DESCRIPTION
## Fix FutureWarning in fertility component
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: bugfix
- *JIRA issue*: N/A
- *Research reference*: N/A

### Changes and notes
Fix Future Warning that became apparent after suppressing the FutureWarnings coming from vivarium

### Verification and Testing
Ran simulation and verified no warnings were logged.