### PR TITLE
Fix data type for survey_date

### DIFF
--- a/src/vivarium_census_prl_synth_pop/components/observers.py
+++ b/src/vivarium_census_prl_synth_pop/components/observers.py
@@ -231,7 +231,7 @@ class HouseholdSurveyObserver(BaseObserver):
         new_responses = new_responses[
             new_responses["household_id"].isin(respondent_households)
         ]
-        new_responses["survey_date"] = event.time.date()
+        new_responses["survey_date"] = event.time.floor("D")
         new_responses = utilities.add_guardian_address_ids(new_responses)
         # Apply column schema and concatenate
         return new_responses[self.output_columns]

--- a/src/vivarium_census_prl_synth_pop/components/observers.py
+++ b/src/vivarium_census_prl_synth_pop/components/observers.py
@@ -231,7 +231,8 @@ class HouseholdSurveyObserver(BaseObserver):
         new_responses = new_responses[
             new_responses["household_id"].isin(respondent_households)
         ]
-        new_responses["survey_date"] = event.time.floor("D")
+        # Must be a timestamp, not an actual `date` type, in order to save to HDF in table mode
+        new_responses["survey_date"] = pd.Timestamp(event.time.date())
         new_responses = utilities.add_guardian_address_ids(new_responses)
         # Apply column schema and concatenate
         return new_responses[self.output_columns]

--- a/tests/components/observers/test_household_survey_observers.py
+++ b/tests/components/observers/test_household_survey_observers.py
@@ -62,7 +62,7 @@ def test_do_observation(observer, mocked_pop_view, mocker):
     expected = mocked_pop_view
     expected["middle_initial"] = ["J", "M"]
     expected[["guardian_1_address_id", "guardian_2_address_id"]] = np.nan
-    expected["survey_date"] = [pd.to_datetime(sim_start_date).date()] * 2
+    expected["survey_date"] = [pd.to_datetime(sim_start_date).floor("D")] * 2
 
     pd.testing.assert_frame_equal(expected[observer.output_columns], observation)
 
@@ -87,8 +87,8 @@ def test_multiple_observation(observer, mocked_pop_view, mocker):
     expected = pd.concat([mocked_pop_view] * 2)
     expected["middle_initial"] = ["J", "M"] * 2
     expected[["guardian_1_address_id", "guardian_2_address_id"]] = np.nan
-    expected["survey_date"] = [pd.to_datetime(sim_start_date).date()] * 2 + [
-        event.time.date()
+    expected["survey_date"] = [pd.to_datetime(sim_start_date).floor("D")] * 2 + [
+        event.time.floor("D")
     ] * 2
 
     pd.testing.assert_frame_equal(expected[observer.output_columns], observer.responses)

--- a/tests/components/observers/test_household_survey_observers.py
+++ b/tests/components/observers/test_household_survey_observers.py
@@ -62,7 +62,7 @@ def test_do_observation(observer, mocked_pop_view, mocker):
     expected = mocked_pop_view
     expected["middle_initial"] = ["J", "M"]
     expected[["guardian_1_address_id", "guardian_2_address_id"]] = np.nan
-    expected["survey_date"] = [pd.to_datetime(sim_start_date).floor("D")] * 2
+    expected["survey_date"] = [pd.to_datetime(sim_start_date)] * 2
 
     pd.testing.assert_frame_equal(expected[observer.output_columns], observation)
 
@@ -87,8 +87,6 @@ def test_multiple_observation(observer, mocked_pop_view, mocker):
     expected = pd.concat([mocked_pop_view] * 2)
     expected["middle_initial"] = ["J", "M"] * 2
     expected[["guardian_1_address_id", "guardian_2_address_id"]] = np.nan
-    expected["survey_date"] = [pd.to_datetime(sim_start_date).floor("D")] * 2 + [
-        event.time.floor("D")
-    ] * 2
+    expected["survey_date"] = [pd.to_datetime(sim_start_date)] * 2 + [event.time] * 2
 
     pd.testing.assert_frame_equal(expected[observer.output_columns], observer.responses)


### PR DESCRIPTION
## Fix data type for survey_date

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: bugfix
- *JIRA issue*: none
- *Research reference*: none

### Changes and notes

We store dates/times in our population table and in our observers as datetimes. The one exception was survey_date, and this was causing an error trying to save to tabular HDF.

### Verification and Testing

The simulation did not run to completion before with a 20k population (larger population was necessary to have anyone returned by the survey observers). Now it does.