### PR TITLE
add ability to mark best and latest versions

### DIFF
--- a/src/vivarium_census_prl_synth_pop/constants/paths.py
+++ b/src/vivarium_census_prl_synth_pop/constants/paths.py
@@ -13,6 +13,9 @@ MODEL_SPEC_DIR = BASE_DIR / "model_specifications"
 RAW_RESULTS_DIR_NAME = Path("raw_results")
 FINAL_RESULTS_DIR_NAME = Path("final_results")
 
+BEST_DIR_NAME = Path("best")
+LATEST_DIR_NAME = Path("latest")
+
 HOUSEHOLDS_DATA_DIR = PROJECT_ROOT / "data/raw_data/current/United_States/"
 PERSONS_DATA_DIR = PROJECT_ROOT / "data/raw_data/current/United_States/"
 

--- a/src/vivarium_census_prl_synth_pop/tools/cli.py
+++ b/src/vivarium_census_prl_synth_pop/tools/cli.py
@@ -65,7 +65,19 @@ def make_artifacts(
     is_flag=True,
     help="Drop into python debugger if an error occurs.",
 )
-def make_results(output_dir: str, verbose: int, with_debugger: bool) -> None:
+@click.option(
+    "-b",
+    "--mark-best",
+    is_flag=True,
+)
+@click.option(
+    "-t",
+    "--test-run",
+    is_flag=True,
+)
+def make_results(
+    output_dir: str, verbose: int, with_debugger: bool, mark_best: bool, test_run: bool
+) -> None:
     configure_logging_to_terminal(verbose)
     main = handle_exceptions(build_results, logger, with_debugger=with_debugger)
-    main(output_dir)
+    main(output_dir, mark_best, test_run)

--- a/src/vivarium_census_prl_synth_pop/tools/make_results.py
+++ b/src/vivarium_census_prl_synth_pop/tools/make_results.py
@@ -8,12 +8,36 @@ from vivarium_census_prl_synth_pop import utilities
 from vivarium_census_prl_synth_pop.constants import paths
 
 
-def build_results(results_dir: str) -> None:
+def build_results(results_dir: str, mark_best: bool, test_run: bool) -> None:
+    if mark_best and test_run:
+        logger.error(
+            "A test run can't be marked best. "
+            "Please remove either the mark best or the test run flag."
+        )
+        return
+
     logger.info("Creating final results directory.")
-    final_output_dir = utilities.build_output_dir(
+    final_output_root_dir = utilities.build_output_dir(
         Path(results_dir), subdir=paths.FINAL_RESULTS_DIR_NAME
-    ) / datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
+    )
+    final_output_dir = final_output_root_dir / datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
 
     logger.info("Copying raw results to final location.")
     raw_output_dir = Path(results_dir) / paths.RAW_RESULTS_DIR_NAME
     shutil.copytree(raw_output_dir, final_output_dir)
+
+    if test_run:
+        logger.info("Test run - not marking results as latest.")
+    else:
+        create_results_link(final_output_dir, paths.LATEST_DIR_NAME)
+
+    if mark_best:
+        create_results_link(final_output_dir, paths.BEST_DIR_NAME)
+
+
+def create_results_link(output_dir: Path, link_name: Path) -> None:
+    logger.info(f"Marking results as {link_name}.")
+    output_root_dir = output_dir.parent
+    link_dir = output_root_dir / link_name
+    link_dir.unlink(missing_ok=True)
+    link_dir.symlink_to(output_dir, target_is_directory=True)


### PR DESCRIPTION
## Add ability to mark post-processing versions as best and latest
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: post-processing
- *JIRA issue*: [MIC-3759](https://jira.ihme.washington.edu/browse/MIC-3759)
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
 Add ability to mark post-processing versions as best and latest. Also adds the concept of a "test run" which will mark neither.

### Verification and Testing
Tested running multiple times with each flag combination and verified that it works as expected.

