### PR TITLE
Trigger employment change on migration

### DIFF
--- a/integration_tests/test_employment.py
+++ b/integration_tests/test_employment.py
@@ -47,18 +47,13 @@ def test_employed_have_income(tracked_live_populations, time_step):
     assert (employed["income"] > 0).all()
 
 
-def test_movers_change_employment(sim):
-    pop_prev = sim.get_population()
-    sim.step()
-
-    for _ in range(10):
-        pop = sim.get_population()
-
-        common_working_age_simulants = pop_prev.index[pop_prev.age >= 18].intersection(
-            pop.index[pop.age >= 18]
+def test_movers_change_employment(tracked_live_populations):
+    for before, after in zip(tracked_live_populations, tracked_live_populations[1:]):
+        common_working_age_simulants = before.index[before.age >= 18].intersection(
+            after.index[after.age >= 18]
         )
-        before = pop_prev.loc[common_working_age_simulants]
-        after = pop.loc[common_working_age_simulants]
+        before = before.loc[common_working_age_simulants]
+        after = after.loc[common_working_age_simulants]
 
         moved = before["address_id"] != after["address_id"]
         moved_to_military_gq = moved & (after["housing_type"] == "Military")
@@ -67,5 +62,3 @@ def test_movers_change_employment(sim):
         assert (
             before[should_change]["employer_id"] != after[should_change]["employer_id"]
         ).all()
-        pop_prev = pop
-        sim.step()

--- a/integration_tests/test_employment.py
+++ b/integration_tests/test_employment.py
@@ -47,8 +47,8 @@ def test_employed_have_income(tracked_live_populations, time_step):
     assert (employed["income"] > 0).all()
 
 
-def test_movers_change_employment(tracked_live_populations):
-    for before, after in zip(tracked_live_populations, tracked_live_populations[1:]):
+def test_movers_change_employment(populations):
+    for before, after in zip(populations, populations[1:]):
         common_working_age_simulants = before.index[before.age >= 18].intersection(
             after.index[after.age >= 18]
         )

--- a/integration_tests/test_employment.py
+++ b/integration_tests/test_employment.py
@@ -45,3 +45,27 @@ def test_employed_have_income(tracked_live_populations, time_step):
     # All people in military group quarters are
     employed = pop[pop["employer_id"] != data_values.UNEMPLOYED_ID]
     assert (employed["income"] > 0).all()
+
+
+def test_movers_change_employment(sim):
+    pop_prev = sim.get_population()
+    sim.step()
+
+    for _ in range(10):
+        pop = sim.get_population()
+
+        common_working_age_simulants = pop_prev.index[pop_prev.age >= 18].intersection(
+            pop.index[pop.age >= 18]
+        )
+        before = pop_prev.loc[common_working_age_simulants]
+        after = pop.loc[common_working_age_simulants]
+
+        moved = before["address_id"] != after["address_id"]
+        moved_to_military_gq = moved & (after["housing_type"] == "Military")
+        previously_military_employed = before["employer_id"] == 1
+        should_change = moved & (~moved_to_military_gq | ~previously_military_employed)
+        assert (
+            before[should_change]["employer_id"] != after[should_change]["employer_id"]
+        ).all()
+        pop_prev = pop
+        sim.step()

--- a/src/vivarium_census_prl_synth_pop/components/businesses.py
+++ b/src/vivarium_census_prl_synth_pop/components/businesses.py
@@ -8,7 +8,7 @@ from vivarium.framework.population import SimulantData
 from vivarium.framework.time import get_time_stamp
 from vivarium_public_health import utilities
 
-from vivarium_census_prl_synth_pop.constants import data_keys, data_values
+from vivarium_census_prl_synth_pop.constants import data_keys, data_values, metadata
 from vivarium_census_prl_synth_pop.utilities import (
     filter_by_rate,
     update_address_id_for_unit_and_sims,
@@ -61,6 +61,7 @@ class Businesses:
         ]
         self.columns_used = [
             "address_id",
+            "previous_timestep_address_id",
             "age",
             "household_id",
         ] + self.columns_created
@@ -82,8 +83,12 @@ class Businesses:
             requires_columns=["age"],
             creates_columns=self.columns_created,
         )
-        # note: priority must be later than that of persons.on_time_step
-        builder.event.register_listener("time_step", self.on_time_step, priority=6)
+        # note: priority must be later than that of migration components
+        builder.event.register_listener(
+            "time_step",
+            self.on_time_step,
+            priority=metadata.PRIORITY_MAP["businesses.on_time_step"],
+        )
 
     ########################
     # Event-driven methods #
@@ -140,9 +145,7 @@ class Businesses:
         change jobs at rate of 50 changes / 100 person-years
         businesses change addresses at rate of 10 changes / 100 person-years
         """
-        pop = self.population_view.subview(
-            self.columns_created + ["age", "household_id"]
-        ).get(event.index)
+        pop = self.population_view.get(event.index)
 
         all_businesses = self.businesses.loc[
             self.businesses["employer_id"] != data_values.UNEMPLOYED_ID, "employer_id"
@@ -168,11 +171,14 @@ class Businesses:
             address_id_col_name="employer_address_id",
         )
 
-        # change jobs if of working age already
+        # change jobs if of working age already and either selected by rate or moved
+        # on this timestep
         working_age_idx = pop.loc[pop["age"] >= data_values.WORKING_AGE].index
         changing_jobs_idx = filter_by_rate(
             working_age_idx, self.randomness, self.job_change_rate, "changing jobs"
         )
+        moved_idx = pop.index[pop["address_id"] != pop["previous_timestep_address_id"]]
+        changing_jobs_idx = changing_jobs_idx.union(moved_idx.intersection(working_age_idx))
         if len(changing_jobs_idx) > 0:
             pop.loc[changing_jobs_idx, "employer_id"] = self.assign_different_employer(
                 changing_jobs_idx

--- a/src/vivarium_census_prl_synth_pop/components/businesses.py
+++ b/src/vivarium_census_prl_synth_pop/components/businesses.py
@@ -178,7 +178,8 @@ class Businesses:
             working_age_idx, self.randomness, self.job_change_rate, "changing jobs"
         )
         moved_idx = pop.index[pop["address_id"] != pop["previous_timestep_address_id"]]
-        changing_jobs_idx = changing_jobs_idx.union(moved_idx.intersection(working_age_idx))
+        moved_working_age_idx = moved_idx.intersection(working_age_idx)
+        changing_jobs_idx = changing_jobs_idx.union(moved_working_age_idx)
         if len(changing_jobs_idx) > 0:
             pop.loc[changing_jobs_idx, "employer_id"] = self.assign_different_employer(
                 changing_jobs_idx

--- a/src/vivarium_census_prl_synth_pop/components/household.py
+++ b/src/vivarium_census_prl_synth_pop/components/household.py
@@ -7,7 +7,12 @@ from vivarium.framework.randomness import RESIDUAL_CHOICE
 from vivarium.framework.time import get_time_stamp
 from vivarium.framework.utilities import from_yearly
 
-from vivarium_census_prl_synth_pop.constants import data_keys, data_values, paths
+from vivarium_census_prl_synth_pop.constants import (
+    data_keys,
+    data_values,
+    metadata,
+    paths,
+)
 from vivarium_census_prl_synth_pop.utilities import (
     filter_by_rate,
     update_address_id_for_unit_and_sims,
@@ -70,7 +75,11 @@ class HouseholdMigration:
             requires_columns=["household_id"],
             creates_columns=self.columns_created,
         )
-        builder.event.register_listener("time_step", self.on_time_step)
+        builder.event.register_listener(
+            "time_step",
+            self.on_time_step,
+            priority=metadata.PRIORITY_MAP["household.on_time_step"],
+        )
 
     ########################
     # Event-driven methods #

--- a/src/vivarium_census_prl_synth_pop/constants/metadata.py
+++ b/src/vivarium_census_prl_synth_pop/constants/metadata.py
@@ -241,3 +241,12 @@ class __Scenarios(NamedTuple):
 
 
 SCENARIOS = __Scenarios()
+
+PRIORITY_MAP = {
+    # 5 is the default, but we are explicit here to show ordering.
+    # Businesses must come after migration
+    # components, so that migration can trigger employment change.
+    "person.on_time_step": 5,
+    "household.on_time_step": 5,
+    "businesses.on_time_step": 6,
+}


### PR DESCRIPTION
## Trigger employment change on migration

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: implementation
- *JIRA issue*: [MIC-3677](https://jira.ihme.washington.edu/browse/MIC-3677)
- *Research reference*: https://vivarium-research.readthedocs.io/en/latest/models/concept_models/vivarium_census_synthdata/concept_model.html#simulation-strategy

### Changes and notes

### Verification and Testing

Automated integration tests, also stepped through to check reasonable numbers of movers are changing employment.