### PR TITLE
define simulation output directory structure

### DIFF
--- a/src/vivarium_census_prl_synth_pop/components/observers.py
+++ b/src/vivarium_census_prl_synth_pop/components/observers.py
@@ -79,7 +79,7 @@ class BaseObserver(ABC):
 
     def setup(self, builder: Builder):
         # FIXME: move filepaths to data container
-        # FIXME: settle on output dirs
+        self.seed = builder.configuration.randomness.random_seed
         self.output_dir = Path(builder.configuration.output_data.results_directory)
         self.population_view = self.get_population_view(builder)
         self.responses = None
@@ -141,10 +141,9 @@ class BaseObserver(ABC):
 
     def on_simulation_end(self, event: Event) -> None:
         output_dir = utilities.build_output_dir(
-            self.output_dir, subdir=paths.RAW_RESULTS_DIR_NAME
+            self.output_dir / paths.RAW_RESULTS_DIR_NAME / self.name
         )
-        # 'fixed' format is not compatible with categorical data
-        self.responses.to_csv(output_dir / (f"{self.name}.csv.bz2"))
+        self.responses.to_csv(output_dir / f"{self.name}_{self.seed}.csv.bz2")
 
 
 class HouseholdSurveyObserver(BaseObserver):
@@ -180,7 +179,7 @@ class HouseholdSurveyObserver(BaseObserver):
 
     @property
     def name(self):
-        return f"household_survey_observer.{self.survey}"
+        return f"household_survey_observer_{self.survey}"
 
     @property
     def input_columns(self):

--- a/src/vivarium_census_prl_synth_pop/utilities.py
+++ b/src/vivarium_census_prl_synth_pop/utilities.py
@@ -290,7 +290,7 @@ def build_output_dir(output_dir: Path, subdir: Optional[Union[str, Path]] = None
 
     old_umask = os.umask(0o002)
     try:
-        output_dir.mkdir(exist_ok=True)
+        output_dir.mkdir(exist_ok=True, parents=True)
     finally:
         os.umask(old_umask)
 

--- a/tests/components/observers/test_household_survey_observers.py
+++ b/tests/components/observers/test_household_survey_observers.py
@@ -44,7 +44,10 @@ def test_on_simulation_end(observer, mocker):
     observer.responses = pd.DataFrame()
     observer.on_simulation_end(event)
     assert (
-        observer.output_dir / paths.RAW_RESULTS_DIR_NAME / (f"{observer.name}.csv.bz2")
+        observer.output_dir
+        / paths.RAW_RESULTS_DIR_NAME
+        / observer.name
+        / f"{observer.name}_{observer.seed}.csv.bz2"
     ).is_file()
 
 


### PR DESCRIPTION
## Define an output structure
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: bugfix
- *JIRA issue*: [MIC-3771](https://jira.ihme.washington.edu/browse/MIC-3771)
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
Updated output directory structure such that parallel runs don't overwrite each other's results.

### Verification and Testing
Ran simulation and made results at the following location: `/mnt/team/simulation_science/priv/engineering/vivarium_census_prl_synth_pop/results/parallel-runs/florida/2023_01_14_13_10_05`