### PR TITLE
make reference person moving/death atomic with reassigning a referenc…

### DIFF
--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -11,7 +11,7 @@ from vivarium_census_prl_synth_pop.constants import paths
 def sim() -> InteractiveContext:
     """Initialize a simulation for use in tests"""
     simulation = InteractiveContext(paths.MODEL_SPEC_DIR / "model_spec.yaml", setup=False)
-    simulation.configuration.population.population_size = 20_000
+    simulation.configuration.population.population_size = 250_000
     simulation.setup()
     return simulation
 

--- a/src/vivarium_census_prl_synth_pop/components/mortality.py
+++ b/src/vivarium_census_prl_synth_pop/components/mortality.py
@@ -1,9 +1,16 @@
 from vivarium.framework.engine import Builder
+from vivarium.framework.event import Event
 from vivarium.framework.population import PopulationView
 from vivarium_public_health.population import Mortality as _Mortality
 
 
 class Mortality(_Mortality):
+    def setup(self, builder: Builder) -> None:
+        super().setup(builder)
+        self.updated_relation_to_reference_person = builder.value.get_value(
+            "updated_relation_to_reference_person"
+        )
+
     def _get_population_view(self, builder: Builder) -> PopulationView:
         return builder.population.get_view(
             [
@@ -13,5 +20,12 @@ class Mortality(_Mortality):
                 "exit_time",
                 "age",
                 "sex",
+                "relation_to_household_head",
             ]
         )
+
+    def on_time_step(self, event: Event) -> None:
+        super().on_time_step(event)
+
+        new_relation_to_ref_person = self.updated_relation_to_reference_person(event.index)
+        self.population_view.update(new_relation_to_ref_person)

--- a/src/vivarium_census_prl_synth_pop/components/person_emigration.py
+++ b/src/vivarium_census_prl_synth_pop/components/person_emigration.py
@@ -44,6 +44,9 @@ class PersonEmigration:
             "tracked",
         ]
         self.population_view = builder.population.get_view(self.columns_needed)
+        self.updated_relation_to_reference_person = builder.value.get_value(
+            "updated_relation_to_reference_person"
+        )
 
         non_reference_person_move_rates_data = pd.read_csv(
             paths.NON_REFERENCE_PERSON_EMIGRATION_RATES_PATH,
@@ -130,3 +133,6 @@ class PersonEmigration:
         pop.loc[emigrating_idx, "tracked"] = False
 
         self.population_view.update(pop)
+
+        new_relation_to_ref_person = self.updated_relation_to_reference_person(event.index)
+        self.population_view.update(new_relation_to_ref_person)

--- a/src/vivarium_census_prl_synth_pop/components/person_migration.py
+++ b/src/vivarium_census_prl_synth_pop/components/person_migration.py
@@ -50,6 +50,9 @@ class PersonMigration:
             "housing_type",
         ]
         self.population_view = builder.population.get_view(self.columns_needed)
+        self.updated_relation_to_reference_person = builder.value.get_value(
+            "updated_relation_to_reference_person"
+        )
 
         move_rates_data = pd.read_csv(
             paths.INDIVIDUAL_DOMESTIC_MIGRATION_RATES_PATH,
@@ -140,6 +143,9 @@ class PersonMigration:
         )
 
         self.population_view.update(pop)
+
+        new_relation_to_ref_person = self.updated_relation_to_reference_person(event.index)
+        self.population_view.update(new_relation_to_ref_person)
 
     ##################
     # Helper methods #

--- a/src/vivarium_census_prl_synth_pop/constants/data_values.py
+++ b/src/vivarium_census_prl_synth_pop/constants/data_values.py
@@ -1,6 +1,9 @@
 from typing import NamedTuple
 
+import pandas as pd
 from scipy import stats
+
+from vivarium_census_prl_synth_pop.constants import paths
 
 #########################
 # Population parameters #
@@ -37,6 +40,10 @@ PROPORTION_INITIALIZATION_WITH_SSN = 0.743
 
 UNKNOWN_GUARDIAN_IDX = -1
 PROPORTION_GUARDIAN_TYPES = {"single_female": 0.23, "single_male": 0.05, "partnered": 0.72}
+
+REFERENCE_PERSON_UPDATE_RELATIONSHIPS_MAP = pd.read_csv(
+    paths.REFERENCE_PERSON_UPDATE_RELATIONSHIP_DATA_PATH,
+)
 
 #########################
 # Synthetic Name Inputs #

--- a/src/vivarium_census_prl_synth_pop/utilities.py
+++ b/src/vivarium_census_prl_synth_pop/utilities.py
@@ -7,11 +7,9 @@ import numpy as np
 import pandas as pd
 from loguru import logger
 from scipy import stats
-from vivarium.framework.engine import Builder
 from vivarium.framework.lookup import LookupTable
 from vivarium.framework.randomness import Array, RandomnessStream, get_hash
 from vivarium.framework.values import Pipeline
-from vivarium_public_health.risks.data_transformations import pivot_categorical
 
 from vivarium_census_prl_synth_pop.constants import metadata
 
@@ -61,34 +59,6 @@ def delete_if_exists(*paths: Union[Path, List[Path]], confirm=False):
         for p in existing_paths:
             logger.info(f"Deleting artifact at {str(p)}.")
             p.unlink()
-
-
-def read_data_by_draw(artifact_path: str, key: str, draw: int) -> pd.DataFrame:
-    """Reads data from the artifact on a per-draw basis. This
-    is necessary for Low Birthweight Short Gestation (LBWSG) data.
-
-    Parameters
-    ----------
-    artifact_path
-        The artifact to read from.
-    key
-        The entity key associated with the data to read.
-    draw
-        The data to retrieve.
-
-    """
-    key = key.replace(".", "/")
-    with pd.HDFStore(artifact_path, mode="r") as store:
-        index = store.get(f"{key}/index")
-        draw = store.get(f"{key}/draw_{draw}")
-    draw = draw.rename("value")
-    data = pd.concat([index, draw], axis=1)
-    data = data.drop(columns="location")
-    data = pivot_categorical(data)
-    data[
-        project_globals.LBWSG_MISSING_CATEGORY.CAT
-    ] = project_globals.LBWSG_MISSING_CATEGORY.EXPOSURE
-    return data
 
 
 def get_norm(


### PR DESCRIPTION
…e person

## Atomicize reference person actions
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: implementation
- *JIRA issue*: [MIC-3796](https://jira.ihme.washington.edu/browse/MIC-3796)
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
Previously reference people would die or move and the simulation would account for that having happened on time-step cleanup. This meant that we would be in the correct state at the end of the simulation, but it meant that during a time-step there would be situations where households had no living reference person, which makes several actions difficult to reason about. This makes all of these reference persons atomic with the new assignment of a reference person

Fixed some related tests that were breaking at larger population sizes. Increased the size of the default integration test population size so that these failures don't get missed going forward.

Also removed an unused function from utilities. 

### Verification and Testing
Got unit and integration tests working.

