### PR TITLE
create simple post-processing cli stub

### DIFF
--- a/src/vivarium_census_prl_synth_pop/components/observers.py
+++ b/src/vivarium_census_prl_synth_pop/components/observers.py
@@ -10,7 +10,7 @@ from vivarium.framework.population import PopulationView
 from vivarium_public_health.utilities import DAYS_PER_YEAR
 
 from vivarium_census_prl_synth_pop import utilities
-from vivarium_census_prl_synth_pop.constants import data_values
+from vivarium_census_prl_synth_pop.constants import data_values, paths
 
 
 class BaseObserver(ABC):
@@ -140,7 +140,9 @@ class BaseObserver(ABC):
         pass
 
     def on_simulation_end(self, event: Event) -> None:
-        output_dir = utilities.build_output_dir(self.output_dir, subdir="results")
+        output_dir = utilities.build_output_dir(
+            self.output_dir, subdir=paths.RAW_RESULTS_DIR_NAME
+        )
         # 'fixed' format is not compatible with categorical data
         self.responses.to_csv(output_dir / (f"{self.name}.csv.bz2"))
 

--- a/src/vivarium_census_prl_synth_pop/constants/paths.py
+++ b/src/vivarium_census_prl_synth_pop/constants/paths.py
@@ -9,7 +9,9 @@ BASE_DIR = Path(vivarium_census_prl_synth_pop.__file__).resolve().parent
 PROJECT_ROOT = Path(f"/mnt/team/simulation_science/priv/engineering/{metadata.PROJECT_NAME}")
 ARTIFACT_ROOT = PROJECT_ROOT / "data/artifacts/"
 MODEL_SPEC_DIR = BASE_DIR / "model_specifications"
-RESULTS_ROOT = PROJECT_ROOT / "results/"
+
+RAW_RESULTS_DIR_NAME = Path("raw_results")
+FINAL_RESULTS_DIR_NAME = Path("final_results")
 
 HOUSEHOLDS_DATA_DIR = PROJECT_ROOT / "data/raw_data/current/United_States/"
 PERSONS_DATA_DIR = PROJECT_ROOT / "data/raw_data/current/United_States/"

--- a/src/vivarium_census_prl_synth_pop/tools/cli.py
+++ b/src/vivarium_census_prl_synth_pop/tools/cli.py
@@ -57,7 +57,7 @@ def make_artifacts(
 
 
 @click.command()
-@click.argument("output_file", type=click.Path(exists=True))
+@click.argument("output_dir", type=click.Path(exists=True))
 @click.option("-v", "verbose", count=True, help="Configure logging verbosity.")
 @click.option(
     "--pdb",
@@ -65,17 +65,7 @@ def make_artifacts(
     is_flag=True,
     help="Drop into python debugger if an error occurs.",
 )
-@click.option(
-    "-s",
-    "--single",
-    "single_run",
-    default=False,
-    is_flag=True,
-    help="Results are from a single, non-parallel run.",
-)
-def make_results(
-    output_file: str, verbose: int, with_debugger: bool, single_run: bool
-) -> None:
+def make_results(output_dir: str, verbose: int, with_debugger: bool) -> None:
     configure_logging_to_terminal(verbose)
     main = handle_exceptions(build_results, logger, with_debugger=with_debugger)
-    main(output_file, single_run)
+    main(output_dir)

--- a/src/vivarium_census_prl_synth_pop/tools/make_results.py
+++ b/src/vivarium_census_prl_synth_pop/tools/make_results.py
@@ -1,30 +1,19 @@
 import shutil
+from datetime import datetime
 from pathlib import Path
 
 from loguru import logger
 
-from vivarium_census_prl_synth_pop.results_processing import process_results
+from vivarium_census_prl_synth_pop import utilities
+from vivarium_census_prl_synth_pop.constants import paths
 
 
-def build_results(output_file: str, single_run: bool) -> None:
-    output_file = Path(output_file)
-    measure_dir = output_file.parent / "count_data"
-    if measure_dir.exists():
-        shutil.rmtree(measure_dir)
-    measure_dir.mkdir(exist_ok=True, mode=0o775)
+def build_results(results_dir: str) -> None:
+    logger.info("Creating final results directory.")
+    final_output_dir = utilities.build_output_dir(
+        Path(results_dir), subdir=paths.FINAL_RESULTS_DIR_NAME
+    ) / datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
 
-    logger.info(f"Reading in output data from {str(output_file)}.")
-    data, keyspace = process_results.read_data(output_file, single_run)
-    logger.info(f"Filtering incomplete data from outputs.")
-    rows = len(data)
-    data = process_results.filter_out_incomplete(data, keyspace)
-    new_rows = len(data)
-    logger.info(
-        f"Filtered {rows - new_rows} from data due to incomplete information.  {new_rows} remaining."
-    )
-    data = process_results.aggregate_over_seed(data)
-    logger.info(f"Computing raw count and proportion data.")
-    measure_data = process_results.make_measure_data(data)
-    logger.info(f"Writing raw count and proportion data to {str(measure_dir)}")
-    measure_data.dump(measure_dir)
-    logger.info("**DONE**")
+    logger.info("Copying raw results to final location.")
+    raw_output_dir = Path(results_dir) / paths.RAW_RESULTS_DIR_NAME
+    shutil.copytree(raw_output_dir, final_output_dir)

--- a/tests/components/observers/test_household_survey_observers.py
+++ b/tests/components/observers/test_household_survey_observers.py
@@ -3,6 +3,7 @@ import pandas as pd
 import pytest
 
 from vivarium_census_prl_synth_pop.components.observers import HouseholdSurveyObserver
+from vivarium_census_prl_synth_pop.constants import paths
 
 # TODO: Broader test coverage
 
@@ -42,7 +43,9 @@ def test_on_simulation_end(observer, mocker):
     event = mocker.MagicMock()
     observer.responses = pd.DataFrame()
     observer.on_simulation_end(event)
-    assert (observer.output_dir / "results" / (f"{observer.name}.csv.bz2")).is_file()
+    assert (
+        observer.output_dir / paths.RAW_RESULTS_DIR_NAME / (f"{observer.name}.csv.bz2")
+    ).is_file()
 
 
 def test_do_observation(observer, mocked_pop_view, mocker):


### PR DESCRIPTION
## Create post-processing CLI sub
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: post-processing
- *JIRA issue*: [MIC-3734](https://jira.ihme.washington.edu/browse/MIC-3734)
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
Created a stub for post-processing that copies existing outputs to final output location 

### Verification and Testing
Tested using `/mnt/team/simulation_science/priv/engineering/vivarium_census_prl_synth_pop/results/vv_observers/popsize_2_500_000/florida/2022_12_23_12_57_17`

Note: I had to revert the change to the raw output location to be compatible with the above run, but this will work with all future runs.
