### PR TITLE
Add additional tax observers to support simulated 1040 data

### DIFF
--- a/src/vivarium_census_prl_synth_pop/components/__init__.py
+++ b/src/vivarium_census_prl_synth_pop/components/__init__.py
@@ -11,7 +11,7 @@ from vivarium_census_prl_synth_pop.components.observers import (
     DecennialCensusObserver,
     HouseholdSurveyObserver,
     SocialSecurityObserver,
-    TaxW2Observer,
+    TaxObserver,
     WICObserver,
 )
 from vivarium_census_prl_synth_pop.components.person_emigration import PersonEmigration

--- a/src/vivarium_census_prl_synth_pop/components/observers.py
+++ b/src/vivarium_census_prl_synth_pop/components/observers.py
@@ -535,7 +535,6 @@ class TaxW2Observer(BaseObserver):
         "employer_id",
     ]
     OUTPUT_COLUMNS = [
-        "simulant_id",
         "first_name_id",
         "middle_name_id",
         "last_name_id",
@@ -846,7 +845,6 @@ class Tax1040Observer(BaseObserver):
         "relation_to_household_head",
     ]
     OUTPUT_COLUMNS = [
-        "simulant_id",
         "first_name_id",
         "middle_name_id",
         "last_name_id",
@@ -900,7 +898,6 @@ class Tax1040Observer(BaseObserver):
         ]
 
         # add derived columns
-        pop["simulant_id"] = pop.index
         pop["tax_year"] = event.time.year - 1
 
         # delete extraneous columns
@@ -911,7 +908,7 @@ class Tax1040Observer(BaseObserver):
         ### get series of all person/employment pairs from w2 observer
         s_w2 = self.w2_observer.income_last_year
         non_zero_income_ids = s_w2.reset_index()["simulant_id"].unique()
-        non_zero_income_rows = pop["simulant_id"].isin(non_zero_income_ids)
+        non_zero_income_rows = pop.index.isin(non_zero_income_ids)
         pop = pop[non_zero_income_rows]
 
         return pop

--- a/src/vivarium_census_prl_synth_pop/components/observers.py
+++ b/src/vivarium_census_prl_synth_pop/components/observers.py
@@ -510,7 +510,7 @@ class TaxObserver:
         self._sub_components = [
             tax_w2,
             tax_1040,
-            tax_dependents,  # NOTE: this component must come after the TaxW2Observer to function correctly
+            tax_dependents,
         ]  # following pattern from vivarium.examples.disease_model.disease.SISDiseaseModel
         # TODO: it would be cool if there was more documentation on this, and if it was easy to find!
 

--- a/src/vivarium_census_prl_synth_pop/model_specifications/model_spec.yaml
+++ b/src/vivarium_census_prl_synth_pop/model_specifications/model_spec.yaml
@@ -15,7 +15,7 @@ components:
             - HouseholdSurveyObserver("cps")
             - WICObserver()
             - SocialSecurityObserver()
-            - TaxW2Observer()
+            - TaxObserver()
 
 configuration:
     input_data:


### PR DESCRIPTION
## Add additional tax observers to support simulated 1040 data
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: observers<!-- one of bugfix, data artifact, implementation, observers,
                   post-processing, refactor, revert, test, release, other/misc -->
- *JIRA issue*: [MIC-3786](https://jira.ihme.washington.edu/browse/MIC-3786)
- *Research reference*: <!--Link to research documentation for code -->https://vivarium-research.readthedocs.io/en/latest/models/concept_models/vivarium_census_synthdata/concept_model.html#form

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
It is a little weird to have the dependents in the W2, so Abie and Rajan decided to refactor this approach to have a composite observer that has three subclasses of BaseObserver.  One will be a refactor of the W2 Observer, another will be the 1040 observer described above, and the third will be the eligible dependent information, organized by dependent (in a long format). See design discussion in JIRA for a sketch https://jira.ihme.washington.edu/browse/MIC-3772

### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->
Simulate runs successfully with model_spec.yaml, results look acceptable.  All tests pass.
