### PR TITLE
Assigns new reference persons and adds test

### DIFF
--- a/integration_tests/test_household_structure.py
+++ b/integration_tests/test_household_structure.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
-import pytest
 
+from integration_tests.conftest import TIME_STEPS_TO_TEST
 from vivarium_census_prl_synth_pop.constants import data_values, metadata
 
 # TODO: Broader test coverage
@@ -25,8 +25,6 @@ def test_relationship_is_categorical(tracked_live_populations):
         assert not relationship.isnull().any()
 
 
-# TODO stop skipping once MIC-3527 and MIC-3714 have been implemented
-@pytest.mark.skip
 def test_all_households_have_reference_person(tracked_live_populations):
     for pop in tracked_live_populations:
         non_gq_household_ids = pop[
@@ -54,3 +52,53 @@ def test_household_id_and_address_id_correspond(tracked_live_populations):
     assert (all_time_pop.groupby("address_id")["household_id"].nunique() == 1).all()
     # Note, however, that the reverse is not true: a household_id can span multiple address_ids
     # (over multiple time steps) when the whole house moved as a unit between those time steps.
+
+
+def test_new_reference_person_is_oldest_household_member(tracked_live_populations):
+    for time_step in range(max(TIME_STEPS_TO_TEST)):
+        before_reference_person_idx = (
+            tracked_live_populations[time_step]
+            .loc[
+                tracked_live_populations[time_step]["relation_to_household_head"]
+                == "Reference person"
+            ]
+            .index
+        )
+        after_reference_person_idx = (
+            tracked_live_populations[time_step + 1]
+            .loc[
+                tracked_live_populations[time_step + 1]["relation_to_household_head"]
+                == "Reference person"
+            ]
+            .index
+        )
+        new_reference_person_idx = np.setdiff1d(
+            after_reference_person_idx, before_reference_person_idx
+        )
+
+        # Get households with new reference persons
+        household_ids_with_new_reference_person = tracked_live_populations[time_step + 1].loc[
+            new_reference_person_idx, "household_id"
+        ]
+        assert len(household_ids_with_new_reference_person) == len(
+            household_ids_with_new_reference_person.unique()
+        )
+
+        households_with_new_reference_person_idx = (
+            tracked_live_populations[time_step + 1]
+            .loc[
+                tracked_live_populations[time_step + 1]["household_id"].isin(
+                    household_ids_with_new_reference_person
+                )
+            ]
+            .index
+        )
+        oldest_members_of_affected_households = (
+            tracked_live_populations[time_step + 1]
+            .loc[households_with_new_reference_person_idx]
+            .groupby(["household_id"])["age"]
+            .idxmax()
+            .values
+        )
+
+        assert new_reference_person_idx.sort() == oldest_members_of_affected_households.sort()

--- a/src/vivarium_census_prl_synth_pop/components/population.py
+++ b/src/vivarium_census_prl_synth_pop/components/population.py
@@ -356,6 +356,18 @@ class Population:
         household_ids_without_reference_person = set(standard_household_ids) - set(
             household_ids_with_reference_person
         )
+        households_to_update_idx = population.index[
+            population["household_id"].isin(household_ids_without_reference_person)
+        ]
+
+        # Find oldest member in each household and make them new reference person
+        # This is a series with household_id as the index and the new reference person as the value
+        new_reference_persons = (
+            population.loc[households_to_update_idx].groupby(["household_id"])["age"].idxmax()
+        )
+        population.loc[
+            new_reference_persons, "relation_to_household_head"
+        ] = "Reference person"
 
         self.population_view.update(population)
 


### PR DESCRIPTION
## Assign new reference person in households.

### When a household loses a reference person on time step, assign the oldest living member of that household as the new reference person.
- *Category*: Feature
- *JIRA issue*: [MIC-3753](https://jira.ihme.washington.edu/browse/MIC-3753)
- *Research reference*: https://vivarium-research.readthedocs.io/en/latest/models/concept_models/vivarium_census_synthdata/concept_model.html#component-7-mortality

### Changes and notes
-Assigns oldest member of households without a reference person as the new reference person for that household.
-Adds a test that the oldest member is assigned as the reference person and now utilizes an existing test that was previously skipped that verifies every standard household has a reference person.
-Note: This is assigning a new reference person for these selected households but does not update the relation_to_household_head for other members yet.  

### Verification and Testing
Successfully ran simulation and new reference persons were properly updated.

