### PR TITLE
Do not keep ACS data longer than necessary

### DIFF
--- a/src/vivarium_census_prl_synth_pop/components/population.py
+++ b/src/vivarium_census_prl_synth_pop/components/population.py
@@ -66,6 +66,9 @@ class Population:
         ]
         self.register_simulants = builder.randomness.register_simulants
         self.population_view = builder.population.get_view(self.columns_created)
+
+        # HACK: ACS data must be loaded in setup, since it comes from the artifact;
+        # however, we only use it while creating the initial population.
         self.population_data = self._load_population_data(builder)
 
         self.updated_relation_to_reference_person = builder.value.register_value_producer(
@@ -96,6 +99,10 @@ class Population:
         # at start of sim, generate base population
         if pop_data.creation_time < self.start_time:
             self.generate_initial_population(pop_data)
+            # HACK: ACS data must be loaded in setup, since it comes from the artifact;
+            # however, we don't need it after creating the initial population and want to avoid keeping
+            # it in memory.
+            self.population_data = None
         # if new simulants are born into the sim
         else:
             self.initialize_newborns(pop_data)


### PR DESCRIPTION
## Do not keep ACS data longer than necessary

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: performance
- *JIRA issue*: none
- *Research reference*: none

### Changes and notes

This should free up the memory (once it is garbage collected) after we are done with the ACS data, which is quite large.

### Verification and Testing

Integration tests passing.