### PR TITLE
implement domestic move state/puma

### DIFF
--- a/integration_tests/test_domestic_migration.py
+++ b/integration_tests/test_domestic_migration.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 import pandas as pd
 
 from vivarium_census_prl_synth_pop.constants import data_values
@@ -61,8 +59,6 @@ def test_individuals_move_into_new_households(simulants_on_adjacent_timesteps):
         new_addresses = after[new_household_movers]["address_id"]
         assert new_addresses.nunique() == len(new_addresses)
         assert not new_addresses.isin(before["address_id"]).any()
-
-        # TODO: Add state/puma tests
 
 
 def test_individuals_move_into_group_quarters(simulants_on_adjacent_timesteps):

--- a/integration_tests/test_household_structure.py
+++ b/integration_tests/test_household_structure.py
@@ -71,4 +71,4 @@ def test_initialized_pumas_states(populations):
     non_gq_pop = initialized_pop[
         ~initialized_pop["household_id"].isin(data_values.GQ_HOUSING_TYPE_MAP)
     ]
-    assert (non_gq_pop.groupby("address_id")["state", "puma"].nunique() == 1).values.all()
+    assert (non_gq_pop.groupby("address_id")[["state", "puma"]].nunique() == 1).values.all()

--- a/src/vivarium_census_prl_synth_pop/components/businesses.py
+++ b/src/vivarium_census_prl_synth_pop/components/businesses.py
@@ -182,9 +182,9 @@ class Businesses:
             event.index,
             query="alive == 'alive'",
         )
-        all_businesses = self.businesses.loc[
+        all_businesses = self.businesses.index[
             self.businesses.index != data_values.UNEMPLOYED_ID
-        ].index
+        ]
         businesses_that_move_idx = filter_by_rate(
             all_businesses,
             self.randomness,
@@ -359,10 +359,10 @@ class Businesses:
         employer_ids = pop.loc[rows_to_update, "employer_id"]
 
         pop.loc[rows_to_update, "employer_address_id"] = employer_ids.map(
-            self.businesses["employer_address_id"].to_dict()
+            self.businesses["employer_address_id"]
         )
         pop.loc[rows_to_update, "employer_name"] = employer_ids.map(
-            self.businesses["employer_name"].to_dict()
+            self.businesses["employer_name"]
         )
 
         return pop

--- a/src/vivarium_census_prl_synth_pop/components/household.py
+++ b/src/vivarium_census_prl_synth_pop/components/household.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 import numpy as np
 import pandas as pd
 from vivarium.framework.engine import Builder

--- a/src/vivarium_census_prl_synth_pop/components/person.py
+++ b/src/vivarium_census_prl_synth_pop/components/person.py
@@ -1,5 +1,3 @@
-from typing import Dict, Union
-
 import numpy as np
 import pandas as pd
 from loguru import logger

--- a/src/vivarium_census_prl_synth_pop/components/population.py
+++ b/src/vivarium_census_prl_synth_pop/components/population.py
@@ -118,13 +118,15 @@ class Population:
         pop["housing_type"] = pop["housing_type"].astype(
             pd.CategoricalDtype(categories=data_values.HOUSING_TYPES)
         )
+        # set int dtypes to float64 to play nicely with population_view checks
+        for col in ["age", "state", "puma"]:
+            pop[col] = pop[col].astype("float64")
 
         # give name ids
         pop["first_name_id"] = pop.index
         pop["middle_name_id"] = pop.index
         pop["last_name_id"] = self.assign_last_name_ids(pop)
 
-        pop["age"] = pop["age"].astype("float64")
         # Shift age so all households do not have the same birthday
         pop["age"] = pop["age"] + self.randomness.get_draw(pop.index, "age")
         pop["date_of_birth"] = self.start_time - pd.to_timedelta(
@@ -148,7 +150,6 @@ class Population:
         pop["exit_time"] = pd.NaT
         pop["alive"] = "alive"
         # add typing
-        pop["state"] = pop["state"].astype("int64")
         pop = pop.set_index(pop_data.index)
 
         pop = self.assign_general_population_guardians(pop)

--- a/src/vivarium_census_prl_synth_pop/utilities.py
+++ b/src/vivarium_census_prl_synth_pop/utilities.py
@@ -371,7 +371,7 @@ def update_addresses(
         # Preserve pop index
         pop = pop.reset_index().rename(columns={"index": "simulant_id"})
 
-        units, starting_address_id = _update_address_id_state_puma(
+        units, updated_starting_address_id = _update_address_id_state_puma(
             df=units,
             movers_idx=movers_idx,
             starting_address_id=starting_address_id,
@@ -400,7 +400,7 @@ def update_addresses(
 
     # Move individuals
     elif (units is None) and (len(movers_idx) > 0):
-        pop, starting_address_id = _update_address_id_state_puma(
+        pop, updated_starting_address_id = _update_address_id_state_puma(
             df=pop,
             movers_idx=movers_idx,
             starting_address_id=starting_address_id,
@@ -410,8 +410,10 @@ def update_addresses(
             puma_col_name=puma_col_name,
             randomness=randomness,
         )
+    else:
+        updated_starting_address_id = starting_address_id
 
-    return pop, units, starting_address_id
+    return pop, units, updated_starting_address_id
 
 
 def _update_address_id_state_puma(

--- a/src/vivarium_census_prl_synth_pop/utilities.py
+++ b/src/vivarium_census_prl_synth_pop/utilities.py
@@ -1,17 +1,15 @@
 import os
 from pathlib import Path
-from typing import Any, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import click
 import numpy as np
 import pandas as pd
 from loguru import logger
 from scipy import stats
-from vivarium.framework.engine import Builder
 from vivarium.framework.lookup import LookupTable
 from vivarium.framework.randomness import Array, RandomnessStream, get_hash
 from vivarium.framework.values import Pipeline
-from vivarium_public_health.risks.data_transformations import pivot_categorical
 
 from vivarium_census_prl_synth_pop.constants import metadata
 
@@ -61,34 +59,6 @@ def delete_if_exists(*paths: Union[Path, List[Path]], confirm=False):
         for p in existing_paths:
             logger.info(f"Deleting artifact at {str(p)}.")
             p.unlink()
-
-
-def read_data_by_draw(artifact_path: str, key: str, draw: int) -> pd.DataFrame:
-    """Reads data from the artifact on a per-draw basis. This
-    is necessary for Low Birthweight Short Gestation (LBWSG) data.
-
-    Parameters
-    ----------
-    artifact_path
-        The artifact to read from.
-    key
-        The entity key associated with the data to read.
-    draw
-        The data to retrieve.
-
-    """
-    key = key.replace(".", "/")
-    with pd.HDFStore(artifact_path, mode="r") as store:
-        index = store.get(f"{key}/index")
-        draw = store.get(f"{key}/draw_{draw}")
-    draw = draw.rename("value")
-    data = pd.concat([index, draw], axis=1)
-    data = data.drop(columns="location")
-    data = pivot_categorical(data)
-    data[
-        project_globals.LBWSG_MISSING_CATEGORY.CAT
-    ] = project_globals.LBWSG_MISSING_CATEGORY.EXPOSURE
-    return data
 
 
 def get_norm(
@@ -297,16 +267,20 @@ def build_output_dir(output_dir: Path, subdir: Optional[Union[str, Path]] = None
     return output_dir
 
 
+def get_state_puma_map(df: pd.DataFrame) -> Dict[int, int]:
+    return df.groupby("state")["puma"].apply(lambda x: list(x.unique())).to_dict()
+
+
 def update_address_id(
-    df: pd.DataFrame,
-    rows_to_update: pd.Index,
+    units: pd.DataFrame,
+    units_that_move_ids: pd.Index,
     starting_address_id: int,
     address_id_col_name: str = "address_id",
 ) -> pd.DataFrame:
     """
     Parameters
     ----------
-    df: the pd.DataFrame to update, business table
+    units: the pd.DataFrame to update, business table
     rows_to_update: a pd.Index of the rows of df to update
     starting_address_id: int that is tracking value for business or household_ids max value.:
     address_id_col_name: a string. the name of the column in df to hold addresses.
@@ -314,72 +288,143 @@ def update_address_id(
     -------
     df with appropriately updated address_ids
     """
-    df.loc[rows_to_update, address_id_col_name] = starting_address_id + np.arange(
-        len(rows_to_update)
+    units.loc[units_that_move_ids, address_id_col_name] = starting_address_id + np.arange(
+        len(units_that_move_ids)
     )
-    return df
+    return units
 
 
-def update_address_id_for_unit_and_sims(
-    pop: pd.DataFrame,
-    moving_units: pd.DataFrame,
+def update_state_and_puma(
+    units: pd.DataFrame,
     units_that_move_ids: pd.Index,
-    starting_address_id: int,
-    unit_id_col_name: str,
-    address_id_col_name: str,
-) -> Tuple[pd.DataFrame, pd.DataFrame, int]:
+    state_col_name: str,
+    puma_col_name: str,
+    state_puma_map: Dict[int, List[int]],
+    randomness,
+) -> pd.DataFrame:
+    """Sample from all states/pumas in the artifact. This adds 'state' and 'puma'
+    columns to the units dataframe
     """
-    Units are multiperson groups tracked in the simulation.  Examples being households and employers.
+    state_puma_options = []
+    for state in state_puma_map:
+        state_puma_options.extend([(state, puma) for puma in state_puma_map[state]])
+    state_puma_choices = pd.DataFrame(
+        vectorized_choice(
+            options=np.array(state_puma_options, dtype="i,i"),
+            n_to_choose=len(units_that_move_ids),
+            randomness_stream=randomness,
+            additional_key="sampling_state_puma",
+        ),
+        index=units_that_move_ids,
+    )
+    state_puma_choices.columns = [state_col_name, puma_col_name]
+    units.loc[
+        units_that_move_ids, [state_col_name, puma_col_name]
+    ] = state_puma_choices.astype(int)
+
+    return units
+
+
+def update_addresses(
+    pop: pd.DataFrame,
+    movers_idx: pd.Index,
+    starting_address_id: int,
+    address_id_col_name: str,
+    state_col_name: str,
+    puma_col_name: str,
+    state_puma_map: Dict[int, List[int]],
+    randomness: RandomnessStream,
+    units: Optional[pd.DataFrame] = None,
+    unit_id_col_name: Optional[str] = None,
+) -> Tuple[pd.DataFrame, pd.DataFrame, int]:
+    """Updates the addresses (address_id, state, and puma) of moving units
+    (where units are multiperson groups tracked in the simulation, eg households
+    and employers).
 
     Parameters
     ----------
     pop: population table
-    moving_units: Dataframe with column address_id_col_name.
-    units_that_move_ids: IDs of moving units.  This is a subset of moving_units.index
-    starting_address_id: Integer at which to start generating new address_ids, to prevent collisions.
-    unit_id_col_name: Column name in state table where ids for the unit are stored.
+    movers_idx: pd.Index of movers (eg simulant, household_id, employer_id).
+    starting_address_id: Integer at which to start generating new address_ids (to prevent collisions).
     address_id_col_name: Column name in state table where address_id for the unit is stored.
+    state_col_name: Column name for state
+    puma_col_name: Column name for puma
+    state_puma_map: dictionary of state-to-puma mapping
+    randomness: Randomness stream
+    units: (Optional) Dataframe of units that might move with index unit ID
+        (eg household_id) and columns address_id_col_name (eg address_id),
+        state_col_name, and puma_col_name.
+        NOTE: None units means it is an individual moving
+    unit_id_col_name: (Optional) Column name in state table where ids for the
+    unit are stored.
 
     Returns
     -------
     pop: Updated version of the state table.
-    moving_units: Updated version of units dataframe.  This is done for the purpose of the businesses table.
+    units: Updated version of units dataframe.  This is done for the purpose of the businesses table.
     starting_address_id: Updated integer at which to start when generating more address_ids.
     """
 
-    if len(units_that_move_ids) > 0:
-        # update the employer address_id in self.businesses
-        # this will update address_id in a households dataframe we are not tracking like we are businesses
-        # todo:  Should add income/salary to mapping function here
-        moving_units = update_address_id(
-            df=moving_units,
-            rows_to_update=units_that_move_ids,
+    def _update_address_id_state_puma(
+        df, movers_idx, starting_address_id, address_id_col_name
+    ):
+        df = update_address_id(
+            units=df,
+            units_that_move_ids=movers_idx,
             starting_address_id=starting_address_id,
             address_id_col_name=address_id_col_name,
         )
-        starting_address_id += len(units_that_move_ids)
+        df = update_state_and_puma(
+            units=df,
+            units_that_move_ids=movers_idx,
+            state_col_name=state_col_name,
+            puma_col_name=puma_col_name,
+            state_puma_map=state_puma_map,
+            randomness=randomness,
+        )
+        starting_address_id += len(movers_idx)
+        return df, starting_address_id
 
-        # update address_id column in the pop table
-        rows_changing_address_id_idx = pop.loc[
-            pop[unit_id_col_name].isin(units_that_move_ids)
-        ].index
+    pop0 = pop.copy()
+    # Move groups (households or employers), not individuals
+    if (units is not None) and (len(movers_idx) > 0):
+        address_change_idx = pop.loc[pop[unit_id_col_name].isin(movers_idx)].index
         # Preserve pop index
         pop = pop.reset_index().rename(columns={"index": "simulant_id"})
-        # todo:  Should add income/salary to mapping function here
+
+        units, starting_address_id = _update_address_id_state_puma(
+            df=units,
+            movers_idx=movers_idx,
+            starting_address_id=starting_address_id,
+            address_id_col_name=address_id_col_name,
+        )
+
+        # update address columns in the pop table
         updated_address_ids = (
             pop[["simulant_id", unit_id_col_name]]
             .merge(
-                moving_units[[address_id_col_name]],
+                units,
                 how="left",
                 left_on=unit_id_col_name,
-                right_on=moving_units.index,
+                right_on=units.index,
             )
-            .set_index("simulant_id")[address_id_col_name]
+            .set_index("simulant_id")
         )
         pop = pop.set_index("simulant_id")
-        pop.loc[rows_changing_address_id_idx, address_id_col_name] = updated_address_ids
+        pop.loc[
+            address_change_idx, [address_id_col_name, state_col_name, puma_col_name]
+        ] = updated_address_ids
 
-    return pop, moving_units, starting_address_id
+    # Move individuals
+    elif (units is None) and (len(movers_idx) > 0):
+        pop, starting_address_id = _update_address_id_state_puma(
+            df=pop,
+            movers_idx=movers_idx,
+            starting_address_id=starting_address_id,
+            address_id_col_name=address_id_col_name,
+        )
+
+    return pop, units, starting_address_id
 
 
 def add_guardian_address_ids(pop: pd.DataFrame) -> pd.DataFrame:


### PR DESCRIPTION
## Title: Implement domestic moving state/puma updates

### Description
- *Category*: Implementation
- *JIRA issue*: [MIC-3728](https://jira.ihme.washington.edu/browse/MIC-3728)
- *Research reference*: 
  - [Household moves](https://vivarium-research.readthedocs.io/en/latest/models/concept_models/vivarium_census_synthdata/concept_model.html#household-moves)
  - [Business moves](https://vivarium-research.readthedocs.io/en/latest/models/concept_models/vivarium_census_synthdata/concept_model.html#business-address-changes)
  - [Individual moves](https://vivarium-research.readthedocs.io/en/latest/models/concept_models/vivarium_census_synthdata/concept_model.html#individual-moves)

### Changes and notes
Apologies in advance - this probably should have been broken into smaller tasks.

The meat of this is the `utilities.update_addresses` function, which
includes the (already-existing) logic to update address_ids as well as the
new logic to update states and pumas. Note that two entirely new columns
are now added to the state table: "employer_state" and "employer_puma".

What's particularly important to remember is that for this task, we're not
quite doing what is requested by the docs. Specifically, we are not using a
dataset to assign state/pumas upon movement. Instead, we are uniformly
sampling from all existing pumas in the artifact data. This was agreed
upon as a good first cut at domestic travel and a different ticket exists
to improve the domestic migration patterns.

A couple edge notes I clarified with the RT:
- Households and businesses are free to move within the same state/puma
- Individuals moving into a GQ have state/puma re-sampled. This effectively
  "grows" the locations of jails, nursing homes, etc.

Finally: If this PR gets implmented as-is, I intend on creating a followup task
to make this far more readable and possibly less fragile; we should maintain
an address_id-to-state/puma mapping throughout the sim to ease in
adding new addresses, extracting the relevant mappings, etc.


### Verification and Testing
All tests pass with 200k population size

