### PR TITLE
Add tax observer for W2 forms

### DIFF
--- a/src/vivarium_census_prl_synth_pop/components/__init__.py
+++ b/src/vivarium_census_prl_synth_pop/components/__init__.py
@@ -7,6 +7,7 @@ from vivarium_census_prl_synth_pop.components.observers import (
     HouseholdSurveyObserver,
     SocialSecurityObserver,
     WICObserver,
+    TaxW2Observer,
 )
 from vivarium_census_prl_synth_pop.components.person import PersonMigration
 from vivarium_census_prl_synth_pop.components.population import Population

--- a/src/vivarium_census_prl_synth_pop/components/__init__.py
+++ b/src/vivarium_census_prl_synth_pop/components/__init__.py
@@ -6,8 +6,8 @@ from vivarium_census_prl_synth_pop.components.observers import (
     DecennialCensusObserver,
     HouseholdSurveyObserver,
     SocialSecurityObserver,
-    WICObserver,
     TaxW2Observer,
+    WICObserver,
 )
 from vivarium_census_prl_synth_pop.components.person import PersonMigration
 from vivarium_census_prl_synth_pop.components.population import Population

--- a/src/vivarium_census_prl_synth_pop/components/observers.py
+++ b/src/vivarium_census_prl_synth_pop/components/observers.py
@@ -487,7 +487,6 @@ def empty_income_series():
     )
 
 
-empty_income_series()
 
 
 class TaxW2Observer(BaseObserver):

--- a/src/vivarium_census_prl_synth_pop/components/observers.py
+++ b/src/vivarium_census_prl_synth_pop/components/observers.py
@@ -61,11 +61,6 @@ class BaseObserver(ABC):
 
     @property
     @abstractmethod
-    def output_filename(self):
-        pass
-
-    @property
-    @abstractmethod
     def input_columns(self):
         pass
 
@@ -147,7 +142,7 @@ class BaseObserver(ABC):
     def on_simulation_end(self, event: Event) -> None:
         output_dir = utilities.build_output_dir(self.output_dir, subdir="results")
         # 'fixed' format is not compatible with categorical data
-        self.responses.to_csv(output_dir / self.output_filename)
+        self.responses.to_csv(output_dir / (self.name+'.csv.bz2'))
 
 
 class HouseholdSurveyObserver(BaseObserver):
@@ -184,10 +179,6 @@ class HouseholdSurveyObserver(BaseObserver):
     @property
     def name(self):
         return f"household_survey_observer.{self.survey}"
-
-    @property
-    def output_filename(self):
-        return f"{self.survey}.csv.bz2"
 
     @property
     def input_columns(self):
@@ -259,10 +250,6 @@ class DecennialCensusObserver(BaseObserver):
         return f"decennial_census_observer"
 
     @property
-    def output_filename(self):
-        return f"decennial_census.csv.bz2"
-
-    @property
     def input_columns(self):
         return self.DEFAULT_INPUT_COLUMNS + self.ADDITIONAL_INPUT_COLUMNS
 
@@ -306,10 +293,6 @@ class WICObserver(BaseObserver):
     @property
     def name(self):
         return f"wic_observer"
-
-    @property
-    def output_filename(self):
-        return f"wic.csv.bz2"
 
     @property
     def input_columns(self):
@@ -450,10 +433,6 @@ class SocialSecurityObserver(BaseObserver):
         return f"social_security_observer"
 
     @property
-    def output_filename(self):
-        return f"social_security.csv.bz2"
-
-    @property
     def input_columns(self):
         return self.DEFAULT_INPUT_COLUMNS + self.ADDITIONAL_INPUT_COLUMNS
 
@@ -539,10 +518,6 @@ class TaxW2Observer(BaseObserver):
     @property
     def name(self):
         return f"tax_w2_observer"
-
-    @property
-    def output_filename(self):
-        return f"tax_w2.csv.bz2"
 
     @property
     def input_columns(self):

--- a/src/vivarium_census_prl_synth_pop/components/observers.py
+++ b/src/vivarium_census_prl_synth_pop/components/observers.py
@@ -515,6 +515,7 @@ class TaxW2Observer(BaseObserver):
         "dependent_id_list",
         "dependent_address_id_list",
         "housing_type",
+        "tax_year",
     ]
 
     def __repr__(self):
@@ -589,6 +590,7 @@ class TaxW2Observer(BaseObserver):
         # with the pd.Series, but it is getting lost at some point in the computation
 
         df_w2 = self.income_to_date.reset_index()
+        df_w2["tax_year"] = event.time.year
 
         # merge in simulant columns based on simulant id
         for col in [

--- a/src/vivarium_census_prl_synth_pop/model_specifications/model_spec.yaml
+++ b/src/vivarium_census_prl_synth_pop/model_specifications/model_spec.yaml
@@ -13,6 +13,7 @@ components:
             - HouseholdSurveyObserver("cps")
             - WICObserver()
             - SocialSecurityObserver()
+            - TaxW2Observer()
 
 configuration:
     input_data:

--- a/tests/components/observers/test_household_survey_observers.py
+++ b/tests/components/observers/test_household_survey_observers.py
@@ -42,7 +42,7 @@ def test_on_simulation_end(observer, mocker):
     event = mocker.MagicMock()
     observer.responses = pd.DataFrame()
     observer.on_simulation_end(event)
-    assert (observer.output_dir / "results" / (observer.name + ".csv.bz2")).is_file()
+    assert (observer.output_dir / "results" / (f"{observer.name}.csv.bz2")).is_file()
 
 
 def test_do_observation(observer, mocked_pop_view, mocker):

--- a/tests/components/observers/test_household_survey_observers.py
+++ b/tests/components/observers/test_household_survey_observers.py
@@ -42,7 +42,7 @@ def test_on_simulation_end(observer, mocker):
     event = mocker.MagicMock()
     observer.responses = pd.DataFrame()
     observer.on_simulation_end(event)
-    assert (observer.output_dir / "results" / observer.output_filename).is_file()
+    assert (observer.output_dir / "results" / (observer.name + '.csv.bz2')).is_file()
 
 
 def test_do_observation(observer, mocked_pop_view, mocker):

--- a/tests/components/observers/test_household_survey_observers.py
+++ b/tests/components/observers/test_household_survey_observers.py
@@ -42,7 +42,7 @@ def test_on_simulation_end(observer, mocker):
     event = mocker.MagicMock()
     observer.responses = pd.DataFrame()
     observer.on_simulation_end(event)
-    assert (observer.output_dir / "results" / (observer.name + '.csv.bz2')).is_file()
+    assert (observer.output_dir / "results" / (observer.name + ".csv.bz2")).is_file()
 
 
 def test_do_observation(observer, mocked_pop_view, mocker):


### PR DESCRIPTION
## Title: Add tax observer for W2 forms
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: observers<!-- one of bugfix, data artifact, implementation, observers,
                   post-processing, refactor, revert, test, release, other/misc -->
- *JIRA issue*: [MIC-3762](https://jira.ihme.washington.edu/browse/MIC-3762)
- *Research reference*: https://vivarium-research.readthedocs.io/en/latest/models/concept_models/vivarium_census_synthdata/concept_model.html#w2-and-1099-forms

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
changed output from .hdf to .csv.bz2 after finding this is substantially smaller *and* better supports some of the columns in the W2 output

### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->
tests pass, model_spec.yaml runs with `simulate run`