### PR TITLE
Correct GQ definition in artifact loading

### DIFF
--- a/src/vivarium_census_prl_synth_pop/data/loader.py
+++ b/src/vivarium_census_prl_synth_pop/data/loader.py
@@ -343,7 +343,6 @@ def _read_and_format_raw_data(
         ]
     )
 
-    data["SERIALNO"] = data["SERIALNO"].astype(str)
     data = data.rename(columns=column_map)
 
     if location == "United States of America":


### PR DESCRIPTION
## Correct GQ definition in artifact loading

### Description
- *Category*: bugfix
- *JIRA issue*: [MIC-3807](https://jira.ihme.washington.edu/browse/MIC-3807)
- *Research reference*: none

### Changes and notes

This was previously changed in simulation code (#167) but I missed a spot where the same assumption was made in artifact loading. Therefore, GQ households in 2017 and earlier had NaN person_weights.

### Verification and Testing

Generated an artifact using this code; integration tests are passing with that artifact. Stepped through ACS sampling to check that NaN weights were no longer being sampled from.