### PR TITLE
Feature/households missing reference person

### DIFF
--- a/src/vivarium_census_prl_synth_pop/components/population.py
+++ b/src/vivarium_census_prl_synth_pop/components/population.py
@@ -73,7 +73,7 @@ class Population:
             self.initialize_simulants, creates_columns=self.columns_created
         )
 
-        builder.event.register_listener("time_step__cleanup", self.on_time_step__prepare)
+        builder.event.register_listener("time_step__cleanup", self.on_time_step__cleanup)
 
     def _load_population_data(self, builder: Builder):
         households = builder.data.load(data_keys.POPULATION.HOUSEHOLDS)
@@ -335,8 +335,8 @@ class Population:
 
         self.population_view.update(new_births[self.columns_created])
 
-    def on_time_step__prepare(self, event: Event):
-        """Ages simulants each time step.
+    def on_time_step__cleanup(self, event: Event):
+        """Ages simulants each time step and updates household structure when a reference person moves or dies.
 
         Parameters
         ----------
@@ -347,6 +347,16 @@ class Population:
             event.index, query="alive == 'alive'"
         )
         population["age"] += to_years(event.step_size)
+
+        # Find standard households that do not have a reference person
+        household_ids_with_reference_person = population.loc[
+            population["relation_to_household_head"] == "Reference person", "household_id"
+        ]
+        standard_household_ids = population.loc[
+            population["housing_type"] == "Standard", "household_id"
+        ].unique()
+        household_ids_without_reference_person = set(standard_household_ids) - set(household_ids_with_reference_person)
+
         self.population_view.update(population)
 
     def assign_general_population_guardians(self, pop: pd.DataFrame) -> pd.DataFrame:

--- a/src/vivarium_census_prl_synth_pop/components/population.py
+++ b/src/vivarium_census_prl_synth_pop/components/population.py
@@ -343,9 +343,7 @@ class Population:
         event : vivarium.framework.event.Event
 
         """
-        population = self.population_view.subview(["age"]).get(
-            event.index, query="alive == 'alive'"
-        )
+        population = self.population_view.get(event.index, query="alive == 'alive'")
         population["age"] += to_years(event.step_size)
 
         # Find standard households that do not have a reference person
@@ -355,7 +353,9 @@ class Population:
         standard_household_ids = population.loc[
             population["housing_type"] == "Standard", "household_id"
         ].unique()
-        household_ids_without_reference_person = set(standard_household_ids) - set(household_ids_with_reference_person)
+        household_ids_without_reference_person = set(standard_household_ids) - set(
+            household_ids_with_reference_person
+        )
 
         self.population_view.update(population)
 


### PR DESCRIPTION
## Determine households without a reference person

### Gets list of households that do not have a reference person after time step.
- *Category*: Other
- *JIRA issue*: [MIC-3751](https://jira.ihme.washington.edu/browse/MIC-3751)
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
-Changes name for on_time_step__cleanup function to match event listener.
-Finds households after on_time_step that do not have a reference person living in them.
-This have no implementation change.  It is setup for a coming feature and no tests are needed for this.

### Verification and Testing
Successfully ran simulation.

