### PR TITLE
Test initialization for nationwide states/pumas

### DIFF
--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -11,7 +11,7 @@ from vivarium_census_prl_synth_pop.constants import paths
 def sim() -> InteractiveContext:
     """Initialize a simulation for use in tests"""
     simulation = InteractiveContext(paths.MODEL_SPEC_DIR / "model_spec.yaml", setup=False)
-    simulation.configuration.population.population_size = 20_000
+    simulation.configuration.population.population_size = 200_000
     simulation.setup()
     return simulation
 

--- a/integration_tests/test_household_structure.py
+++ b/integration_tests/test_household_structure.py
@@ -54,3 +54,21 @@ def test_household_id_and_address_id_correspond(tracked_live_populations):
     assert (all_time_pop.groupby("address_id")["household_id"].nunique() == 1).all()
     # Note, however, that the reverse is not true: a household_id can span multiple address_ids
     # (over multiple time steps) when the whole house moved as a unit between those time steps.
+
+
+def test_initialized_state_complete_coverage(populations, sim):
+    """Initialized states should include all locations from artifact"""
+    initialized_pop = populations[0]
+    states_in_artifact = set(
+        sim._data.artifact.load("population.households").index.unique(level="state")
+    )
+    assert states_in_artifact == set(initialized_pop["state"])
+
+
+def test_initialized_pumas_states(populations):
+    """Each unique non-GQ initialized address_id should have identical puma/state"""
+    initialized_pop = populations[0]
+    non_gq_pop = initialized_pop[
+        ~initialized_pop["household_id"].isin(data_values.GQ_HOUSING_TYPE_MAP)
+    ]
+    assert (non_gq_pop.groupby("address_id")["state", "puma"].nunique() == 1).values.all()

--- a/src/vivarium_census_prl_synth_pop/model_specifications/model_spec.yaml
+++ b/src/vivarium_census_prl_synth_pop/model_specifications/model_spec.yaml
@@ -16,7 +16,7 @@ components:
 
 configuration:
     input_data:
-        artifact_path: '/mnt/team/simulation_science/priv/engineering/vivarium_census_prl_synth_pop/data/artifacts/florida.hdf'
+        artifact_path: '/mnt/team/simulation_science/priv/engineering/vivarium_census_prl_synth_pop/data/artifacts/united_states_of_america.hdf'
         input_draw_number: 0
     output_data:
         results_directory: '/mnt/team/simulation_science/priv/engineering/vivarium_census_prl_synth_pop/results/'
@@ -38,4 +38,4 @@ configuration:
             day: 1
         step_size: 28 # Days
     population:
-        population_size: 2_000
+        population_size: 200_000


### PR DESCRIPTION
## Title: Initialize nationwide addresses

### Description
- *Category*: test
- *JIRA issue*: [MIC-3727](https://jira.ihme.washington.edu/browse/MIC-3727)
- *Research reference*: n/a

### Changes and notes
Since we have chosen to implement a single artifact for all population data,
the only thing needed to ensure states/pumas are being properly initialized
is to add a couple of integration tests.
* check that upon initialization, all states from the artifact exist in the state column
* check that upon initialization, each non-qg address_id is tied to a unique state/puma

### Verification and Testing
Tests are passing
