### PR TITLE
fix gq proportion test to work on small populations

### DIFF
--- a/integration_tests/test_group_quarters.py
+++ b/integration_tests/test_group_quarters.py
@@ -7,13 +7,16 @@ from vivarium_census_prl_synth_pop.constants import data_values
 # TODO: Broader test coverage
 
 
-def test_gq_proportion(tracked_live_populations):
+def test_gq_proportion(sim, tracked_live_populations):
+    pop_size = sim.configuration.population.population_size
     pop = tracked_live_populations[0]
+    expected_gq_population = pop_size * data_values.PROP_POPULATION_IN_GQ
+    min_gq_population = expected_gq_population - (data_values.MAX_HOUSEHOLD_SIZE - 1)
+    max_gq_population = expected_gq_population + (data_values.MAX_HOUSEHOLD_SIZE - 1)
+    actual_gq_population = pop["household_id"].isin(data_values.GQ_HOUSING_TYPE_MAP).sum()
+
     # GQ proportion matches expectation
-    assert np.isclose(
-        pop["household_id"].isin(data_values.GQ_HOUSING_TYPE_MAP).mean(),
-        data_values.PROP_POPULATION_IN_GQ,
-    )
+    assert min_gq_population <= actual_gq_population <= max_gq_population
 
 
 @pytest.mark.parametrize("time_step", TIME_STEPS_TO_TEST)

--- a/src/vivarium_census_prl_synth_pop/constants/data_values.py
+++ b/src/vivarium_census_prl_synth_pop/constants/data_values.py
@@ -7,6 +7,7 @@ from typing import NamedTuple
 # TODO: implement gbd call (vivarium_inputs.get_population_structure("United States"))
 US_POPULATION = 333339776
 
+MAX_HOUSEHOLD_SIZE = 17
 PROP_POPULATION_IN_GQ = 0.03
 PROBABILITY_OF_TWINS = 0.04
 N_GROUP_QUARTER_TYPES = 6


### PR DESCRIPTION
## Fix GQ proportion test
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: test
- *JIRA issue*: N/A
- *Research reference*: N/A

### Changes and notes
As previously written the test fails on populations with size 2_000. Tests are generally run with at least size 20_000, but this is more in line with what the documentation actually says the reality should be.

### Verification and Testing
Tested integration tests with both 2_000 and 20_000 simulants.
