### PR TITLE
fix name of population component time-step cleanup function

### DIFF
--- a/src/vivarium_census_prl_synth_pop/components/population.py
+++ b/src/vivarium_census_prl_synth_pop/components/population.py
@@ -73,7 +73,7 @@ class Population:
             self.initialize_simulants, creates_columns=self.columns_created
         )
 
-        builder.event.register_listener("time_step__cleanup", self.on_time_step__prepare)
+        builder.event.register_listener("time_step__cleanup", self.on_time_step__cleanup)
 
     def _load_population_data(self, builder: Builder):
         households = builder.data.load(data_keys.POPULATION.HOUSEHOLDS)
@@ -335,7 +335,7 @@ class Population:
 
         self.population_view.update(new_births[self.columns_created])
 
-    def on_time_step__prepare(self, event: Event):
+    def on_time_step__cleanup(self, event: Event):
         """Ages simulants each time step.
 
         Parameters


### PR DESCRIPTION
## Fix time-step cleanup function name
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: bugfix
- *JIRA issue*: [MIC-3781](https://jira.ihme.washington.edu/browse/MIC-3781)
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
Fix function name 

### Verification and Testing
N/A
