### PR TITLE
Only perform migration events on living simulants

### DIFF
--- a/integration_tests/test_domestic_migration.py
+++ b/integration_tests/test_domestic_migration.py
@@ -1,0 +1,39 @@
+import pytest
+
+# TODO: Broader test coverage
+
+
+def test_individuals_do_move(populations):
+    for before, after in zip(populations, populations[1:]):
+        common_simulants = before.index.intersection(after.index)
+        before = before.loc[common_simulants]
+        after = after.loc[common_simulants]
+
+        individual_movers = before["household_id"] != after["household_id"]
+        assert individual_movers.any()
+        assert (
+            before[individual_movers]["address_id"] != after[individual_movers]["address_id"]
+        ).all()
+
+
+def test_households_do_move(populations):
+    for before, after in zip(populations, populations[1:]):
+        common_simulants = before.index.intersection(after.index)
+        before = before.loc[common_simulants]
+        after = after.loc[common_simulants]
+
+        household_movers = (before["household_id"] == after["household_id"]) & (
+            before["address_id"] != after["address_id"]
+        )
+        assert household_movers.any()
+
+
+def test_only_living_people_move(populations):
+    for before, after in zip(populations, populations[1:]):
+        common_simulants = before.index.intersection(after.index)
+        before = before.loc[common_simulants]
+        after = after.loc[common_simulants]
+
+        movers = before["address_id"] != after["address_id"]
+        assert after[movers]["tracked"].all()
+        assert (after[movers]["alive"] == "alive").all()

--- a/src/vivarium_census_prl_synth_pop/components/household.py
+++ b/src/vivarium_census_prl_synth_pop/components/household.py
@@ -106,9 +106,12 @@ class HouseholdMigration:
         choose which households move;
         move those households to a new address
         """
-        # NOTE: Currently, it is possible for a household not to have a reference person;
+        # NOTE: Currently, it is possible for a household not to have a living reference person;
         # in this case, that household can no longer move.
-        pop = self.population_view.get(event.index)
+        pop = self.population_view.get(
+            event.index,
+            query="alive == 'alive'",
+        )
         reference_people = pop[pop["relation_to_household_head"] == "Reference person"]
 
         household_sizes = pop.groupby("household_id").size()

--- a/src/vivarium_census_prl_synth_pop/components/person.py
+++ b/src/vivarium_census_prl_synth_pop/components/person.py
@@ -89,8 +89,10 @@ class PersonMigration:
         Determines which simulants will move with which move type
         and performs those move operations.
         """
-
-        pop = self.population_view.get(event.index)
+        pop = self.population_view.get(
+            event.index,
+            query="alive == 'alive'",
+        )
 
         # Get subsets of simulants that do each move type on this timestep
         move_type_probabilities = self.person_move_probabilities(pop.index)


### PR DESCRIPTION
## Only perform migration events on living simulants

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: bugfix
- *JIRA issue*: [MIC-3723](https://jira.ihme.washington.edu/browse/MIC-3723)
- *Research reference*: none

### Changes and notes

### Verification and Testing

Verified simulation still runs, and that this call returns a slightly smaller dataframe than before.