### PR TITLE
Save all populations for integration tests

### DIFF
--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import List
 
 import pandas as pd
 import pytest
@@ -20,14 +20,17 @@ TIME_STEPS_TO_TEST = [0, 1, 10]
 
 
 @pytest.fixture(scope="session")
-def tracked_live_populations(sim) -> Dict[int, pd.DataFrame]:
-    previous_step_number = 0
-    population_states = {}
-    for step in TIME_STEPS_TO_TEST:
-        sim.take_steps(step - previous_step_number)
-
+def populations(sim) -> List[pd.DataFrame]:
+    population_states = []
+    for _ in range(max(TIME_STEPS_TO_TEST) + 1):
         pop = sim.get_population()
-        population_states[step] = pop[pop["alive"] == "alive"]
+        population_states.append(pop)
 
-        previous_step_number = step
+        sim.step()
+
     return population_states
+
+
+@pytest.fixture(scope="session")
+def tracked_live_populations(populations) -> List[pd.DataFrame]:
+    return [pop[pop["alive"] == "alive"] for pop in populations]

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -23,7 +23,7 @@ TIME_STEPS_TO_TEST = [0, 1, 10]
 def populations(sim) -> List[pd.DataFrame]:
     population_states = []
     for _ in range(max(TIME_STEPS_TO_TEST) + 1):
-        pop = sim.get_population()
+        pop = sim.get_population(untracked=True)
         population_states.append(pop)
 
         sim.step()
@@ -32,5 +32,10 @@ def populations(sim) -> List[pd.DataFrame]:
 
 
 @pytest.fixture(scope="session")
-def tracked_live_populations(populations) -> List[pd.DataFrame]:
-    return [pop[pop["alive"] == "alive"] for pop in populations]
+def tracked_populations(populations) -> List[pd.DataFrame]:
+    return [pop[pop["tracked"]] for pop in populations]
+
+
+@pytest.fixture(scope="session")
+def tracked_live_populations(tracked_populations) -> List[pd.DataFrame]:
+    return [pop[pop["alive"] == "alive"] for pop in tracked_populations]


### PR DESCRIPTION
## Save all populations for integration tests

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: chore
- *JIRA issue*: none
- *Research reference*: none

### Changes and notes

I think pretty much all tests having to do with migration are going to need to compare consecutive populations, which isn't well served by saving only a few populations.

### Verification and Testing

Ran existing tests, ran simulation to completion.