### PR TITLE
Only perform job change events on living simulants

### DIFF
--- a/integration_tests/test_employment.py
+++ b/integration_tests/test_employment.py
@@ -45,3 +45,14 @@ def test_employed_have_income(tracked_live_populations, time_step):
     # All people in military group quarters are
     employed = pop[pop["employer_id"] != data_values.UNEMPLOYED_ID]
     assert (employed["income"] > 0).all()
+
+
+def test_only_living_change_employment(populations):
+    for before, after in zip(populations, populations[1:]):
+        common_simulants = before.index.intersection(after.index)
+        before = before.loc[common_simulants]
+        after = after.loc[common_simulants]
+
+        employment_changers = before["employer_id"] != after["employer_id"]
+        assert after[employment_changers]["tracked"].all()
+        assert (after[employment_changers]["alive"] == "alive").all()

--- a/src/vivarium_census_prl_synth_pop/components/businesses.py
+++ b/src/vivarium_census_prl_synth_pop/components/businesses.py
@@ -142,8 +142,10 @@ class Businesses:
         """
         pop = self.population_view.subview(
             self.columns_created + ["age", "household_id"]
-        ).get(event.index)
-
+        ).get(
+            event.index,
+            query="alive == 'alive'",
+        )
         all_businesses = self.businesses.loc[
             self.businesses["employer_id"] != data_values.UNEMPLOYED_ID, "employer_id"
         ]


### PR DESCRIPTION
## Only perform job change events on living simulants

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: bugfix
- *JIRA issue*: [MIC-3723](https://jira.ihme.washington.edu/browse/MIC-3723)
- *Research reference*: none

### Changes and notes

### Verification and Testing

Ran simulation; verified that this call gets a slightly shorter dataframe than the previous.