### PR TITLE
Household address maps

### DIFF
--- a/src/vivarium_census_prl_synth_pop/components/observers.py
+++ b/src/vivarium_census_prl_synth_pop/components/observers.py
@@ -158,6 +158,7 @@ class HouseholdSurveyObserver(BaseObserver):
     ADDITIONAL_INPUT_COLUMNS = [
         "alive",
         "household_id",
+        "address_id",
     ]
     ADDITIONAL_OUTPUT_COLUMNS = [
         "survey_date",
@@ -247,7 +248,7 @@ class DecennialCensusObserver(BaseObserver):
     """
 
     INPUT_VALUES = ["household_details"]
-    ADDITIONAL_INPUT_COLUMNS = ["relation_to_household_head"]
+    ADDITIONAL_INPUT_COLUMNS = ["relation_to_household_head", "address_id"]
     ADDITIONAL_OUTPUT_COLUMNS = [
         "relation_to_household_head",
         "census_year",
@@ -302,7 +303,7 @@ class WICObserver(BaseObserver):
     """Class for observing columns relevant to WIC administrative data."""
 
     INPUT_VALUES = ["income", "household_details"]
-    ADDITIONAL_OUTPUT_COLUMNS = ["wic_year"]
+    ADDITIONAL_OUTPUT_COLUMNS = ["wic_year", "address_id"]
     WIC_BASELINE_SALARY = 16_410
     WIC_SALARY_PER_HOUSEHOLD_MEMBER = 8_732
     WIC_RACE_ETHNICITIES = ["White", "Black", "Latino", "Other"]
@@ -447,6 +448,7 @@ class SocialSecurityObserver(BaseObserver):
         "sex",
         "race_ethnicity",
     ]
+    EXTRA_OUTPUT_COLUMNS = ["address_id"]
     POST_PROCESSING_FIRST_NAME_METADATA_COLS = [
         "first_name_id",
         "middle_name_id",
@@ -469,7 +471,7 @@ class SocialSecurityObserver(BaseObserver):
 
     @property
     def output_columns(self):
-        return self.OUTPUT_COLUMNS
+        return list(set(self.OUTPUT_COLUMNS) - set(self.EXTRA_OUTPUT_COLUMNS))
 
     def setup(self, builder: Builder):
         super().setup(builder)
@@ -541,6 +543,7 @@ class TaxW2Observer(BaseObserver):
         "tracked",
         "ssn",
         "employer_id",
+        "address_id",
     ]
     OUTPUT_COLUMNS = [
         "first_name_id",
@@ -734,12 +737,7 @@ class TaxDependentsObserver(BaseObserver):
     """
 
     INPUT_VALUES = ["household_details"]
-    ADDITIONAL_INPUT_COLUMNS = [
-        "alive",
-        "in_united_states",
-        "tracked",
-        "ssn",
-    ]
+    ADDITIONAL_INPUT_COLUMNS = ["alive", "in_united_states", "tracked", "ssn", "address_id"]
     OUTPUT_COLUMNS = [
         "guardian_id",
         "dependent_id",
@@ -865,6 +863,7 @@ class Tax1040Observer(BaseObserver):
         "tracked",
         "ssn",
         "relation_to_household_head",
+        "address_id",
     ]
     OUTPUT_COLUMNS = [
         "first_name_id",

--- a/src/vivarium_census_prl_synth_pop/components/observers.py
+++ b/src/vivarium_census_prl_synth_pop/components/observers.py
@@ -469,7 +469,7 @@ class SocialSecurityObserver(BaseObserver):
 
     @property
     def output_columns(self):
-        return list(set(self.OUTPUT_COLUMNS) - set(self.EXTRA_OUTPUT_COLUMNS))
+        return self.OUTPUT_COLUMNS
 
     def setup(self, builder: Builder):
         super().setup(builder)

--- a/src/vivarium_census_prl_synth_pop/components/observers.py
+++ b/src/vivarium_census_prl_synth_pop/components/observers.py
@@ -158,7 +158,6 @@ class HouseholdSurveyObserver(BaseObserver):
     ADDITIONAL_INPUT_COLUMNS = [
         "alive",
         "household_id",
-        "address_id",
     ]
     ADDITIONAL_OUTPUT_COLUMNS = [
         "survey_date",
@@ -248,7 +247,7 @@ class DecennialCensusObserver(BaseObserver):
     """
 
     INPUT_VALUES = ["household_details"]
-    ADDITIONAL_INPUT_COLUMNS = ["relation_to_household_head", "address_id"]
+    ADDITIONAL_INPUT_COLUMNS = ["relation_to_household_head"]
     ADDITIONAL_OUTPUT_COLUMNS = [
         "relation_to_household_head",
         "census_year",
@@ -303,7 +302,7 @@ class WICObserver(BaseObserver):
     """Class for observing columns relevant to WIC administrative data."""
 
     INPUT_VALUES = ["income", "household_details"]
-    ADDITIONAL_OUTPUT_COLUMNS = ["wic_year", "address_id"]
+    ADDITIONAL_OUTPUT_COLUMNS = ["wic_year"]
     WIC_BASELINE_SALARY = 16_410
     WIC_SALARY_PER_HOUSEHOLD_MEMBER = 8_732
     WIC_RACE_ETHNICITIES = ["White", "Black", "Latino", "Other"]
@@ -448,7 +447,6 @@ class SocialSecurityObserver(BaseObserver):
         "sex",
         "race_ethnicity",
     ]
-    EXTRA_OUTPUT_COLUMNS = ["address_id"]
     POST_PROCESSING_FIRST_NAME_METADATA_COLS = [
         "first_name_id",
         "middle_name_id",
@@ -543,7 +541,6 @@ class TaxW2Observer(BaseObserver):
         "tracked",
         "ssn",
         "employer_id",
-        "address_id",
     ]
     OUTPUT_COLUMNS = [
         "first_name_id",
@@ -737,7 +734,7 @@ class TaxDependentsObserver(BaseObserver):
     """
 
     INPUT_VALUES = ["household_details"]
-    ADDITIONAL_INPUT_COLUMNS = ["alive", "in_united_states", "tracked", "ssn", "address_id"]
+    ADDITIONAL_INPUT_COLUMNS = ["alive", "in_united_states", "tracked", "ssn"]
     OUTPUT_COLUMNS = [
         "guardian_id",
         "dependent_id",
@@ -863,7 +860,6 @@ class Tax1040Observer(BaseObserver):
         "tracked",
         "ssn",
         "relation_to_household_head",
-        "address_id",
     ]
     OUTPUT_COLUMNS = [
         "first_name_id",

--- a/src/vivarium_census_prl_synth_pop/results_processing/addresses.py
+++ b/src/vivarium_census_prl_synth_pop/results_processing/addresses.py
@@ -1,0 +1,45 @@
+from typing import Dict
+
+import numpy as np
+import pandas as pd
+from vivarium import Artifact
+from vivarium.framework.randomness import RandomnessStream
+
+from vivarium_census_prl_synth_pop.constants import data_keys, data_values
+from vivarium_census_prl_synth_pop.results_processing.formatter import (
+    format_data_for_mapping,
+)
+from vivarium_census_prl_synth_pop.utilities import vectorized_choice
+
+
+def get_household_address_map(
+    column_name: str,
+    obs_data: Dict[str, pd.DataFrame],
+    artifact: Artifact,
+    randomness: RandomnessStream,
+) -> Dict[str, Dict[str, pd.Series]]:
+    # This will return address_id mapped to address number, street name, and unit number.
+
+    output_cols = [column_name]
+    address_data = format_data_for_mapping(
+        index_name=column_name,
+        obs_results=obs_data,
+        output_columns=output_cols,
+    )
+    address_map = pd.Series(index=address_data.index, dtype=object)
+
+    # Load address dazta from artifact
+    synthetic_address_data = artifact.load(data_keys.SYNTHETIC_DATA.ADDRESSES)
+    # Generate addresses
+    for col in ["StreetNumber", "StreetName", "Unit"]:
+        chosen_indices = vectorized_choice(
+            options=synthetic_address_data.index,
+            n_to_choose=len(address_map),
+            randomness_stream=randomness,
+        )
+        address_map += synthetic_address_data.loc[chosen_indices, col].fillna("").values
+        address_map += " "
+
+    # todo: Separate address strings into necessary columns and return address map
+
+

--- a/src/vivarium_census_prl_synth_pop/results_processing/addresses.py
+++ b/src/vivarium_census_prl_synth_pop/results_processing/addresses.py
@@ -44,8 +44,9 @@ def get_household_address_map(
             n_to_choose=len(address_data),
             randomness_stream=randomness,
             additional_key=obs_column,
-        )
-        address_data[obs_column] = address_details.fillna("", axis=0)
+        ).values
+        address_data[obs_column] = address_details
+        address_data.fillna("", inplace=True)
         # Update map
         address_map[obs_column] = address_data[obs_column]
 

--- a/src/vivarium_census_prl_synth_pop/results_processing/addresses.py
+++ b/src/vivarium_census_prl_synth_pop/results_processing/addresses.py
@@ -35,7 +35,7 @@ def get_household_address_map(
     )
     address_data = pd.DataFrame(index=address_ids.index)
 
-    # Load address dazta from artifact
+    # Load address data from artifact
     synthetic_address_data = artifact.load(data_keys.SYNTHETIC_DATA.ADDRESSES).reset_index()
     # Generate addresses
     for artifact_column, obs_column in HOUSEHOLD_ADDRESS_COL_MAP.items():

--- a/src/vivarium_census_prl_synth_pop/results_processing/addresses.py
+++ b/src/vivarium_census_prl_synth_pop/results_processing/addresses.py
@@ -45,8 +45,8 @@ def get_household_address_map(
             randomness_stream=randomness,
             additional_key=obs_column,
         )
-        address_data[artifact_column] = address_details.fillna("").values
+        address_data[obs_column] = address_details.fillna("", axis=0)
         # Update map
         address_map[obs_column] = address_data[obs_column]
 
-    return {column_name: address_map}
+    return address_map

--- a/src/vivarium_census_prl_synth_pop/results_processing/addresses.py
+++ b/src/vivarium_census_prl_synth_pop/results_processing/addresses.py
@@ -44,7 +44,7 @@ def get_household_address_map(
             n_to_choose=len(address_data),
             randomness_stream=randomness,
             additional_key=obs_column,
-        ).values
+        ).to_numpy()
         address_data[obs_column] = address_details
         address_data.fillna("", inplace=True)
         # Update map

--- a/src/vivarium_census_prl_synth_pop/results_processing/formatter.py
+++ b/src/vivarium_census_prl_synth_pop/results_processing/formatter.py
@@ -59,6 +59,12 @@ def format_data_for_mapping(
     output_columns: List[str],
 ) -> pd.DataFrame:
     data_to_map = [obs_data[output_columns] for obs_data in obs_results.values()]
+
+    data_to_map = [
+        obs_data[output_columns]
+        for obs_data in obs_results.values()
+        if set(output_columns).issubset(set(obs_data.columns))
+    ]
     data = pd.concat(data_to_map).drop_duplicates()
     data = data[output_columns].set_index(index_name)
 

--- a/src/vivarium_census_prl_synth_pop/results_processing/formatter.py
+++ b/src/vivarium_census_prl_synth_pop/results_processing/formatter.py
@@ -58,7 +58,6 @@ def format_data_for_mapping(
     obs_results: Dict[str, pd.DataFrame],
     output_columns: List[str],
 ) -> pd.DataFrame:
-    data_to_map = [obs_data[output_columns] for obs_data in obs_results.values()]
 
     data_to_map = [
         obs_data[output_columns]

--- a/src/vivarium_census_prl_synth_pop/tools/make_results.py
+++ b/src/vivarium_census_prl_synth_pop/tools/make_results.py
@@ -1,3 +1,4 @@
+import csv
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, Tuple
@@ -91,7 +92,11 @@ def perform_post_processing(
 
         logger.info(f"Writing final results for {observer}.")
         # fixme: Process columns for final outputs - columns being mapped are no longer dropped
-        obs_data.to_csv(final_output_dir / f"{observer}.csv.bz2", index=False)
+        obs_data.to_csv(
+            final_output_dir / f"{observer}.csv.bz2",
+            index=False,
+            quoting=csv.QUOTE_NONNUMERIC,
+        )
 
 
 def load_data(raw_results_dir: Path) -> Dict[str, pd.DataFrame]:

--- a/src/vivarium_census_prl_synth_pop/tools/make_results.py
+++ b/src/vivarium_census_prl_synth_pop/tools/make_results.py
@@ -10,7 +10,9 @@ from vivarium.framework.randomness import RandomnessStream
 from vivarium_census_prl_synth_pop import utilities
 from vivarium_census_prl_synth_pop.constants import paths
 from vivarium_census_prl_synth_pop.results_processing import formatter
-from vivarium_census_prl_synth_pop.results_processing.addresses import get_household_address_map
+from vivarium_census_prl_synth_pop.results_processing.addresses import (
+    get_household_address_map,
+)
 from vivarium_census_prl_synth_pop.results_processing.names import (
     get_given_name_map,
     get_last_name_map,

--- a/src/vivarium_census_prl_synth_pop/tools/make_results.py
+++ b/src/vivarium_census_prl_synth_pop/tools/make_results.py
@@ -88,11 +88,9 @@ def perform_post_processing(
             if column in maps:
                 for target_column_name, column_map in maps[column].items():
                     obs_data[target_column_name] = obs_data[column].map(column_map)
-                # This assumes the column we are mapping will be dropped
-                obs_data.drop(columns=column, inplace=True)
 
         logger.info(f"Writing final results for {observer}.")
-        # fixme: Process columns for final outputs
+        # fixme: Process columns for final outputs - columns being mapped are no longer dropped
         obs_data.to_csv(final_output_dir / f"{observer}.csv.bz2", index=False)
 
 

--- a/src/vivarium_census_prl_synth_pop/tools/make_results.py
+++ b/src/vivarium_census_prl_synth_pop/tools/make_results.py
@@ -10,6 +10,7 @@ from vivarium.framework.randomness import RandomnessStream
 from vivarium_census_prl_synth_pop import utilities
 from vivarium_census_prl_synth_pop.constants import paths
 from vivarium_census_prl_synth_pop.results_processing import formatter
+from vivarium_census_prl_synth_pop.results_processing.addresses import get_household_address_map
 from vivarium_census_prl_synth_pop.results_processing.names import (
     get_given_name_map,
     get_last_name_map,
@@ -146,6 +147,7 @@ def generate_maps(
         "first_name_id": get_given_name_map,
         "middle_name_id": get_middle_initial_map,
         "last_name_id": get_last_name_map,
+        "address_id": get_household_address_map,
     }
     maps = {
         column: mapper(column, obs_data, artifact, randomness)

--- a/tests/test_synthetic_pii.py
+++ b/tests/test_synthetic_pii.py
@@ -1,15 +1,17 @@
 # Sample Test passing with nose and pytest
+import string
 from types import MethodType
 from typing import List
 
 import numpy as np
 import pandas as pd
 import pytest
-import string
 from vivarium.framework.randomness import RandomnessStream
 
 from vivarium_census_prl_synth_pop.components import synthetic_pii
-from vivarium_census_prl_synth_pop.results_processing.addresses import get_household_address_map
+from vivarium_census_prl_synth_pop.results_processing.addresses import (
+    get_household_address_map,
+)
 from vivarium_census_prl_synth_pop.results_processing.names import (
     get_given_name_map,
     get_last_name_map,
@@ -274,11 +276,13 @@ def test_last_name_from_oldest_member(mocker):
 
 def test_address(mocker):
     # Fake synthetic pii address data
-    synthetic_address_data = pd.DataFrame({
-        "StreetNumber": list(range(26)),
-        "StreetName": list(string.ascii_lowercase),
-        "Unit": list(range(26)),
-    })
+    synthetic_address_data = pd.DataFrame(
+        {
+            "StreetNumber": list(range(26)),
+            "StreetName": list(string.ascii_lowercase),
+            "Unit": list(range(26)),
+        }
+    )
     synthetic_address_data.set_index(["StreetNumber", "StreetName", "Unit"], inplace=True)
     # Mock artifact
     artifact = mocker.MagicMock()
@@ -295,10 +299,11 @@ def test_address(mocker):
         artifact,
         randomness,
     )
-    expected_keys = ["street_number", "street_name", "unit"]
-    # todo: test index of fake_obs_data is index of generated addresses and all are present
-    assert all(key in expected_keys for key in address_map.keys())
-    for key, value in address_map.values():
-        assert (address_map.values()[key].index == address_ids["address_ids"]).all()
+    expected_keys = ["street_number", "street_name", "unit_number"]
 
-    # FIXME: come up with a more robust test of the synthetic content
+    assert all(street_key in expected_keys for street_key in address_map.keys())
+    for street_key, series in address_map.items():
+        assert (address_map[street_key].index == address_ids["address_id"]).all()
+        assert len(address_map[street_key].index.unique()) == len(
+            address_map[street_key].index
+        )

--- a/tests/test_synthetic_pii.py
+++ b/tests/test_synthetic_pii.py
@@ -307,3 +307,4 @@ def test_address(mocker):
         assert len(address_map[street_key].index.unique()) == len(
             address_map[street_key].index
         )
+        assert not (address_map["street_name"].isnull().any())

--- a/tests/test_synthetic_pii.py
+++ b/tests/test_synthetic_pii.py
@@ -272,19 +272,18 @@ def test_last_name_from_oldest_member(mocker):
     assert (last_names_map["last_name"] == expected).all()
 
 
-@pytest.mark.slow
 def test_address(mocker):
     # Fake synthetic pii address data
     synthetic_address_data = pd.DataFrame({
-        "StreetNumber": [list(range(26))],
+        "StreetNumber": list(range(26)),
         "StreetName": list(string.ascii_lowercase),
-        "Unit": [list(range(26))]
+        "Unit": list(range(26)),
     })
     synthetic_address_data.set_index(["StreetNumber", "StreetName", "Unit"], inplace=True)
-
     # Mock artifact
     artifact = mocker.MagicMock()
     artifact.load.return_value = synthetic_address_data
+
     # Address_ids will just be an series of ids so we just need a unique series in a one column dataframe
     address_ids = pd.DataFrame()
     address_ids["address_id"] = list(range(10))
@@ -296,13 +295,10 @@ def test_address(mocker):
         artifact,
         randomness,
     )
-
-    # todo: test keys of address_map
-    # todo: test columns of generated addresses
+    expected_keys = ["street_number", "street_name", "unit"]
     # todo: test index of fake_obs_data is index of generated addresses and all are present
+    assert all(key in expected_keys for key in address_map.keys())
+    for key, value in address_map.values():
+        assert (address_map.values()[key].index == address_ids["address_ids"]).all()
 
-    assert "zip_code" in df.columns
-    assert "address" in df.columns
-    assert not np.any(df.address.isnull())
-    assert not np.any(df.zip_code.isnull())
     # FIXME: come up with a more robust test of the synthetic content


### PR DESCRIPTION
## Household address maps

### Generates street number, street name, and unit number for final results.
- *Category*: Post-processing
- *JIRA issue*: [MIC-3738](https://jira.ihme.washington.edu/browse/MIC-3738)
- *Research reference*: https://vivarium-research.readthedocs.io/en/latest/models/concept_models/vivarium_census_synthdata/concept_model.html#residential-households

### Changes and notes
- Adds address_id to mappers in make_results
- Creates map for appropriate columns for street addresses.
- Updates tests for porting over of synthetic pii code.
- No longer drops columns we are mapping (address_id is now preserved afterwe map).

### Verification and Testing
Successfully ran simulation and make_results.

