### PR TITLE
Add `address_id` formatter

### DIFF
--- a/src/vivarium_census_prl_synth_pop/results_processing/formatter.py
+++ b/src/vivarium_census_prl_synth_pop/results_processing/formatter.py
@@ -51,7 +51,6 @@ def format_data_for_mapping(
     obs_results: Dict[str, pd.DataFrame],
     output_columns: List[str],
 ) -> pd.DataFrame:
-
     data_to_map = [obs_data[output_columns] for obs_data in obs_results.values()]
     data = pd.concat(data_to_map).drop_duplicates()
     data = data[output_columns].set_index(index_name)

--- a/src/vivarium_census_prl_synth_pop/results_processing/formatter.py
+++ b/src/vivarium_census_prl_synth_pop/results_processing/formatter.py
@@ -25,6 +25,10 @@ def format_simulant_id(data: pd.DataFrame) -> pd.Series:
     return data["random_seed"].astype(str) + "_" + data["simulant_id"].astype(str)
 
 
+def format_address_id(data: pd.DataFrame) -> pd.Series:
+    return data["random_seed"].astype(str) + "_" + data["address_id"].astype(str)
+
+
 def get_state_name(data: pd.DataFrame) -> pd.Series:
     state_map = {state: state_id for state_id, state in metadata.CENSUS_STATE_IDS.items()}
     return data["state"].map(state_map)
@@ -38,6 +42,7 @@ COLUMN_FORMATTERS = {
     "middle_name_id": (get_middle_name_id, ["middle_name_id", "random_seed"]),
     "last_name_id": (get_last_name_id, ["last_name_id", "random_seed"]),
     "state": (get_state_name, ["state"]),
+    "address_id": (format_address_id, ["address_id", "random_seed"]),
 }
 
 


### PR DESCRIPTION
## Add `address_id` formatter

### Description
- *Category*:  implementation
- *JIRA issue*: [MIC-3812](https://jira.ihme.washington.edu/browse/MIC-3812)

### Changes and notes
Adds a formatter for address_id, which prepends the random seed followed by an underbar.

### Verification and Testing
CI

