### PR TITLE
remove state and puma cols

### DIFF
--- a/integration_tests/test_emigration.py
+++ b/integration_tests/test_emigration.py
@@ -101,8 +101,9 @@ def test_nothing_happens_to_untracked_people(
         if untracked.sum() == 0:
             continue
 
+        known_changing_cols = pipeline_columns + ["time", "state_id_for_lookup"]
         columns_that_should_not_change = [
-            c for c in before.columns if c != "time" and c not in pipeline_columns
+            c for c in before.columns if c not in known_changing_cols
         ]
         assert before.loc[untracked, columns_that_should_not_change].equals(
             after.loc[untracked, columns_that_should_not_change]

--- a/integration_tests/test_household_structure.py
+++ b/integration_tests/test_household_structure.py
@@ -130,11 +130,11 @@ def test_housing_type_does_not_change(simulants_on_adjacent_timesteps):
 
 def test_state_complete_coverage(populations, sim):
     """States should include all locations from artifact"""
+    states_in_artifact = set(
+        sim._data.artifact.load("population.households").index.unique(level="state")
+    )
     for pop in populations:
-        states_in_artifact = set(
-            sim._data.artifact.load("population.households").index.unique(level="state")
-        )
-        assert states_in_artifact == set(pop["state"])
+        assert states_in_artifact == set(pop["household_details.state_id"])
 
 
 def test_pumas_states(populations):

--- a/src/vivarium_census_prl_synth_pop/components/household.py
+++ b/src/vivarium_census_prl_synth_pop/components/household.py
@@ -43,6 +43,7 @@ class Households:
         self.columns_used = [
             "tracked",
             "household_id",
+            "state_id_for_lookup",
         ]
 
         self.population_view = builder.population.get_view(self.columns_used)
@@ -77,6 +78,12 @@ class Households:
             requires_columns=["household_id", "tracked"],
         )
 
+        builder.population.initializes_simulants(
+            self.on_initialize_simulants,
+            creates_columns=["state_id_for_lookup"],
+            requires_values=["household_details"],
+        )
+
     ##################################
     # Pipeline sources and modifiers #
     ##################################
@@ -94,6 +101,20 @@ class Households:
         )
         household_details = household_details.astype(HOUSEHOLD_DETAILS_DTYPES)
         return household_details
+
+    ########################
+    # Event-driven methods #
+    ########################
+
+    def on_initialize_simulants(self, pop_data: SimulantData) -> None:
+        """Initialize the state_id_for_lookup column with the initialized
+        household_details.state_id values
+        """
+        pop_update = pd.DataFrame(
+            {"state_id_for_lookup": self.household_details(pop_data.index)["state_id"]},
+            index=pop_data.index,
+        )
+        self.population_view.update(pop_update)
 
     ##################
     # Public methods #

--- a/src/vivarium_census_prl_synth_pop/components/population.py
+++ b/src/vivarium_census_prl_synth_pop/components/population.py
@@ -50,8 +50,6 @@ class Population:
 
         self.columns_created = [
             "household_id",
-            "state",
-            "puma",
             "relation_to_household_head",
             "sex",
             "age",
@@ -69,7 +67,9 @@ class Population:
             "born_in_us",
         ]
         self.register_simulants = builder.randomness.register_simulants
-        self.population_view = builder.population.get_view(self.columns_created)
+        self.population_view = builder.population.get_view(
+            self.columns_created + ["state_id_for_lookup"]
+        )
         self.households = builder.components.get_component("households")
 
         # HACK: ACS data must be loaded in setup, since it comes from the artifact;
@@ -227,8 +227,6 @@ class Population:
 
         inherited_traits = [
             "household_id",
-            "state",
-            "puma",
             "race_ethnicity",
             "relation_to_household_head",
             "last_name_id",
@@ -352,9 +350,6 @@ class Population:
         """
         # Add basic, non-ACS columns
         new_simulants = self.initialize_new_simulants(new_simulants, pop_data)
-
-        # set state dtype
-        new_simulants["state"] = new_simulants["state"].astype("int64")
 
         # Age is recorded in ACS as an integer, floored.
         # We shift ages to a random floating point value between the reported age and the next.

--- a/src/vivarium_census_prl_synth_pop/results_processing/formatter.py
+++ b/src/vivarium_census_prl_synth_pop/results_processing/formatter.py
@@ -58,7 +58,6 @@ def format_data_for_mapping(
     obs_results: Dict[str, pd.DataFrame],
     output_columns: List[str],
 ) -> pd.DataFrame:
-
     data_to_map = [
         obs_data[output_columns]
         for obs_data in obs_results.values()

--- a/tests/components/observers/test_household_survey_observers.py
+++ b/tests/components/observers/test_household_survey_observers.py
@@ -40,6 +40,9 @@ def mocked_household_details_pipeline(mocked_pop_view):
         df = mocked_pop_view[["household_id"]]
         df["housing_type"] = ["Van", "Standard"]
         df["address_id"] = [100, 200]
+        df["po_box"] = [-1, -2]
+        df["state_id"] = [-1, -2]
+        df["puma"] = [-1, -2]
         return df
 
     return _mocked_pipeline
@@ -84,8 +87,10 @@ def test_get_observation(
     expected["middle_initial"] = ["J", "M"]
     expected[["guardian_1_address_id", "guardian_2_address_id"]] = np.nan
     expected["survey_date"] = [pd.to_datetime(sim_start_date)] * 2
-    expected[["housing_type", "address_id"]] = mocked_household_details_pipeline("dummy")[
-        ["housing_type", "address_id"]
+    expected[
+        ["housing_type", "address_id", "state_id", "puma"]
+    ] = mocked_household_details_pipeline("dummy")[
+        ["housing_type", "address_id", "state_id", "puma"]
     ]
     pd.testing.assert_frame_equal(expected[observer.output_columns], observation)
 
@@ -115,8 +120,13 @@ def test_multiple_observation(
     expected["middle_initial"] = ["J", "M"] * 2
     expected[["guardian_1_address_id", "guardian_2_address_id"]] = np.nan
     expected["survey_date"] = [pd.to_datetime(sim_start_date)] * 2 + [event.time] * 2
-    expected[["housing_type", "address_id"]] = pd.concat(
-        [mocked_household_details_pipeline("dummy")[["housing_type", "address_id"]]] * 2,
+    expected[["housing_type", "address_id", "state_id", "puma"]] = pd.concat(
+        [
+            mocked_household_details_pipeline("dummy")[
+                ["housing_type", "address_id", "state_id", "puma"]
+            ]
+        ]
+        * 2,
         axis=0,
     )
     pd.testing.assert_frame_equal(expected[observer.output_columns], observer.responses)


### PR DESCRIPTION
## Title: Remove state and puma cols from state table

### Description
- *Category*: implementation
- *JIRA issue*: [MIC-3728](https://jira.ihme.washington.edu/browse/MIC-3728)
- *Research reference*: na

### Changes and notes
This [previous PR](https://github.com/ihmeuw/vivarium_census_prl_synth_pop/pull/205) added state_id and
puma to the household_details pipeline but did not actually remove the columns
from the state table. This removes those columns.

### Verification and Testing
pytests pass and a small sim was run and observations generated.

