### PR TITLE
Ingest Immigrant Source Data

### DIFF
--- a/src/vivarium_census_prl_synth_pop/components/__init__.py
+++ b/src/vivarium_census_prl_synth_pop/components/__init__.py
@@ -6,6 +6,7 @@ from vivarium_census_prl_synth_pop.components.household_emigration import (
 from vivarium_census_prl_synth_pop.components.household_migration import (
     HouseholdMigration,
 )
+from vivarium_census_prl_synth_pop.components.immigration import Immigration
 from vivarium_census_prl_synth_pop.components.mortality import Mortality
 from vivarium_census_prl_synth_pop.components.observers import (
     DecennialCensusObserver,

--- a/src/vivarium_census_prl_synth_pop/components/immigration.py
+++ b/src/vivarium_census_prl_synth_pop/components/immigration.py
@@ -1,0 +1,49 @@
+from vivarium.framework.engine import Builder
+
+from vivarium_census_prl_synth_pop.constants import data_keys
+
+
+class Immigration:
+    """
+    Handles migration of individuals *into* the US.
+    """
+
+    def __repr__(self) -> str:
+        return "Immigration()"
+
+    ##############
+    # Properties #
+    ##############
+
+    @property
+    def name(self):
+        return "immigration"
+
+    #################
+    # Setup methods #
+    #################
+
+    def setup(self, builder: Builder):
+        persons_data = builder.data.load(data_keys.POPULATION.PERSONS)
+
+        immigrants = persons_data[persons_data["immigrated_in_last_year"]]
+
+        is_gq = immigrants["relation_to_household_head"].isin(
+            [
+                "Insitutionalized GQ pop",
+                "Noninstitutionalized GQ pop",
+            ]
+        )
+        self.gq_immigrants = immigrants[is_gq]
+
+        non_gq_immigrants = immigrants[~is_gq]
+        immigrant_reference_people = non_gq_immigrants[
+            non_gq_immigrants["relation_to_household_head"] == "Reference person"
+        ]
+
+        is_household_immigrant = non_gq_immigrants["census_household_id"].isin(
+            immigrant_reference_people["census_household_id"]
+        )
+
+        self.household_immigrants = non_gq_immigrants[is_household_immigrant]
+        self.non_reference_person_immigrants = non_gq_immigrants[~is_household_immigrant]

--- a/src/vivarium_census_prl_synth_pop/model_specifications/model_spec.yaml
+++ b/src/vivarium_census_prl_synth_pop/model_specifications/model_spec.yaml
@@ -2,6 +2,7 @@ components:
     vivarium_census_prl_synth_pop:
         components:
             - Population()
+            - Immigration()
             - HouseholdMigration()
             - PersonMigration()
             - HouseholdEmigration()


### PR DESCRIPTION
## Ingest Immigrant Source Data

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: implementation
- *JIRA issue*: [MIC-3775](https://jira.ihme.washington.edu/browse/MIC-3775)
- *Research reference*: https://vivarium-research.readthedocs.io/en/latest/models/concept_models/vivarium_census_synthdata/concept_model.html#id4

### Changes and notes

The data loaded here does not include the person weight column, because that is not currently in the artifact. My expectation is that this will be done in a separate PR.

Because of the way the population component works, **two** copies of the full ACS person data will be in memory at the same time (this won't be handled by the artifact cache because of [this](https://github.com/ihmeuw/vivarium/blob/0560ee82b8dfd765a16c78027bd3f9f80f7c95f1/src/vivarium/framework/artifact/manager.py#L91)). I am assuming that we will want to change this, but that it will be a separate PR.

### Verification and Testing

Ran simulation to completion, stepped through code and verified that ACS immigrant data looks right.