### PR TITLE
add state/puma to household_details pipeline

### DIFF
--- a/integration_tests/test_domestic_migration.py
+++ b/integration_tests/test_domestic_migration.py
@@ -193,7 +193,12 @@ def test_only_living_people_change_households(simulants_on_adjacent_timesteps):
             "household_details.state_id",
             "household_details.puma",
         ),
-        ("household_id", "household_details.po_box", "household_details.state_id", "household_details.puma"),
+        (
+            "household_id",
+            "household_details.po_box",
+            "household_details.state_id",
+            "household_details.puma",
+        ),
     ],
 )
 def test_unit_members_share_address(
@@ -218,7 +223,12 @@ def test_unit_members_share_address(
             "household_details.state_id",
             "household_details.puma",
         ),
-        ("household_id", "household_details.po_box", "household_details.state_id", "household_details.puma"),
+        (
+            "household_id",
+            "household_details.po_box",
+            "household_details.state_id",
+            "household_details.puma",
+        ),
     ],
 )
 def test_unit_address_uniqueness(
@@ -235,7 +245,6 @@ def test_unit_address_uniqueness(
             assert (pop.groupby(address_cols)[unit_id_col].nunique() == 1).all()
 
 
-
 @pytest.mark.parametrize(
     "state_id_col, puma_col",
     [
@@ -243,15 +252,14 @@ def test_unit_address_uniqueness(
         ("household_details.state_id", "household_details.puma"),
     ],
 )
-def test_pumas_exist_in_states(
-    sim, populations, state_id_col, puma_col
-):
+def test_pumas_exist_in_states(sim, populations, state_id_col, puma_col):
     """Check that PUMAs map to correct state.
 
     NOTE: This is an imperfect test because PUMAs are only unique within states
     and so one PUMA can exist in multiple states. Here we only ensure no
     impossible PUMAs exist in each state
     """
+    # FIXME: Use the US households static file for states/pumas
     state_puma_map = (
         sim._data.artifact.load("population.households")
         .reset_index()

--- a/integration_tests/test_household_structure.py
+++ b/integration_tests/test_household_structure.py
@@ -137,15 +137,12 @@ def test_state_complete_coverage(populations, sim):
         assert states_in_artifact == set(pop["state"])
 
 
-@pytest.mark.parametrize(
-    "pop_type", [pytest.param("gq", marks=pytest.mark.xfail(reason="MIC-3728")), "non_gq"]
-)
-def test_pumas_states(populations, pop_type):
-    """Each unique non-GQ initialized address_id should have identical puma/state"""
-    pop = populations[0]
-    gq_housing_mask = pop["household_id"].isin(data_values.GQ_HOUSING_TYPE_MAP)
-    sub_population = pop[gq_housing_mask] if pop_type == "gq" else pop[~gq_housing_mask]
-    assert (
-        sub_population.groupby("household_details.address_id")[["state", "puma"]].nunique()
-        == 1
-    ).values.all()
+def test_pumas_states(populations):
+    """Each unique address_id should have identical puma/state"""
+    for pop in populations:
+        assert (
+            pop.groupby("household_details.address_id")[
+                ["household_details.state_id", "household_details.puma"]
+            ].nunique()
+            == 1
+        ).values.all()

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@ import os
 from setuptools import find_packages, setup
 
 if __name__ == "__main__":
-
     base_dir = os.path.dirname(__file__)
     src_dir = os.path.join(base_dir, "src")
 

--- a/src/vivarium_census_prl_synth_pop/components/businesses.py
+++ b/src/vivarium_census_prl_synth_pop/components/businesses.py
@@ -326,7 +326,6 @@ class Businesses:
         return new_employers
 
     def calculate_income(self, idx: pd.Index) -> pd.Series:
-
         income = pd.Series(0.0, index=idx)
         pop = self.population_view.get(idx, query="tracked")
         employed_idx = pop.index[pop["employer_id"] != data_values.Unemployed.EMPLOYER_ID]

--- a/src/vivarium_census_prl_synth_pop/components/household.py
+++ b/src/vivarium_census_prl_synth_pop/components/household.py
@@ -65,9 +65,6 @@ class Households:
                 "address_id": data_values.GQ_HOUSING_TYPE_MAP.keys(),
                 "housing_type": data_values.GQ_HOUSING_TYPE_MAP.values(),
                 "po_box": data_values.NO_PO_BOX,
-                # Add dummy state_id and puma during setup b/c we do not have
-                # access to the randomness stream - these will be sampled
-                # during initialization
                 "state_id": states_pumas["state_id"],
                 "puma": states_pumas["puma"],
             },

--- a/src/vivarium_census_prl_synth_pop/components/population.py
+++ b/src/vivarium_census_prl_synth_pop/components/population.py
@@ -182,8 +182,12 @@ class Population:
         ]
 
         new_simulants = self.initialize_new_simulants_from_acs(chosen_persons, pop_data)
-
-        household_ids = self.households.create_households(len(chosen_households))
+        household_ids = self.households.create_households(
+            num_households=len(chosen_households),
+            states_pumas=chosen_households[["state", "puma"]].rename(
+                columns={"state": "state_id"}
+            ),
+        )
         household_id_mapping = pd.Series(
             household_ids, index=chosen_households["census_sample_household_id"]
         )

--- a/src/vivarium_census_prl_synth_pop/data/loader.py
+++ b/src/vivarium_census_prl_synth_pop/data/loader.py
@@ -202,7 +202,6 @@ def _capitalize_names(name):
 
 
 def load_last_name_data(key: str, location: str) -> pd.DataFrame:
-
     df_census_names = pd.read_csv(paths.LAST_NAME_DATA_PATH, na_values=["(S)"])
 
     df_census_names["name"] = df_census_names["name"].apply(_capitalize_names)

--- a/src/vivarium_census_prl_synth_pop/model_specifications/model_spec.yaml
+++ b/src/vivarium_census_prl_synth_pop/model_specifications/model_spec.yaml
@@ -20,7 +20,8 @@ components:
 
 configuration:
     input_data:
-        artifact_path: '/mnt/team/simulation_science/priv/engineering/vivarium_census_prl_synth_pop/data/artifacts/united_states_of_america.hdf'
+        # artifact_path: '/mnt/team/simulation_science/priv/engineering/vivarium_census_prl_synth_pop/data/artifacts/united_states_of_america.hdf'
+        artifact_path: '/Users/sbachmei/scratch/prl/artifacts/united_states_of_america.hdf'
         input_draw_number: 0
     output_data:
         results_directory: '/mnt/team/simulation_science/priv/engineering/vivarium_census_prl_synth_pop/results/'

--- a/src/vivarium_census_prl_synth_pop/model_specifications/model_spec.yaml
+++ b/src/vivarium_census_prl_synth_pop/model_specifications/model_spec.yaml
@@ -20,8 +20,7 @@ components:
 
 configuration:
     input_data:
-        # artifact_path: '/mnt/team/simulation_science/priv/engineering/vivarium_census_prl_synth_pop/data/artifacts/united_states_of_america.hdf'
-        artifact_path: '/Users/sbachmei/scratch/prl/artifacts/united_states_of_america.hdf'
+        artifact_path: '/mnt/team/simulation_science/priv/engineering/vivarium_census_prl_synth_pop/data/artifacts/united_states_of_america.hdf'
         input_draw_number: 0
     output_data:
         results_directory: '/mnt/team/simulation_science/priv/engineering/vivarium_census_prl_synth_pop/results/'

--- a/src/vivarium_census_prl_synth_pop/tools/make_artifacts.py
+++ b/src/vivarium_census_prl_synth_pop/tools/make_artifacts.py
@@ -29,7 +29,6 @@ from vivarium_census_prl_synth_pop.utilities import (
 
 
 def running_from_cluster() -> bool:
-
     import vivarium_cluster_tools as vct
 
     on_cluster = True

--- a/src/vivarium_census_prl_synth_pop/utilities.py
+++ b/src/vivarium_census_prl_synth_pop/utilities.py
@@ -174,9 +174,9 @@ def vectorized_choice(
     additional_key: Any = None,
     random_seed: int = None,
 ):
-    if not randomness_stream and not (str(additional_key) and str(random_seed)):
+    if not randomness_stream and (additional_key == None and random_seed == None):
         raise RuntimeError(
-            "An additonal_key and a ransom_seed are required in 'vectorized_choice'"
+            "An additional_key and a random_seed are required in 'vectorized_choice'"
             + "if no RandomnessStream is passed in"
         )
     if weights is None:

--- a/tests/components/test_population.py
+++ b/tests/components/test_population.py
@@ -137,7 +137,6 @@ def fake_population() -> pd.DataFrame:
 
 
 def test_update_to_reference_person_and_relationships(mocker, fake_population):
-
     expected_relationships_1 = pd.Series(
         data=[
             "Reference person",


### PR DESCRIPTION
## Title: Add state_id and puma to household_details pipeline

### Description
- *Category*: implementation
- *JIRA issue*: [MIC-3728](https://jira.ihme.washington.edu/browse/MIC-3728)
- *Research reference*: na
- 
### Changes and notes
This adds state_id and puma to the household_details pipeline.
NOTES:
 - It does remove the cols (in the next PR)
 - It does not do the equivalent for the business_details pipeline (in a separate task)


### Verification and Testing
Pytests have been updated to use the pipeline and all pass.

