### PR TITLE
Feature/mic 3793 po box

### DIFF
--- a/integration_tests/test_domestic_migration.py
+++ b/integration_tests/test_domestic_migration.py
@@ -173,7 +173,7 @@ def check_po_box_collisions(after, before, movers):
     assert (
         before[po_box_movers]["household_details.po_box"]
         == after[po_box_movers]["household_details.po_box"]
-    ).sum() < int(po_box_movers.sum() * 0.005)
+    ).sum() <= int(po_box_movers.sum() * 0.05)
 
 
 def test_only_living_people_change_households(simulants_on_adjacent_timesteps):

--- a/integration_tests/test_domestic_migration.py
+++ b/integration_tests/test_domestic_migration.py
@@ -1,6 +1,7 @@
 import pandas as pd
 import pytest
 
+from integration_tests.conftest import TIME_STEPS_TO_TEST
 from vivarium_census_prl_synth_pop.constants import data_values
 
 # TODO: Broader test coverage
@@ -14,6 +15,7 @@ def test_individuals_move(simulants_on_adjacent_timesteps):
             before[individual_movers]["household_details.address_id"]
             != after[individual_movers]["household_details.address_id"]
         ).all()
+        check_po_box_collisions(after, before, individual_movers)
 
 
 def test_individuals_move_into_new_households(simulants_on_adjacent_timesteps):
@@ -159,6 +161,20 @@ def test_households_move(simulants_on_adjacent_timesteps):
             before[household_movers]["household_details.housing_type"] == "Standard"
         ).all()
 
+        check_po_box_collisions(after, before, household_movers)
+
+
+def check_po_box_collisions(after, before, movers):
+    """Assert that the number of PO Box collisions are miniscule."""
+    po_box_movers = (
+        (before["household_details.po_box"] != data_values.NO_PO_BOX)
+        | (after["household_details.po_box"] != data_values.NO_PO_BOX)
+    ) & movers
+    assert (
+        before[po_box_movers]["household_details.po_box"]
+        == after[po_box_movers]["household_details.po_box"]
+    ).sum() < int(po_box_movers.sum() * 0.005)
+
 
 def test_only_living_people_change_households(simulants_on_adjacent_timesteps):
     for before, after in simulants_on_adjacent_timesteps:
@@ -172,6 +188,7 @@ def test_only_living_people_change_households(simulants_on_adjacent_timesteps):
     [
         ("employer_id", "business_details.employer_address_id"),
         ("household_id", "household_details.address_id"),
+        ("household_id", "household_details.po_box"),
     ],
 )
 def test_unit_address_uniqueness(populations, unit_id_col, address_id_col):
@@ -182,8 +199,9 @@ def test_unit_address_uniqueness(populations, unit_id_col, address_id_col):
     for pop in populations:
         # Check that all simulants in the same unit have the same address
         assert (pop.groupby(unit_id_col)[address_cols].nunique() == 1).all().all()
-        # Check that all units have unique addresses
-        assert (pop.groupby(address_cols)[unit_id_col].nunique() == 1).all()
+        # Check that all units have unique addresses (unless it's a PO Box, which has relaxed requirements)
+        if address_id_col != "household_details.po_box":
+            assert (pop.groupby(address_cols)[unit_id_col].nunique() == 1).all()
 
     # # TODO implement state/puma checks
     # # Ensure pumas map to correct state. This will be an imperfect test
@@ -246,3 +264,19 @@ def test_addresses_during_moves(simulants_on_adjacent_timesteps, unit_id_col, ad
         # assert (
         #     before.loc[mask_movers, "puma"] != after.loc[mask_movers, "puma"]
         # ).sum() / mask_movers.sum() >= 0.95
+
+
+def test_po_box_probability(populations):
+    """Tests that the prevalence of PO Boxes and ."""
+    for pop in populations:
+        # Check that actual proportion of households with PO Boxes is close to the expected
+        no_po_box = len(
+            pop.groupby("household_id").apply(lambda x: x)["household_details.po_box"]
+            != data_values.NO_PO_BOX
+        ) / len(pop.groupby("household_id"))
+
+        # Check that all simulants in the same unit have the same address
+        # assert (pop.groupby("household_id")[address_cols].nunique() == 1).all().all()
+        # # Check that all units have unique addresses (unless it's a PO Box, which has relaxed requirements)
+        # if address_id_col != "household_details.po_box":
+        #     assert (pop.groupby(address_cols)[unit_id_col].nunique() == 1).all()

--- a/integration_tests/test_domestic_migration.py
+++ b/integration_tests/test_domestic_migration.py
@@ -165,7 +165,8 @@ def test_households_move(simulants_on_adjacent_timesteps):
 
 
 def check_po_box_collisions(after, before, movers):
-    """Assert that the number of PO Box collisions are miniscule."""
+    """Assert that the number of PO Box collisions are miniscule. Movers
+    assumed to have address_id changes."""
     po_box_movers = (
         (before["household_details.po_box"] != data_values.NO_PO_BOX)
         | (after["household_details.po_box"] != data_values.NO_PO_BOX)

--- a/integration_tests/test_group_quarters.py
+++ b/integration_tests/test_group_quarters.py
@@ -34,8 +34,18 @@ def test_gq_relationship_column(tracked_live_populations):
 
 
 @pytest.mark.parametrize("time_step", TIME_STEPS_TO_TEST)
-def test_gq_housing_type_column(tracked_live_populations, time_step):
+def test_gq_address_columns(tracked_live_populations, time_step):
+    """Tests that simulants' `housing_type` and `po_box` columns are as expected."""
     pop = tracked_live_populations[time_step]
+
+    # All people in GQ do not have PO Box
+    assert (
+        pop[pop["household_details.address_id"].isin(data_values.GQ_HOUSING_TYPE_MAP.keys())][
+            "household_details.po_box"
+        ]
+        == data_values.NO_PO_BOX
+    ).all()
+
     # All people in institutional GQ have a correct housing type
     assert (
         (

--- a/src/vivarium_census_prl_synth_pop/components/household.py
+++ b/src/vivarium_census_prl_synth_pop/components/household.py
@@ -134,7 +134,9 @@ class Households:
         new_address_ids = self._next_available_ids(
             len(household_ids), taken=self._households["address_id"]
         )
+        po_boxes = self.generate_po_boxes(len(household_ids))
         self._households.loc[household_ids, "address_id"] = new_address_ids
+        self._households.loc[household_ids, "po_box"] = po_boxes
 
     ##################
     # Helper methods #

--- a/src/vivarium_census_prl_synth_pop/components/household.py
+++ b/src/vivarium_census_prl_synth_pop/components/household.py
@@ -38,7 +38,7 @@ class Households:
         ]
 
         self.population_view = builder.population.get_view(self.columns_used)
-        self.clock = builder.time.clock()
+        # self.clock = builder.time.clock()
 
         # GQ households are special, with fixed IDs
         gq_household_ids = (
@@ -161,7 +161,8 @@ class Households:
         different_mailing_physical_addresses = self.randomness.filter_for_probability(
             pd.Index(list(range(num_addresses))),
             1 - data_values.PROBABILITY_OF_SAME_MAILING_PHYSICAL_ADDRESS,
-            additional_key=f"po_box_filter_{self.clock}",
+            # additional_key=f"po_box_filter_{self.clock}",
+            additional_key="po_box_filter",
         )
         po_boxes = pd.Series(
             data_values.NO_PO_BOX, index=pd.Index(list(range(num_addresses)))
@@ -171,6 +172,7 @@ class Households:
             max_val=20_000,
             index=different_mailing_physical_addresses,
             randomness=self.randomness,
-            additional_key=f"po_box_int_{self.clock}",
+            # additional_key=f"po_box_int_{self.clock}",
+            additional_key="po_box_number",
         )
         return np.array(po_boxes)

--- a/src/vivarium_census_prl_synth_pop/components/household.py
+++ b/src/vivarium_census_prl_synth_pop/components/household.py
@@ -38,7 +38,7 @@ class Households:
         ]
 
         self.population_view = builder.population.get_view(self.columns_used)
-        # self.clock = builder.time.clock()
+        self.clock = builder.time.clock()
 
         # GQ households are special, with fixed IDs
         gq_household_ids = (
@@ -161,8 +161,8 @@ class Households:
         different_mailing_physical_addresses = self.randomness.filter_for_probability(
             pd.Index(list(range(num_addresses))),
             1 - data_values.PROBABILITY_OF_SAME_MAILING_PHYSICAL_ADDRESS,
-            # additional_key=f"po_box_filter_{self.clock}",
-            additional_key="po_box_filter",
+            additional_key=f"po_box_filter_{self.clock()}",
+            # additional_key="po_box_filter",
         )
         po_boxes = pd.Series(
             data_values.NO_PO_BOX, index=pd.Index(list(range(num_addresses)))
@@ -172,7 +172,7 @@ class Households:
             max_val=20_000,
             index=different_mailing_physical_addresses,
             randomness=self.randomness,
-            # additional_key=f"po_box_int_{self.clock}",
-            additional_key="po_box_number",
+            additional_key=f"po_box_int_{self.clock()}",
+            # additional_key="po_box_number",
         )
         return np.array(po_boxes)

--- a/src/vivarium_census_prl_synth_pop/components/household.py
+++ b/src/vivarium_census_prl_synth_pop/components/household.py
@@ -38,7 +38,6 @@ class Households:
         ]
 
         self.population_view = builder.population.get_view(self.columns_used)
-        self.clock = builder.time.clock()
 
         # GQ households are special, with fixed IDs
         gq_household_ids = (
@@ -161,8 +160,7 @@ class Households:
         different_mailing_physical_addresses = self.randomness.filter_for_probability(
             pd.Index(list(range(num_addresses))),
             1 - data_values.PROBABILITY_OF_SAME_MAILING_PHYSICAL_ADDRESS,
-            additional_key=f"po_box_filter_{self.clock()}",
-            # additional_key="po_box_filter",
+            additional_key="po_box_filter",
         )
         po_boxes = pd.Series(
             data_values.NO_PO_BOX, index=pd.Index(list(range(num_addresses)))
@@ -172,7 +170,6 @@ class Households:
             max_val=20_000,
             index=different_mailing_physical_addresses,
             randomness=self.randomness,
-            additional_key=f"po_box_int_{self.clock()}",
-            # additional_key="po_box_number",
+            additional_key="po_box_number",
         )
         return np.array(po_boxes)

--- a/src/vivarium_census_prl_synth_pop/components/household.py
+++ b/src/vivarium_census_prl_synth_pop/components/household.py
@@ -38,7 +38,7 @@ class Households:
         ]
 
         self.population_view = builder.population.get_view(self.columns_used)
-        self.clock = builder.time.clock
+        self.clock = builder.time.clock()
 
         # GQ households are special, with fixed IDs
         gq_household_ids = (

--- a/src/vivarium_census_prl_synth_pop/components/household.py
+++ b/src/vivarium_census_prl_synth_pop/components/household.py
@@ -38,6 +38,7 @@ class Households:
         ]
 
         self.population_view = builder.population.get_view(self.columns_used)
+        self.clock = builder.time.clock()
 
         # GQ households are special, with fixed IDs
         gq_household_ids = (
@@ -160,7 +161,7 @@ class Households:
         different_mailing_physical_addresses = self.randomness.filter_for_probability(
             pd.Index(list(range(num_addresses))),
             1 - data_values.PROBABILITY_OF_SAME_MAILING_PHYSICAL_ADDRESS,
-            additional_key="po_box_filter",
+            additional_key=f"po_box_filter_{self.clock}",
         )
         po_boxes = pd.Series(
             data_values.NO_PO_BOX, index=pd.Index(list(range(num_addresses)))
@@ -170,6 +171,6 @@ class Households:
             max_val=20_000,
             index=different_mailing_physical_addresses,
             randomness=self.randomness,
-            additional_key="po_box_number",
+            additional_key=f"po_box_int_{self.clock}",
         )
         return np.array(po_boxes)

--- a/src/vivarium_census_prl_synth_pop/components/household.py
+++ b/src/vivarium_census_prl_synth_pop/components/household.py
@@ -38,7 +38,7 @@ class Households:
         ]
 
         self.population_view = builder.population.get_view(self.columns_used)
-        self.clock = builder.time.clock()
+        self.clock = builder.time.clock
 
         # GQ households are special, with fixed IDs
         gq_household_ids = (

--- a/src/vivarium_census_prl_synth_pop/components/household.py
+++ b/src/vivarium_census_prl_synth_pop/components/household.py
@@ -168,8 +168,8 @@ class Households:
             data_values.NO_PO_BOX, index=pd.Index(list(range(num_addresses)))
         )
         po_boxes.loc[different_mailing_physical_addresses] = random_integers(
-            min_val=1,
-            max_val=20_000,
+            min_val=data_values.MIN_PO_BOX,
+            max_val=data_values.MAX_PO_BOX,
             index=different_mailing_physical_addresses,
             randomness=self.randomness,
             additional_key="po_box_number",

--- a/src/vivarium_census_prl_synth_pop/components/household.py
+++ b/src/vivarium_census_prl_synth_pop/components/household.py
@@ -38,7 +38,6 @@ class Households:
         ]
 
         self.population_view = builder.population.get_view(self.columns_used)
-        self.clock = builder.time.clock()
 
         # GQ households are special, with fixed IDs
         gq_household_ids = (
@@ -161,7 +160,7 @@ class Households:
         different_mailing_physical_addresses = self.randomness.filter_for_probability(
             pd.Index(list(range(num_addresses))),
             1 - data_values.PROBABILITY_OF_SAME_MAILING_PHYSICAL_ADDRESS,
-            additional_key=f"po_box_filter_{self.clock}",
+            additional_key="po_box_filter",
         )
         po_boxes = pd.Series(
             data_values.NO_PO_BOX, index=pd.Index(list(range(num_addresses)))
@@ -171,6 +170,6 @@ class Households:
             max_val=20_000,
             index=different_mailing_physical_addresses,
             randomness=self.randomness,
-            additional_key=f"po_box_int_{self.clock}",
+            additional_key="po_box_number",
         )
         return np.array(po_boxes)

--- a/src/vivarium_census_prl_synth_pop/components/household.py
+++ b/src/vivarium_census_prl_synth_pop/components/household.py
@@ -3,11 +3,13 @@ import pandas as pd
 from vivarium.framework.engine import Builder
 
 from vivarium_census_prl_synth_pop.constants import data_values
+from vivarium_census_prl_synth_pop.utilities import random_integers
 
 HOUSEHOLD_ID_DTYPE = int
 HOUSEHOLD_DETAILS_DTYPES = {
     "address_id": int,
     "housing_type": pd.CategoricalDtype(categories=data_values.HOUSING_TYPES),
+    "po_box": int,
 }
 
 
@@ -47,6 +49,7 @@ class Households:
             {
                 "address_id": data_values.GQ_HOUSING_TYPE_MAP.keys(),
                 "housing_type": data_values.GQ_HOUSING_TYPE_MAP.values(),
+                "po_box": data_values.NO_PO_BOX,
             },
             index=gq_household_ids,
         ).astype(HOUSEHOLD_DETAILS_DTYPES)
@@ -56,6 +59,8 @@ class Households:
             source=self.get_household_details,
             requires_columns=["household_id", "tracked"],
         )
+
+        self.randomness = builder.randomness.get_stream(self.name)
 
     ##################################
     # Pipeline sources and modifiers #
@@ -101,11 +106,13 @@ class Households:
         address_ids = self._next_available_ids(
             num_households, taken=self._households["address_id"]
         )
+        po_boxes = self.generate_po_boxes(num_households)
 
         new_households = pd.DataFrame(
             {
                 "address_id": address_ids,
                 "housing_type": housing_type,
+                "po_box": po_boxes,
             },
             index=household_ids.astype(HOUSEHOLD_ID_DTYPE),
         ).astype(HOUSEHOLD_DETAILS_DTYPES)
@@ -148,3 +155,21 @@ class Households:
             return 0
 
         return taken.max() + 1
+
+    def generate_po_boxes(self, num_addresses) -> np.array:
+        different_mailing_physical_addresses = self.randomness.filter_for_probability(
+            pd.Index(list(range(num_addresses))),
+            1 - data_values.PROBABILITY_OF_SAME_MAILING_PHYSICAL_ADDRESS,
+            additional_key="po_box_filter",
+        )
+        po_boxes = pd.Series(
+            data_values.NO_PO_BOX, index=pd.Index(list(range(num_addresses)))
+        )
+        po_boxes.loc[different_mailing_physical_addresses] = random_integers(
+            min_val=1,
+            max_val=20_000,
+            index=different_mailing_physical_addresses,
+            randomness=self.randomness,
+            additional_key="po_box_number",
+        )
+        return np.array(po_boxes)

--- a/src/vivarium_census_prl_synth_pop/components/observers.py
+++ b/src/vivarium_census_prl_synth_pop/components/observers.py
@@ -552,6 +552,7 @@ class TaxW2Observer(BaseObserver):
         "ssn",
         "ssn_id",  # simulant id for ssn from another simulant
         "address_id",
+        "po_box",
         "employer_id",
         "employer_name",
         "employer_address_id",
@@ -649,8 +650,8 @@ class TaxW2Observer(BaseObserver):
         pop_full = self.population_view.get(event.index)
         household_details = self.pipelines["household_details"](pop_full.index)
         business_details = self.pipelines["business_details"](pop_full.index)
-        pop_full[["address_id", "housing_type"]] = household_details[
-            ["address_id", "housing_type"]
+        pop_full[["address_id", "housing_type", "po_box"]] = household_details[
+            ["address_id", "housing_type", "po_box"]
         ]
         pop_full[["employer_address_id", "employer_name"]] = business_details[
             ["employer_address_id", "employer_name"]
@@ -681,8 +682,9 @@ class TaxW2Observer(BaseObserver):
 
         df_w2["address_id"] = df_w2["simulant_id"].map(household_details["address_id"])
         df_w2["housing_type"] = df_w2["simulant_id"].map(household_details["housing_type"])
+        df_w2["po_box"] = df_w2["simulant_id"].map(household_details["po_box"])
 
-        # Tracked, US population to potentially have their SSNs borrowed
+        # Tracked, US population to be dependents or get their SSNs borrowed
         pop = pop_full[
             (pop_full["alive"] == "alive")
             & pop_full["tracked"]
@@ -866,7 +868,7 @@ class Tax1040Observer(BaseObserver):
         "sex",
         "ssn",
         "address_id",  # we do not need to include household_id because we can find it from address_id
-        "relation_to_household_head",  # needed to identifying couples filing jointly
+        "relation_to_household_head",  # needed to identify couples filing jointly
         "housing_type",
         "tax_year",
         "alive",

--- a/src/vivarium_census_prl_synth_pop/constants/data_values.py
+++ b/src/vivarium_census_prl_synth_pop/constants/data_values.py
@@ -47,6 +47,13 @@ REFERENCE_PERSON_UPDATE_RELATIONSHIPS_MAP = pd.read_csv(
     paths.REFERENCE_PERSON_UPDATE_RELATIONSHIP_DATA_PATH,
 )
 
+# 96.50% probability that the mailing address is the same as the physical
+#  address and the mailing ZIP code is the same as the physical ZIP code
+PROBABILITY_OF_SAME_MAILING_PHYSICAL_ADDRESS = 0.9650
+NO_PO_BOX = 0
+MIN_PO_BOX = 1
+MAX_PO_BOX = 20_000
+
 #########################
 # Synthetic Name Inputs #
 #########################

--- a/src/vivarium_census_prl_synth_pop/model_specifications/model_spec.yaml
+++ b/src/vivarium_census_prl_synth_pop/model_specifications/model_spec.yaml
@@ -11,17 +11,16 @@ components:
             - Fertility()
             - Businesses()
 
-#            - DecennialCensusObserver()
-#            - HouseholdSurveyObserver("acs")
-#            - HouseholdSurveyObserver("cps")
-#            - WICObserver()
-#            - SocialSecurityObserver()
-#            - TaxObserver()
+            - DecennialCensusObserver()
+            - HouseholdSurveyObserver("acs")
+            - HouseholdSurveyObserver("cps")
+            - WICObserver()
+            - SocialSecurityObserver()
+            - TaxObserver()
 
 configuration:
     input_data:
-#        artifact_path: '/mnt/team/simulation_science/priv/engineering/vivarium_census_prl_synth_pop/data/artifacts/united_states_of_america.hdf'
-        artifact_path: '/Users/mkappel/artifacts/prl/united_states_of_america.hdf'
+        artifact_path: '/mnt/team/simulation_science/priv/engineering/vivarium_census_prl_synth_pop/data/artifacts/united_states_of_america.hdf'
         input_draw_number: 0
     output_data:
         results_directory: '/mnt/team/simulation_science/priv/engineering/vivarium_census_prl_synth_pop/results/'
@@ -43,5 +42,4 @@ configuration:
             day: 1
         step_size: 28 # Days
     population:
-#        population_size: 250_000
-        population_size: 25_000
+        population_size: 250_000

--- a/src/vivarium_census_prl_synth_pop/model_specifications/model_spec.yaml
+++ b/src/vivarium_census_prl_synth_pop/model_specifications/model_spec.yaml
@@ -11,16 +11,17 @@ components:
             - Fertility()
             - Businesses()
 
-            - DecennialCensusObserver()
-            - HouseholdSurveyObserver("acs")
-            - HouseholdSurveyObserver("cps")
-            - WICObserver()
-            - SocialSecurityObserver()
-            - TaxObserver()
+#            - DecennialCensusObserver()
+#            - HouseholdSurveyObserver("acs")
+#            - HouseholdSurveyObserver("cps")
+#            - WICObserver()
+#            - SocialSecurityObserver()
+#            - TaxObserver()
 
 configuration:
     input_data:
-        artifact_path: '/mnt/team/simulation_science/priv/engineering/vivarium_census_prl_synth_pop/data/artifacts/united_states_of_america.hdf'
+#        artifact_path: '/mnt/team/simulation_science/priv/engineering/vivarium_census_prl_synth_pop/data/artifacts/united_states_of_america.hdf'
+        artifact_path: '/Users/mkappel/artifacts/prl/united_states_of_america.hdf'
         input_draw_number: 0
     output_data:
         results_directory: '/mnt/team/simulation_science/priv/engineering/vivarium_census_prl_synth_pop/results/'
@@ -42,4 +43,5 @@ configuration:
             day: 1
         step_size: 28 # Days
     population:
-        population_size: 250_000
+#        population_size: 250_000
+        population_size: 25_000

--- a/src/vivarium_census_prl_synth_pop/model_specifications/model_spec.yaml
+++ b/src/vivarium_census_prl_synth_pop/model_specifications/model_spec.yaml
@@ -11,17 +11,16 @@ components:
             - Fertility()
             - Businesses()
 
-#            - DecennialCensusObserver()
-#            - HouseholdSurveyObserver("acs")
-#            - HouseholdSurveyObserver("cps")
-#            - WICObserver()
-#            - SocialSecurityObserver()
+            - DecennialCensusObserver()
+            - HouseholdSurveyObserver("acs")
+            - HouseholdSurveyObserver("cps")
+            - WICObserver()
+            - SocialSecurityObserver()
             - TaxObserver()
 
 configuration:
     input_data:
-#        artifact_path: '/mnt/team/simulation_science/priv/engineering/vivarium_census_prl_synth_pop/data/artifacts/united_states_of_america.hdf'
-        artifact_path: '/Users/mkappel/artifacts/prl/united_states_of_america.hdf'
+        artifact_path: '/mnt/team/simulation_science/priv/engineering/vivarium_census_prl_synth_pop/data/artifacts/united_states_of_america.hdf'
         input_draw_number: 0
     output_data:
         results_directory: '/mnt/team/simulation_science/priv/engineering/vivarium_census_prl_synth_pop/results/'
@@ -41,8 +40,6 @@ configuration:
             year: 2030
             month: 5
             day: 1
-#        step_size: 28 # Days
-        step_size: 168 # Days
+        step_size: 28 # Days
     population:
-#        population_size: 250_000
-        population_size: 2_500
+        population_size: 250_000

--- a/src/vivarium_census_prl_synth_pop/model_specifications/model_spec.yaml
+++ b/src/vivarium_census_prl_synth_pop/model_specifications/model_spec.yaml
@@ -11,16 +11,17 @@ components:
             - Fertility()
             - Businesses()
 
-            - DecennialCensusObserver()
-            - HouseholdSurveyObserver("acs")
-            - HouseholdSurveyObserver("cps")
-            - WICObserver()
-            - SocialSecurityObserver()
+#            - DecennialCensusObserver()
+#            - HouseholdSurveyObserver("acs")
+#            - HouseholdSurveyObserver("cps")
+#            - WICObserver()
+#            - SocialSecurityObserver()
             - TaxObserver()
 
 configuration:
     input_data:
-        artifact_path: '/mnt/team/simulation_science/priv/engineering/vivarium_census_prl_synth_pop/data/artifacts/united_states_of_america.hdf'
+#        artifact_path: '/mnt/team/simulation_science/priv/engineering/vivarium_census_prl_synth_pop/data/artifacts/united_states_of_america.hdf'
+        artifact_path: '/Users/mkappel/artifacts/prl/united_states_of_america.hdf'
         input_draw_number: 0
     output_data:
         results_directory: '/mnt/team/simulation_science/priv/engineering/vivarium_census_prl_synth_pop/results/'
@@ -40,6 +41,8 @@ configuration:
             year: 2030
             month: 5
             day: 1
-        step_size: 28 # Days
+#        step_size: 28 # Days
+        step_size: 168 # Days
     population:
-        population_size: 250_000
+#        population_size: 250_000
+        population_size: 2_500


### PR DESCRIPTION
## Add PO Box logic and tests

### Description
- *Category*: implementation
- *JIRA issue*: [MIC-3793](https://jira.ihme.washington.edu/browse/MIC-3793)
- *Research reference*: https://vivarium-research.readthedocs.io/en/latest/models/concept_models/vivarium_census_synthdata/concept_model.html#component-12-mailing-address

### Changes and notes
- Adds PO Box column to W2 observer
- Adds logic to generate PO Box randomly between 1 and 20,000
- Adds tests for PO Box changing in individual and household moves, prevalence of PO Boxes, and range checking

### Verification and Testing
All tests new and old pass.
