### PR TITLE
move standard household intialization into the households component

### DIFF
--- a/integration_tests/test_domestic_migration.py
+++ b/integration_tests/test_domestic_migration.py
@@ -149,9 +149,9 @@ def test_households_move(simulants_on_adjacent_timesteps):
         ).all()
 
         # Address IDs moved to are new
-        moved_households = before[household_movers]["household_id"].unique()
+        moved_households = before[household_movers]["household_id"]
         new_addresses = after[household_movers]["household_details.address_id"]
-        assert new_addresses.nunique() == len(moved_households)
+        assert new_addresses.nunique() == moved_households.nunique()
         assert not before["household_details.address_id"].isin(new_addresses).any()
 
         # Never GQ households

--- a/src/vivarium_census_prl_synth_pop/components/household.py
+++ b/src/vivarium_census_prl_synth_pop/components/household.py
@@ -106,7 +106,7 @@ class Households:
 
         households = pd.concat([gq_households, sampled_standard_households])
         households["housing_type"] = households["housing_type"].astype(
-            pd.CategoricalDtype(categories=data_values.HOUSING_TYPES)
+            HOUSEHOLD_DETAILS_DTYPES["housing_type"]
         )
 
         return households
@@ -138,7 +138,7 @@ class Households:
     def get_household_details(self, idx: pd.Index) -> pd.DataFrame:
         """Source of the household_details pipeline"""
         pop = self.population_view.subview(["tracked", "household_id"]).get(idx)
-        household_details = pop.join(
+        household_details = pop[["household_id"]].join(
             self._households,
             on="household_id",
         )

--- a/src/vivarium_census_prl_synth_pop/components/household.py
+++ b/src/vivarium_census_prl_synth_pop/components/household.py
@@ -4,10 +4,14 @@ from vivarium.framework.engine import Builder
 from vivarium.framework.population import SimulantData
 from vivarium.framework.time import get_time_stamp
 
-from vivarium_census_prl_synth_pop.constants.data_values import (
-    GQ_HOUSING_TYPE_MAP,
-    HOUSING_TYPES,
-)
+from vivarium_census_prl_synth_pop.constants import data_keys, data_values
+from vivarium_census_prl_synth_pop.utilities import vectorized_choice
+
+HOUSEHOLD_DETAILS_DTYPES = {
+    "household_id": int,
+    "address_id": int,
+    "housing_type": pd.CategoricalDtype(categories=data_values.HOUSING_TYPES),
+}
 
 
 class Households:
@@ -29,6 +33,8 @@ class Households:
     #################
 
     def setup(self, builder: Builder):
+        self.pop_config = builder.configuration.population
+        self.seed = builder.configuration.randomness.random_seed
         self.start_time = get_time_stamp(builder.configuration.time.start)
 
         self.randomness = builder.randomness.get_stream(self.name)
@@ -39,7 +45,7 @@ class Households:
 
         self.population_view = builder.population.get_view(self.columns_used)
 
-        self.households = None
+        self._households = self.sample_initial_households(builder)
         self.household_details = builder.value.register_value_producer(
             "household_details",
             source=self.get_household_details,
@@ -51,47 +57,100 @@ class Households:
             requires_columns=["household_id"],
         )
 
+    def sample_initial_households(self, builder: Builder) -> pd.DataFrame:
+        """
+        Initializes the households data structure. Samples as many standard
+        households as the target number of simulants living in standard
+        households to ensure we aren't short. This data structure contains the
+        following columns:
+
+        census_household_id: needed to match up with persons data for population
+            initialization
+        household_id: this will be set as the index after initialization, but
+            for convenience this is a column at this stage
+        housing type: either Standard or specific GQ type
+        address_id: id for the household's address
+        """
+        input_household_data = builder.data.load(data_keys.POPULATION.HOUSEHOLDS)
+        gq_households = pd.DataFrame(
+            {
+                "census_household_id": "N/A",
+                "household_id": data_values.GQ_HOUSING_TYPE_MAP.keys(),
+                "address_id": data_values.GQ_HOUSING_TYPE_MAP.keys(),
+                "housing_type": data_values.GQ_HOUSING_TYPE_MAP.values(),
+            }
+        )
+
+        target_gq_pop_size = int(
+            self.pop_config.population_size * data_values.PROP_POPULATION_IN_GQ
+        )
+        target_standard_housing_pop_size = (
+            self.pop_config.population_size - target_gq_pop_size
+        )
+
+        sampled_census_ids = vectorized_choice(
+            options=input_household_data["census_household_id"],
+            n_to_choose=target_standard_housing_pop_size,
+            weights=input_household_data["household_weight"],
+            additional_key=f"sample_households_{self.seed}",
+        )
+        standard_household_ids = gq_households.index.size + np.arange(len(sampled_census_ids))
+        sampled_standard_households = pd.DataFrame(
+            {
+                "census_household_id": sampled_census_ids,
+                "household_id": standard_household_ids,
+                "address_id": standard_household_ids,
+                "housing_type": "Standard",
+            }
+        )
+
+        households = pd.concat([gq_households, sampled_standard_households])
+        households["housing_type"] = households["housing_type"].astype(
+            pd.CategoricalDtype(categories=data_values.HOUSING_TYPES)
+        )
+
+        return households
+
     ########################
     # Event-driven methods #
     ########################
 
     def on_initialize_simulants(self, pop_data: SimulantData) -> None:
         """
-        add addresses to each household in the population table
+        Remove unused households from the household datastructure immediately
+        following initialization and set household id as index
         """
-        if pop_data.creation_time < self.start_time:  # initial pop
-            self.households = self.generate_initial_households(pop_data)
+        if pop_data.creation_time < self.start_time:
+            households = self._households.set_index("household_id")
+            # Drop all households that aren't in population except for GQ households
+            gq_index = households.index[households["housing_type"] != "Standard"]
+            existing_households = pd.Index(
+                self.population_view.subview(["household_id"])
+                .get(pop_data.index)["household_id"]
+                .drop_duplicates()
+            )
+            self.set_households(households.loc[gq_index.union(existing_households)])
 
-    ##################
-    # Helper methods #
-    ##################
-
-    def generate_initial_households(self, pop_data: SimulantData) -> pd.DataFrame():
-        households = self.population_view.subview(["household_id"]).get(pop_data.index)
-        households = (
-            households.drop_duplicates().sort_values("household_id").set_index("household_id")
-        )
-        households["address_id"] = np.arange(len(households))
-        households["housing_type"] = households.index.map(GQ_HOUSING_TYPE_MAP).fillna(
-            "Standard"
-        )
-        # set housing type dtype
-        households["housing_type"] = households["housing_type"].astype(
-            pd.CategoricalDtype(categories=HOUSING_TYPES)
-        )
-
-        return households
+    ##################################
+    # Pipeline sources and modifiers #
+    ##################################
 
     def get_household_details(self, idx: pd.Index) -> pd.DataFrame:
         """Source of the household_details pipeline"""
-        pop = self.population_view.get(idx)[["household_id"]]
+        pop = self.population_view.subview(["tracked", "household_id"]).get(idx)
         household_details = pop.join(
-            self.households,
+            self._households,
             on="household_id",
         )
-        # FIXME: why is the `housing_type` column losing its CategoricalDtype?
-        household_details["housing_type"] = household_details["housing_type"].astype(
-            pd.CategoricalDtype(categories=HOUSING_TYPES)
-        )
-
+        household_details = household_details.astype(HOUSEHOLD_DETAILS_DTYPES)
         return household_details
+
+    #######################
+    # Getters and setters #
+    #######################
+
+    def get_households(self) -> pd.DataFrame:
+        return self._households
+
+    def set_households(self, households: pd.DataFrame) -> None:
+        self._households = households

--- a/src/vivarium_census_prl_synth_pop/components/household_migration.py
+++ b/src/vivarium_census_prl_synth_pop/components/household_migration.py
@@ -88,11 +88,12 @@ class HouseholdMigration:
             "moving_households",
         )
 
-        self.households.households, _ = update_address_ids(
-            moving_units=self.households.households,
+        households = self.households.get_households()
+        households, _ = update_address_ids(
+            moving_units=households,
             units_that_move_ids=movers["household_id"],
-            starting_address_id=self.households.households["address_id"].max() + 1,
+            starting_address_id=households["address_id"].max() + 1,
             address_id_col_name="address_id",
         )
 
-        self.population_view.update(pop)
+        self.households.set_households(households)

--- a/src/vivarium_census_prl_synth_pop/components/person_emigration.py
+++ b/src/vivarium_census_prl_synth_pop/components/person_emigration.py
@@ -37,6 +37,7 @@ class PersonEmigration:
     def setup(self, builder: Builder):
         self.randomness = builder.randomness.get_stream(self.name)
         self.households = builder.components.get_component("households")
+        self.household_details = builder.value.get_value("household_details")
         self.columns_needed = [
             "relation_to_household_head",
             "in_united_states",
@@ -110,7 +111,7 @@ class PersonEmigration:
             event.index,
             query="alive == 'alive' and in_united_states == True and tracked == True",
         )
-        household_details = self.households.household_details(pop.index)
+        household_details = self.household_details(pop.index)
         non_reference_people_idx = pop.index[
             (household_details["housing_type"] == "Standard")
             & (pop["relation_to_household_head"] != "Reference person")

--- a/src/vivarium_census_prl_synth_pop/components/person_migration.py
+++ b/src/vivarium_census_prl_synth_pop/components/person_migration.py
@@ -42,6 +42,7 @@ class PersonMigration:
     def setup(self, builder: Builder):
         self.randomness = builder.randomness.get_stream(self.name)
         self.households = builder.components.get_component("households")
+        self.household_details = builder.value.get_value("household_details")
         self.columns_needed = [
             "household_id",
             "relation_to_household_head",
@@ -106,7 +107,7 @@ class PersonMigration:
 
     def on_time_step_prepare(self, event: Event) -> None:
         pop = self.population_view.subview(["previous_timestep_address_id"]).get(event.index)
-        pop["previous_timestep_address_id"] = self.households.household_details(pop.index)[
+        pop["previous_timestep_address_id"] = self.household_details(pop.index)[
             ["address_id"]
         ]
         self.population_view.update(pop)
@@ -155,7 +156,7 @@ class PersonMigration:
         """
         Create a new single-person household for each person in movers and move them to it.
         """
-        households = self.households.households
+        households = self.households.get_households()
         first_new_household_id = households.index.max() + 1
         new_household_ids = first_new_household_id + np.arange(len(movers))
         first_new_household_address_id = households["address_id"].max() + 1
@@ -173,7 +174,7 @@ class PersonMigration:
             }
         ).set_index("household_id")
         households = pd.concat([households, new_households], axis=0)
-        self.households.households = households
+        self.households.set_households(households)
 
         return pop
 

--- a/src/vivarium_census_prl_synth_pop/constants/data_values.py
+++ b/src/vivarium_census_prl_synth_pop/constants/data_values.py
@@ -16,6 +16,8 @@ MAX_HOUSEHOLD_SIZE = 17
 PROP_POPULATION_IN_GQ = 0.03
 PROBABILITY_OF_TWINS = 0.04
 N_GROUP_QUARTER_TYPES = 6
+
+# todo see if these dicts can be converted to lists. are they necessary at all?
 INSTITUTIONAL_GROUP_QUARTER_IDS = {"Carceral": 0, "Nursing home": 1, "Other institutional": 2}
 NONINSTITUTIONAL_GROUP_QUARTER_IDS = {
     "College": 3,

--- a/src/vivarium_census_prl_synth_pop/utilities.py
+++ b/src/vivarium_census_prl_synth_pop/utilities.py
@@ -8,7 +8,7 @@ import pandas as pd
 from loguru import logger
 from scipy import stats
 from vivarium.framework.lookup import LookupTable
-from vivarium.framework.randomness import Array, RandomnessStream, get_hash
+from vivarium.framework.randomness import Array, RandomnessStream, get_hash, random
 from vivarium.framework.values import Pipeline
 
 from vivarium_census_prl_synth_pop.constants import metadata
@@ -169,7 +169,7 @@ def get_norm_from_quantiles(
 def vectorized_choice(
     options: Array,
     n_to_choose: int,
-    randomness_stream: RandomnessStream,
+    randomness_stream: RandomnessStream = None,
     weights: Array = None,
     additional_key: Any = None,
 ):
@@ -177,7 +177,11 @@ def vectorized_choice(
         n = len(options)
         weights = np.ones(n) / n
     # for each of n_to_choose, sample uniformly between 0 and 1
-    probs = randomness_stream.get_draw(np.arange(n_to_choose), additional_key=additional_key)
+    index = pd.Index(np.arange(n_to_choose))
+    if randomness_stream is None:
+        probs = random(str(additional_key), index)
+    else:
+        probs = randomness_stream.get_draw(index, additional_key=additional_key)
 
     # build cdf based on weights
     pmf = weights / weights.sum()


### PR DESCRIPTION
## Initialize standard households in Household component
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: refactor
- *JIRA issue*: [MIC-3802](https://jira.ihme.washington.edu/browse/MIC-3802)
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
* Initialize households data structure with standard households in the `Households` component rather than the `Population` component
* Sample households from the artifact to pave the way for not having to carry that data around in memory
* On initialize simulants drop all households that don't have simulants initialized into the sim
* Added setters and getters to centralize access to the households component (was helpful in debugging as I could put a breakpoint in the setter and see every time it was updated).
* Fixed a few more places where the household details pipeline is accessed using the `Household` component
* Modified `vectorized_choice` to function in `setup` (i.e. without a `RandomnessStream`)

### Verification and Testing
Ran simulation and verified tests all pass.

