### PR TITLE
update ci, codeowners, readme

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # default owners
-* @albrja @collijk @hussain-jafari @mattkappel @ramittal @rmudambi @stevebachmeier
+* @albrja @collijk @hussain-jafari @mattkappel @ramittal @rmudambi @stevebachmeier @zmbc

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 # -----------------------------------------------------------------------------
 #   - invoked on push, pull_request, or manual trigger
-#   - test under 2 versions of python
+#   - test under at least 3 versions of python
 # -----------------------------------------------------------------------------
 name: build
 on: [push, pull_request, workflow_dispatch]
@@ -15,9 +15,9 @@ jobs:
       run:
         shell: bash -le {0}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: check for upstream vivarium

--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ Once you have all three installed, you should open up your normal shell
 You'll then make an environment, clone this repository, then install
 all necessary requirements as follows::
 
-  :~$ conda create --name=vivarium_census_prl_synth_pop python=3.8
+  :~$ conda create --name=vivarium_census_prl_synth_pop python=3.10
   ...conda will download python and base dependencies...
   :~$ conda activate vivarium_census_prl_synth_pop
   (vivarium_census_prl_synth_pop) :~$ git clone https://github.com/ihmeuw/vivarium_census_prl_synth_pop.git

--- a/setup.py
+++ b/setup.py
@@ -16,10 +16,10 @@ if __name__ == "__main__":
         long_description = f.read()
 
     install_requirements = [
-        "vivarium==0.10.19",
-        "vivarium_public_health==0.10.21",
+        "vivarium==1.0.2",
+        "vivarium_public_health==0.10.22",
         "click",
-        "gbd_mapping>=3.0.5, <4.0.0",
+        "gbd_mapping>=3.0.6, <4.0.0",
         "jinja2",
         "loguru",
         "numpy",
@@ -32,8 +32,8 @@ if __name__ == "__main__":
 
     # use "pip install -e .[dev]" to install required components + extra components
     data_requires = [
-        "vivarium_cluster_tools>=1.3.7",
-        "vivarium_inputs[data]==4.0.9",
+        "vivarium_cluster_tools>=1.3.8",
+        "vivarium_inputs[data]==4.0.10",
     ]
     test_requirements = [
         "pytest",


### PR DESCRIPTION
## Update CI

### Description
- *Category*: other
- *JIRA issue*: [MIC-3690](https://jira.ihme.washington.edu/browse/MIC-3690)

This addresses a few issues with the github actions:
* Updates the python builds 3.7-3.10 (remove 3.6 and add 3.9-10)
* Update actions to stop future warnings (The `set-output` command
    is deprecated and will be disabled soon. Please upgrade to using
    Environment Files. For more information see: 
    https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
* Update CODEOWNERS
* Update README install 3.10
* Update the setup pins to newest releases

### Testing
All tests passed and warnings are gone

