### PR TITLE
Fix GQ household definition, load person weights

### DIFF
--- a/src/vivarium_census_prl_synth_pop/components/population.py
+++ b/src/vivarium_census_prl_synth_pop/components/population.py
@@ -162,12 +162,15 @@ class Population:
         self.population_view.update(pop)
 
     def choose_standard_households(self, target_number_sims: int) -> pd.DataFrame:
+        standard_households = self.population_data["households"][
+            self.population_data["households"]["household_type"] == "Housing unit"
+        ]
         # oversample households
         chosen_households = vectorized_choice(
-            options=self.population_data["households"]["census_household_id"],
+            options=standard_households["census_household_id"],
             n_to_choose=target_number_sims,
             randomness_stream=self.randomness,
-            weights=self.population_data["households"]["household_weight"],
+            weights=standard_households["household_weight"],
         )
 
         # create unique id for resampled households
@@ -202,9 +205,9 @@ class Population:
         return chosen_persons
 
     def choose_group_quarters(self, target_number_sims: int) -> pd.Series:
-        group_quarters = self.population_data["households"].pipe(
-            lambda df: df[df["census_household_id"].str.contains("GQ")]
-        )
+        group_quarters = self.population_data["households"][
+            self.population_data["households"]["household_type"] != "Housing unit"
+        ]
 
         # group quarters each house one person per census_household_id
         # they have NA household weights, but appropriately weighted person weights.

--- a/src/vivarium_census_prl_synth_pop/constants/metadata.py
+++ b/src/vivarium_census_prl_synth_pop/constants/metadata.py
@@ -32,7 +32,16 @@ HOUSEHOLDS_COLUMN_MAP = {
     "SERIALNO": "census_household_id",
     "PUMA": "puma",
     "WGTP": "household_weight",
+    "TYPEHUGQ": "household_type",
 }
+
+HOUSEHOLD_TYPE_MAP = {
+    1: "Housing unit",
+    2: "Institutional group quarters",
+    3: "Noninstitutional group quarters",
+}
+HOUSEHOLD_TYPES = list(HOUSEHOLD_TYPE_MAP.values())
+
 PERSONS_COLUMNS_TO_INITIALIZE = [
     "census_household_id",
     "age",
@@ -108,6 +117,7 @@ PERSONS_COLUMNS_MAP = {
     "RAC1P": "race",
     "NATIVITY": "born_in_us",
     "MIG": "immigrated_in_last_year",
+    "PWGTP": "person_weight",
 }
 
 SUBSET_PERSONS_COLUMNS_MAP = {

--- a/src/vivarium_census_prl_synth_pop/data/loader.py
+++ b/src/vivarium_census_prl_synth_pop/data/loader.py
@@ -140,6 +140,13 @@ def load_households(key: str, location: str) -> pd.DataFrame:
         location=location,
     )
 
+    # map household_type
+    data["household_type"] = (
+        data["household_type"]
+        .map(metadata.HOUSEHOLD_TYPE_MAP)
+        .astype(pd.CategoricalDtype(categories=metadata.HOUSEHOLD_TYPES))
+    )
+
     # read in persons file to find which household_ids it contains
     persons = load_raw_persons_data(metadata.SUBSET_PERSONS_COLUMNS_MAP, location)
 
@@ -156,7 +163,14 @@ def load_households(key: str, location: str) -> pd.DataFrame:
     )
 
     data = data.set_index(
-        ["state", "puma", "census_household_id", "household_weight", "person_weight"]
+        [
+            "state",
+            "puma",
+            "census_household_id",
+            "household_type",
+            "household_weight",
+            "person_weight",
+        ]
     )
 
     return data


### PR DESCRIPTION
## Fix GQ household definition, load person weights

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: bugfix + artifact
- *JIRA issue*: [MIC-3787](https://jira.ihme.washington.edu/browse/MIC-3787)
- *Research reference*: none

### Changes and notes

This PR bundles two changes which both update the artifact:

* Fixing a bug in how GQ households were defined, which requires a new ACS column
* Loading the person weight column from ACS, which will be used in immigration

### Verification and Testing

Ran simulation to completion; ran integration tests; stepped through code to check that GQ household definition appeared correct and both GQ and non-GQ rows span the whole 2016-2020 interval now.

One integration test is failing due to the problem fixed in #168.