### PR TITLE
Refactor households state into its own component

### DIFF
--- a/src/vivarium_census_prl_synth_pop/components/__init__.py
+++ b/src/vivarium_census_prl_synth_pop/components/__init__.py
@@ -1,5 +1,6 @@
 from vivarium_census_prl_synth_pop.components.businesses import Businesses
 from vivarium_census_prl_synth_pop.components.fertility import Fertility
+from vivarium_census_prl_synth_pop.components.household import Households
 from vivarium_census_prl_synth_pop.components.household_emigration import (
     HouseholdEmigration,
 )

--- a/src/vivarium_census_prl_synth_pop/components/businesses.py
+++ b/src/vivarium_census_prl_synth_pop/components/businesses.py
@@ -10,7 +10,7 @@ from vivarium.framework.time import get_time_stamp
 from vivarium_public_health import utilities
 
 from vivarium_census_prl_synth_pop.constants import data_values, metadata, paths
-from vivarium_census_prl_synth_pop.utilities import filter_by_rate, update_address_ids
+from vivarium_census_prl_synth_pop.utilities import filter_by_rate
 
 
 class Businesses:
@@ -173,12 +173,7 @@ class Businesses:
             "moving_businesses",
         )
 
-        self.businesses, self.employer_address_id_count = update_address_ids(
-            moving_units=self.businesses,
-            units_that_move_ids=businesses_that_move_idx,
-            starting_address_id=self.employer_address_id_count,
-            address_id_col_name="employer_address_id",
-        )
+        self.update_business_address_ids(businesses_that_move_idx)
 
         # change jobs by rate as well as if the household moves (only includes
         # working-age simulants and excludes simulants living in military GQ)
@@ -367,3 +362,19 @@ class Businesses:
         )
 
         return business_details
+
+    def update_business_address_ids(self, moving_business_ids: pd.Index) -> None:
+        """
+        Change the address_id associated with each of the provided business_ids to
+        a new, unique value.
+
+        Parameters
+        ----------
+        moving_business_ids
+            Index into self.businesses for the businesses that should move.
+        """
+        if len(moving_business_ids) > 0:
+            self.businesses.loc[
+                moving_business_ids, "employer_address_id"
+            ] = self.employer_address_id_count + np.arange(len(moving_business_ids))
+            self.employer_address_id_count += len(moving_business_ids)

--- a/src/vivarium_census_prl_synth_pop/components/businesses.py
+++ b/src/vivarium_census_prl_synth_pop/components/businesses.py
@@ -53,7 +53,7 @@ class Businesses:
     def setup(self, builder: Builder):
         self.start_time = get_time_stamp(builder.configuration.time.start)
         self.randomness = builder.randomness.get_stream(self.name)
-        self.household_migration = builder.components.get_component("household_migration")
+        self.household_details = builder.value.get_value("household_details")
         self.employer_address_id_count = 0
         self.columns_created = [
             "employer_id",
@@ -193,7 +193,7 @@ class Businesses:
             working_age_idx, self.randomness, self.job_change_rate, "changing jobs"
         )
         moved_idx = pop.index[
-            self.household_migration.household_details(pop.index)["address_id"]
+            self.household_details(pop.index)["address_id"]
             != pop["previous_timestep_address_id"]
         ]
         moved_working_age_idx = moved_idx.intersection(working_age_idx)

--- a/src/vivarium_census_prl_synth_pop/components/household.py
+++ b/src/vivarium_census_prl_synth_pop/components/household.py
@@ -1,14 +1,13 @@
 import numpy as np
 import pandas as pd
 from vivarium.framework.engine import Builder
-from vivarium.framework.population import SimulantData
 from vivarium.framework.time import get_time_stamp
 
-from vivarium_census_prl_synth_pop.constants import data_keys, data_values
-from vivarium_census_prl_synth_pop.utilities import vectorized_choice
+from vivarium_census_prl_synth_pop.constants import data_values
+from vivarium_census_prl_synth_pop.utilities import update_address_ids
 
+HOUSEHOLD_ID_DTYPE = int
 HOUSEHOLD_DETAILS_DTYPES = {
-    "household_id": int,
     "address_id": int,
     "housing_type": pd.CategoricalDtype(categories=data_values.HOUSING_TYPES),
 }
@@ -45,91 +44,21 @@ class Households:
 
         self.population_view = builder.population.get_view(self.columns_used)
 
-        self._households = self.sample_initial_households(builder)
+        # GQ households are special, with fixed IDs
+        self._households = pd.DataFrame(
+            {
+                "address_id": data_values.GQ_HOUSING_TYPE_MAP.keys(),
+                "housing_type": data_values.GQ_HOUSING_TYPE_MAP.values(),
+            },
+            index=data_values.GQ_HOUSING_TYPE_MAP.keys().astype(HOUSEHOLD_ID_DTYPE),
+        ).astype(HOUSEHOLD_DETAILS_DTYPES)
+        self._households.index.names = ["household_id"]
+
         self.household_details = builder.value.register_value_producer(
             "household_details",
             source=self.get_household_details,
             requires_columns=["household_id", "tracked"],
         )
-
-        builder.population.initializes_simulants(
-            self.on_initialize_simulants,
-            requires_columns=["household_id"],
-        )
-
-    def sample_initial_households(self, builder: Builder) -> pd.DataFrame:
-        """
-        Initializes the households data structure. Samples as many standard
-        households as the target number of simulants living in standard
-        households to ensure we aren't short. This data structure contains the
-        following columns:
-
-        census_household_id: needed to match up with persons data for population
-            initialization
-        household_id: this will be set as the index after initialization, but
-            for convenience this is a column at this stage
-        housing type: either Standard or specific GQ type
-        address_id: id for the household's address
-        """
-        input_household_data = builder.data.load(data_keys.POPULATION.HOUSEHOLDS)
-        gq_households = pd.DataFrame(
-            {
-                "census_household_id": "N/A",
-                "household_id": data_values.GQ_HOUSING_TYPE_MAP.keys(),
-                "address_id": data_values.GQ_HOUSING_TYPE_MAP.keys(),
-                "housing_type": data_values.GQ_HOUSING_TYPE_MAP.values(),
-            }
-        )
-
-        target_gq_pop_size = int(
-            self.pop_config.population_size * data_values.PROP_POPULATION_IN_GQ
-        )
-        target_standard_housing_pop_size = (
-            self.pop_config.population_size - target_gq_pop_size
-        )
-
-        sampled_census_ids = vectorized_choice(
-            options=input_household_data["census_household_id"],
-            n_to_choose=target_standard_housing_pop_size,
-            weights=input_household_data["household_weight"],
-            additional_key=f"sample_households_{self.seed}",
-        )
-        standard_household_ids = gq_households.index.size + np.arange(len(sampled_census_ids))
-        sampled_standard_households = pd.DataFrame(
-            {
-                "census_household_id": sampled_census_ids,
-                "household_id": standard_household_ids,
-                "address_id": standard_household_ids,
-                "housing_type": "Standard",
-            }
-        )
-
-        households = pd.concat([gq_households, sampled_standard_households])
-        households["housing_type"] = households["housing_type"].astype(
-            HOUSEHOLD_DETAILS_DTYPES["housing_type"]
-        )
-
-        return households
-
-    ########################
-    # Event-driven methods #
-    ########################
-
-    def on_initialize_simulants(self, pop_data: SimulantData) -> None:
-        """
-        Remove unused households from the household datastructure immediately
-        following initialization and set household id as index
-        """
-        if pop_data.creation_time < self.start_time:
-            households = self._households.set_index("household_id")
-            # Drop all households that aren't in population except for GQ households
-            gq_index = households.index[households["housing_type"] != "Standard"]
-            existing_households = pd.Index(
-                self.population_view.subview(["household_id"])
-                .get(pop_data.index)["household_id"]
-                .drop_duplicates()
-            )
-            self.set_households(households.loc[gq_index.union(existing_households)])
 
     ##################################
     # Pipeline sources and modifiers #
@@ -138,19 +67,84 @@ class Households:
     def get_household_details(self, idx: pd.Index) -> pd.DataFrame:
         """Source of the household_details pipeline"""
         pop = self.population_view.subview(["tracked", "household_id"]).get(idx)
-        household_details = pop[["household_id"]].join(
-            self._households,
-            on="household_id",
+        household_details = (
+            pop[["household_id"]]
+            .astype(HOUSEHOLD_ID_DTYPE)
+            .join(
+                self._households,
+                on="household_id",
+            )
         )
         household_details = household_details.astype(HOUSEHOLD_DETAILS_DTYPES)
         return household_details
 
-    #######################
-    # Getters and setters #
-    #######################
+    ##################
+    # Public methods #
+    ##################
 
-    def get_households(self) -> pd.DataFrame:
-        return self._households
+    def create_households(
+        self, num_households: int, housing_type: str = "Standard"
+    ) -> pd.Series:
+        """
+        Create a specified number of new households, with new, unique address_ids.
 
-    def set_households(self, households: pd.DataFrame) -> None:
-        self._households = households
+        Parameters
+        ----------
+        num_households
+            The number of households to create.
+        housing_type
+            The housing type of the new households.
+
+        Returns
+        -------
+        household_ids for the new households.
+        The length of this Series will be num_households.
+        """
+        household_ids = self._next_available_ids(num_households, taken=self._households.index)
+        address_ids = self._next_available_ids(
+            num_households, taken=self._households["address_id"]
+        )
+
+        new_households = pd.DataFrame(
+            {
+                "address_id": address_ids,
+                "housing_type": housing_type,
+            },
+            index=household_ids.astype(HOUSEHOLD_ID_DTYPE),
+        ).astype(HOUSEHOLD_DETAILS_DTYPES)
+
+        self._households = pd.concat([self._households, new_households])
+
+        return household_ids
+
+    def update_household_addresses(self, household_ids: pd.Series) -> None:
+        """
+        Changes the address_id associated with each household_id in household_ids
+        to a new, unique value.
+
+        Parameters
+        ----------
+        household_ids
+            The IDs of the households that should move to new addresses.
+        """
+        self._households, _ = update_address_ids(
+            moving_units=self._households,
+            units_that_move_ids=household_ids,
+            starting_address_id=self._first_int_available(self._households["address_id"]),
+            address_id_col_name="address_id",
+        )
+
+    ##################
+    # Helper methods #
+    ##################
+
+    @staticmethod
+    def _next_available_ids(num_ids: int, taken: pd.Series):
+        return Households._first_int_available(taken) + np.arange(num_ids)
+
+    @staticmethod
+    def _first_int_available(taken: pd.Series):
+        if len(taken) == 0:
+            return 0
+
+        return taken.max() + 1

--- a/src/vivarium_census_prl_synth_pop/components/household.py
+++ b/src/vivarium_census_prl_synth_pop/components/household.py
@@ -1,0 +1,97 @@
+import numpy as np
+import pandas as pd
+from vivarium.framework.engine import Builder
+from vivarium.framework.population import SimulantData
+from vivarium.framework.time import get_time_stamp
+
+from vivarium_census_prl_synth_pop.constants.data_values import (
+    GQ_HOUSING_TYPE_MAP,
+    HOUSING_TYPES,
+)
+
+
+class Households:
+    """Manages household details"""
+
+    def __repr__(self) -> str:
+        return "Households()"
+
+    ##############
+    # Properties #
+    ##############
+
+    @property
+    def name(self):
+        return "households"
+
+    #################
+    # Setup methods #
+    #################
+
+    def setup(self, builder: Builder):
+        self.start_time = get_time_stamp(builder.configuration.time.start)
+
+        self.randomness = builder.randomness.get_stream(self.name)
+        self.columns_used = [
+            "tracked",
+            "household_id",
+        ]
+
+        self.population_view = builder.population.get_view(self.columns_used)
+
+        self.households = None
+        self.household_details = builder.value.register_value_producer(
+            "household_details",
+            source=self.get_household_details,
+            requires_columns=["household_id", "tracked"],
+        )
+
+        builder.population.initializes_simulants(
+            self.on_initialize_simulants,
+            requires_columns=["household_id"],
+        )
+
+    ########################
+    # Event-driven methods #
+    ########################
+
+    def on_initialize_simulants(self, pop_data: SimulantData) -> None:
+        """
+        add addresses to each household in the population table
+        """
+        if pop_data.creation_time < self.start_time:  # initial pop
+            self.households = self.generate_initial_households(pop_data)
+
+    ##################
+    # Helper methods #
+    ##################
+
+    def generate_initial_households(self, pop_data: SimulantData) -> pd.DataFrame():
+        households = self.population_view.subview(["household_id"]).get(pop_data.index)
+        households = (
+            households.drop_duplicates().sort_values("household_id").set_index("household_id")
+        )
+        households["address_id"] = np.arange(len(households))
+        households["housing_type"] = households.index.map(GQ_HOUSING_TYPE_MAP).fillna(
+            "Standard"
+        )
+        # set housing type dtype
+        households["housing_type"] = households["housing_type"].astype(
+            pd.CategoricalDtype(categories=HOUSING_TYPES)
+        )
+
+        return households
+
+    def get_household_details(self, idx: pd.Index) -> pd.DataFrame:
+        """Source of the household_details pipeline"""
+        pop = self.population_view.get(idx)[["household_id"]]
+        household_details = pop.join(
+            self.households,
+            on="household_id",
+        )
+        # FIXME: why is the `housing_type` column losing its CategoricalDtype?
+        household_details["housing_type"] = household_details["housing_type"].astype(
+            pd.CategoricalDtype(categories=HOUSING_TYPES)
+        )
+
+        return household_details

--- a/src/vivarium_census_prl_synth_pop/components/household.py
+++ b/src/vivarium_census_prl_synth_pop/components/household.py
@@ -135,6 +135,11 @@ class Households:
 
     @staticmethod
     def _next_available_ids(num_ids: int, taken: pd.Series):
+        # NOTE: Our approach to finding available IDs assumes that households are never deleted --
+        # because if the household with the highest ID were deleted, and we only used the current
+        # state to find available IDs, we would re-assign that ID!
+        # No deletion is guaranteed by the inability to delete households through the public
+        # methods above.
         return Households._first_int_available(taken) + np.arange(num_ids)
 
     @staticmethod

--- a/src/vivarium_census_prl_synth_pop/components/household.py
+++ b/src/vivarium_census_prl_synth_pop/components/household.py
@@ -39,14 +39,18 @@ class Households:
         self.population_view = builder.population.get_view(self.columns_used)
 
         # GQ households are special, with fixed IDs
+        gq_household_ids = (
+            pd.Series(data_values.GQ_HOUSING_TYPE_MAP.keys())
+            .astype(HOUSEHOLD_ID_DTYPE)
+            .rename("household_id")
+        )
         self._households = pd.DataFrame(
             {
                 "address_id": data_values.GQ_HOUSING_TYPE_MAP.keys(),
                 "housing_type": data_values.GQ_HOUSING_TYPE_MAP.values(),
             },
-            index=data_values.GQ_HOUSING_TYPE_MAP.keys().astype(HOUSEHOLD_ID_DTYPE),
+            index=gq_household_ids,
         ).astype(HOUSEHOLD_DETAILS_DTYPES)
-        self._households.index.names = ["household_id"]
 
         self.household_details = builder.value.register_value_producer(
             "household_details",

--- a/src/vivarium_census_prl_synth_pop/components/household.py
+++ b/src/vivarium_census_prl_synth_pop/components/household.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pandas as pd
 from vivarium.framework.engine import Builder
-from vivarium.framework.time import get_time_stamp
 
 from vivarium_census_prl_synth_pop.constants import data_values
 from vivarium_census_prl_synth_pop.utilities import update_address_ids
@@ -32,11 +31,6 @@ class Households:
     #################
 
     def setup(self, builder: Builder):
-        self.pop_config = builder.configuration.population
-        self.seed = builder.configuration.randomness.random_seed
-        self.start_time = get_time_stamp(builder.configuration.time.start)
-
-        self.randomness = builder.randomness.get_stream(self.name)
         self.columns_used = [
             "tracked",
             "household_id",

--- a/src/vivarium_census_prl_synth_pop/components/household.py
+++ b/src/vivarium_census_prl_synth_pop/components/household.py
@@ -3,7 +3,6 @@ import pandas as pd
 from vivarium.framework.engine import Builder
 
 from vivarium_census_prl_synth_pop.constants import data_values
-from vivarium_census_prl_synth_pop.utilities import update_address_ids
 
 HOUSEHOLD_ID_DTYPE = int
 HOUSEHOLD_DETAILS_DTYPES = {
@@ -125,12 +124,10 @@ class Households:
         household_ids
             The IDs of the households that should move to new addresses.
         """
-        self._households, _ = update_address_ids(
-            moving_units=self._households,
-            units_that_move_ids=household_ids,
-            starting_address_id=self._first_int_available(self._households["address_id"]),
-            address_id_col_name="address_id",
+        new_address_ids = self._next_available_ids(
+            len(household_ids), taken=self._households["address_id"]
         )
+        self._households.loc[household_ids, "address_id"] = new_address_ids
 
     ##################
     # Helper methods #

--- a/src/vivarium_census_prl_synth_pop/components/household_migration.py
+++ b/src/vivarium_census_prl_synth_pop/components/household_migration.py
@@ -88,12 +88,4 @@ class HouseholdMigration:
             "moving_households",
         )
 
-        households = self.households.get_households()
-        households, _ = update_address_ids(
-            moving_units=households,
-            units_that_move_ids=movers["household_id"],
-            starting_address_id=households["address_id"].max() + 1,
-            address_id_col_name="address_id",
-        )
-
-        self.households.set_households(households)
+        self.households.update_household_addresses(movers["household_id"])

--- a/src/vivarium_census_prl_synth_pop/components/household_migration.py
+++ b/src/vivarium_census_prl_synth_pop/components/household_migration.py
@@ -1,15 +1,9 @@
-import numpy as np
 import pandas as pd
 from vivarium.framework.engine import Builder
 from vivarium.framework.event import Event
-from vivarium.framework.population import SimulantData
 from vivarium.framework.time import get_time_stamp
 
 from vivarium_census_prl_synth_pop.constants import metadata, paths
-from vivarium_census_prl_synth_pop.constants.data_values import (
-    GQ_HOUSING_TYPE_MAP,
-    HOUSING_TYPES,
-)
 from vivarium_census_prl_synth_pop.utilities import update_address_ids
 
 
@@ -39,8 +33,8 @@ class HouseholdMigration:
     #################
 
     def setup(self, builder: Builder):
-        self.config = builder.configuration
         self.start_time = get_time_stamp(builder.configuration.time.start)
+        self.households = builder.components.get_component("households")
 
         move_rate_data = builder.lookup.build_table(
             data=pd.read_csv(
@@ -56,24 +50,12 @@ class HouseholdMigration:
 
         self.randomness = builder.randomness.get_stream(self.name)
         self.columns_used = [
-            "tracked",
             "household_id",
             "relation_to_household_head",
         ]
 
         self.population_view = builder.population.get_view(self.columns_used)
 
-        self.households = None
-        self.household_details = builder.value.register_value_producer(
-            "household_details",
-            source=self.get_household_details,
-            requires_columns=["household_id", "tracked"],
-        )
-
-        builder.population.initializes_simulants(
-            self.on_initialize_simulants,
-            requires_columns=["household_id"],
-        )
         builder.event.register_listener(
             "time_step",
             self.on_time_step,
@@ -84,24 +66,12 @@ class HouseholdMigration:
     # Event-driven methods #
     ########################
 
-    def on_initialize_simulants(self, pop_data: SimulantData) -> None:
-        """
-        add addresses to each household in the population table
-        """
-        if pop_data.creation_time < self.start_time:  # initial pop
-            self.households = self.generate_initial_households(pop_data)
-
     def on_time_step(self, event: Event):
         """
         choose which households move;
         move those households to a new address
         """
-        # NOTE: Currently, it is possible for a household not to have a living reference person;
-        # in this case, that household can no longer move.
-        pop = self.population_view.get(
-            event.index,
-            query="alive == 'alive' and tracked",
-        )
+        pop = self.population_view.get(event.index, query="alive == 'alive'")
         reference_people = pop[pop["relation_to_household_head"] == "Reference person"]
 
         household_sizes = pop.groupby("household_id").size()
@@ -118,45 +88,11 @@ class HouseholdMigration:
             "moving_households",
         )
 
-        self.households, _ = update_address_ids(
-            moving_units=self.households,
+        self.households.households, _ = update_address_ids(
+            moving_units=self.households.households,
             units_that_move_ids=movers["household_id"],
-            starting_address_id=self.households["address_id"].max() + 1,
+            starting_address_id=self.households.households["address_id"].max() + 1,
             address_id_col_name="address_id",
         )
 
         self.population_view.update(pop)
-
-    ##################
-    # Helper methods #
-    ##################
-
-    def generate_initial_households(self, pop_data: SimulantData) -> pd.DataFrame():
-        households = self.population_view.subview(["household_id"]).get(pop_data.index)
-        households = (
-            households.drop_duplicates().sort_values("household_id").set_index("household_id")
-        )
-        households["address_id"] = np.arange(len(households))
-        households["housing_type"] = households.index.map(GQ_HOUSING_TYPE_MAP).fillna(
-            "Standard"
-        )
-        # set housing type dtype
-        households["housing_type"] = households["housing_type"].astype(
-            pd.CategoricalDtype(categories=HOUSING_TYPES)
-        )
-
-        return households
-
-    def get_household_details(self, idx: pd.Index) -> pd.DataFrame:
-        """Source of the household_details pipeline"""
-        pop = self.population_view.get(idx)[["household_id"]]
-        household_details = pop.join(
-            self.households,
-            on="household_id",
-        )
-        # FIXME: why is the `housing_type` column losing its CategoricalDtype?
-        household_details["housing_type"] = household_details["housing_type"].astype(
-            pd.CategoricalDtype(categories=HOUSING_TYPES)
-        )
-
-        return household_details

--- a/src/vivarium_census_prl_synth_pop/components/household_migration.py
+++ b/src/vivarium_census_prl_synth_pop/components/household_migration.py
@@ -4,7 +4,6 @@ from vivarium.framework.event import Event
 from vivarium.framework.time import get_time_stamp
 
 from vivarium_census_prl_synth_pop.constants import metadata, paths
-from vivarium_census_prl_synth_pop.utilities import update_address_ids
 
 
 class HouseholdMigration:

--- a/src/vivarium_census_prl_synth_pop/components/person_emigration.py
+++ b/src/vivarium_census_prl_synth_pop/components/person_emigration.py
@@ -36,7 +36,7 @@ class PersonEmigration:
 
     def setup(self, builder: Builder):
         self.randomness = builder.randomness.get_stream(self.name)
-        self.household_migration = builder.components.get_component("household_migration")
+        self.households = builder.components.get_component("households")
         self.columns_needed = [
             "relation_to_household_head",
             "in_united_states",
@@ -110,7 +110,7 @@ class PersonEmigration:
             event.index,
             query="alive == 'alive' and in_united_states == True and tracked == True",
         )
-        household_details = self.household_migration.household_details(pop.index)
+        household_details = self.households.household_details(pop.index)
         non_reference_people_idx = pop.index[
             (household_details["housing_type"] == "Standard")
             & (pop["relation_to_household_head"] != "Reference person")

--- a/src/vivarium_census_prl_synth_pop/components/person_emigration.py
+++ b/src/vivarium_census_prl_synth_pop/components/person_emigration.py
@@ -36,7 +36,6 @@ class PersonEmigration:
 
     def setup(self, builder: Builder):
         self.randomness = builder.randomness.get_stream(self.name)
-        self.households = builder.components.get_component("households")
         self.household_details = builder.value.get_value("household_details")
         self.columns_needed = [
             "relation_to_household_head",

--- a/src/vivarium_census_prl_synth_pop/components/person_migration.py
+++ b/src/vivarium_census_prl_synth_pop/components/person_migration.py
@@ -156,25 +156,11 @@ class PersonMigration:
         """
         Create a new single-person household for each person in movers and move them to it.
         """
-        households = self.households.get_households()
-        first_new_household_id = households.index.max() + 1
-        new_household_ids = first_new_household_id + np.arange(len(movers))
-        first_new_household_address_id = households["address_id"].max() + 1
+        new_household_ids = self.households.create_households(len(movers))
 
         # update pop table
         pop.loc[movers, "household_id"] = new_household_ids
         pop.loc[movers, "relation_to_household_head"] = "Reference person"
-
-        # update households object
-        new_households = pd.DataFrame(
-            {
-                "household_id": new_household_ids,
-                "housing_type": "Standard",
-                "address_id": first_new_household_address_id + np.arange(len(movers)),
-            }
-        ).set_index("household_id")
-        households = pd.concat([households, new_households], axis=0)
-        self.households.set_households(households)
 
         return pop
 

--- a/src/vivarium_census_prl_synth_pop/components/population.py
+++ b/src/vivarium_census_prl_synth_pop/components/population.py
@@ -177,7 +177,8 @@ class Population:
             weights=standard_households["household_weight"],
         )
 
-        # create unique id for resampled households
+        # create unique id for resampled households -- each census_household_id
+        # can be sampled multiple times.
         chosen_households = pd.DataFrame(
             {
                 "census_household_id": chosen_households,

--- a/src/vivarium_census_prl_synth_pop/components/population.py
+++ b/src/vivarium_census_prl_synth_pop/components/population.py
@@ -162,12 +162,15 @@ class Population:
         self.population_view.update(pop)
 
     def choose_standard_households(self, target_number_sims: int) -> pd.DataFrame:
+        standard_households = self.population_data["households"][
+            self.population_data["households"]["household_type"] == "Housing unit"
+        ]
         # oversample households
         chosen_households = vectorized_choice(
-            options=self.population_data["households"]["census_household_id"],
+            options=standard_households["census_household_id"],
             n_to_choose=target_number_sims,
             randomness_stream=self.randomness,
-            weights=self.population_data["households"]["household_weight"],
+            weights=standard_households["household_weight"],
         )
 
         # create unique id for resampled households
@@ -202,9 +205,9 @@ class Population:
         return chosen_persons
 
     def choose_group_quarters(self, target_number_sims: int) -> pd.Series:
-        group_quarters = self.population_data["households"].pipe(
-            lambda df: df[df["census_household_id"].str.contains("GQ")]
-        )
+        group_quarters = self.population_data["households"][
+            self.population_data["households"]["household_type"] != "Housing unit"
+        ]
 
         # group quarters each house one person per census_household_id
         # they have NA household weights, but appropriately weighted person weights.

--- a/src/vivarium_census_prl_synth_pop/constants/metadata.py
+++ b/src/vivarium_census_prl_synth_pop/constants/metadata.py
@@ -234,7 +234,7 @@ US_STATE_ABBRV_MAP = {
     "Wisconsin": "WI",
     "Wyoming": "WY",
     "District of Columbia": "DC",
-    "Puerto Rico": "PR",
+    # "Puerto Rico": "PR",
 }
 
 P_GROUP_QUARTERS = 0.03

--- a/src/vivarium_census_prl_synth_pop/constants/metadata.py
+++ b/src/vivarium_census_prl_synth_pop/constants/metadata.py
@@ -32,7 +32,16 @@ HOUSEHOLDS_COLUMN_MAP = {
     "SERIALNO": "census_household_id",
     "PUMA": "puma",
     "WGTP": "household_weight",
+    "TYPEHUGQ": "household_type",
 }
+
+HOUSEHOLD_TYPE_MAP = {
+    1: "Housing unit",
+    2: "Institutional group quarters",
+    3: "Noninstitutional group quarters",
+}
+HOUSEHOLD_TYPES = list(HOUSEHOLD_TYPE_MAP.values())
+
 PERSONS_COLUMNS_TO_INITIALIZE = [
     "census_household_id",
     "age",
@@ -108,6 +117,7 @@ PERSONS_COLUMNS_MAP = {
     "RAC1P": "race",
     "NATIVITY": "born_in_us",
     "MIG": "immigrated_in_last_year",
+    "PWGTP": "person_weight",
 }
 
 SUBSET_PERSONS_COLUMNS_MAP = {

--- a/src/vivarium_census_prl_synth_pop/data/loader.py
+++ b/src/vivarium_census_prl_synth_pop/data/loader.py
@@ -140,6 +140,13 @@ def load_households(key: str, location: str) -> pd.DataFrame:
         location=location,
     )
 
+    # map household_type
+    data["household_type"] = (
+        data["household_type"]
+        .map(metadata.HOUSEHOLD_TYPE_MAP)
+        .astype(pd.CategoricalDtype(categories=metadata.HOUSEHOLD_TYPES))
+    )
+
     # read in persons file to find which household_ids it contains
     persons = load_raw_persons_data(metadata.SUBSET_PERSONS_COLUMNS_MAP, location)
 
@@ -156,7 +163,14 @@ def load_households(key: str, location: str) -> pd.DataFrame:
     )
 
     data = data.set_index(
-        ["state", "puma", "census_household_id", "household_weight", "person_weight"]
+        [
+            "state",
+            "puma",
+            "census_household_id",
+            "household_type",
+            "household_weight",
+            "person_weight",
+        ]
     )
 
     return data

--- a/src/vivarium_census_prl_synth_pop/model_specifications/model_spec.yaml
+++ b/src/vivarium_census_prl_synth_pop/model_specifications/model_spec.yaml
@@ -2,6 +2,7 @@ components:
     vivarium_census_prl_synth_pop:
         components:
             - Population()
+            - Households()
             - HouseholdMigration()
             - PersonMigration()
             - HouseholdEmigration()

--- a/src/vivarium_census_prl_synth_pop/utilities.py
+++ b/src/vivarium_census_prl_synth_pop/utilities.py
@@ -8,7 +8,7 @@ import pandas as pd
 from loguru import logger
 from scipy import stats
 from vivarium.framework.lookup import LookupTable
-from vivarium.framework.randomness import Array, RandomnessStream, get_hash, random
+from vivarium.framework.randomness import Array, RandomnessStream, get_hash
 from vivarium.framework.values import Pipeline
 
 from vivarium_census_prl_synth_pop.constants import metadata
@@ -169,7 +169,7 @@ def get_norm_from_quantiles(
 def vectorized_choice(
     options: Array,
     n_to_choose: int,
-    randomness_stream: RandomnessStream = None,
+    randomness_stream: RandomnessStream,
     weights: Array = None,
     additional_key: Any = None,
 ):
@@ -178,10 +178,7 @@ def vectorized_choice(
         weights = np.ones(n) / n
     # for each of n_to_choose, sample uniformly between 0 and 1
     index = pd.Index(np.arange(n_to_choose))
-    if randomness_stream is None:
-        probs = random(str(additional_key), index)
-    else:
-        probs = randomness_stream.get_draw(index, additional_key=additional_key)
+    probs = randomness_stream.get_draw(np.arange(n_to_choose), additional_key=additional_key)
 
     # build cdf based on weights
     pmf = weights / weights.sum()
@@ -289,7 +286,6 @@ def update_address_ids(
 
     Returns
     -------
-    pop: Updated version of the state table.
     moving_units: Updated version of units dataframe.  This is done for the purpose of the businesses table.
     starting_address_id: Updated integer at which to start when generating more address_ids.
     """

--- a/src/vivarium_census_prl_synth_pop/utilities.py
+++ b/src/vivarium_census_prl_synth_pop/utilities.py
@@ -177,7 +177,6 @@ def vectorized_choice(
         n = len(options)
         weights = np.ones(n) / n
     # for each of n_to_choose, sample uniformly between 0 and 1
-    index = pd.Index(np.arange(n_to_choose))
     probs = randomness_stream.get_draw(np.arange(n_to_choose), additional_key=additional_key)
 
     # build cdf based on weights

--- a/src/vivarium_census_prl_synth_pop/utilities.py
+++ b/src/vivarium_census_prl_synth_pop/utilities.py
@@ -267,37 +267,6 @@ def build_output_dir(output_dir: Path, subdir: Optional[Union[str, Path]] = None
     return output_dir
 
 
-def update_address_ids(
-    moving_units: pd.DataFrame,
-    units_that_move_ids: pd.Index,
-    starting_address_id: int,
-    address_id_col_name: str,
-) -> Tuple[pd.DataFrame, int]:
-    """
-    Updates address_ids in the appropriate data structure (households or businesses)
-
-    Parameters
-    ----------
-    moving_units: Dataframe with column address_id_col_name.
-    units_that_move_ids: IDs of moving units.  This is a subset of moving_units.index
-    starting_address_id: Integer at which to start generating new address_ids, to prevent collisions.
-    address_id_col_name: Column name in state table where address_id for the unit is stored.
-
-    Returns
-    -------
-    moving_units: Updated version of units dataframe.  This is done for the purpose of the businesses table.
-    starting_address_id: Updated integer at which to start when generating more address_ids.
-    """
-
-    if len(units_that_move_ids) > 0:
-        moving_units.loc[
-            units_that_move_ids, address_id_col_name
-        ] = starting_address_id + np.arange(len(units_that_move_ids))
-        starting_address_id += len(units_that_move_ids)
-
-    return moving_units, starting_address_id
-
-
 def add_guardian_address_ids(pop: pd.DataFrame) -> pd.DataFrame:
     """Map the address ids of guardians to each simulant's guardian address columns"""
     for i in [1, 2]:

--- a/src/vivarium_census_prl_synth_pop/utilities.py
+++ b/src/vivarium_census_prl_synth_pop/utilities.py
@@ -272,7 +272,7 @@ def update_address_ids(
     units_that_move_ids: pd.Index,
     starting_address_id: int,
     address_id_col_name: str,
-) -> Tuple[pd.DataFrame, pd.DataFrame, int]:
+) -> Tuple[pd.DataFrame, int]:
     """
     Updates address_ids in the appropriate data structure (households or businesses)
 


### PR DESCRIPTION
## Refactor households state into its own component

### Description
- *Category*: refactor
- *JIRA issue*: [MIC-3801](https://jira.ihme.washington.edu/browse/MIC-3801)
- *Research reference*: none

### Changes and notes

Builds on #181, but pares down the household component's public API. New households are initialized in the same way at population setup as they are on migration (different approach than #182). GQ households are initialized in setup of the households component (different approach than #183).

I suggest we squash this PR into one commit on `main`, because the path we took to get here is not especially enlightening.

### Verification and Testing

Integration and unit tests all passing.