### PR TITLE
add employer state/puma to sim

### DIFF
--- a/integration_tests/test_employment.py
+++ b/integration_tests/test_employment.py
@@ -151,7 +151,6 @@ def test_employer_name_uniqueness(simulants_on_adjacent_timesteps):
         ...
 
 
-@pytest.mark.skip(reason="TODO when employer state/puma is implemented")
 def test_pumas_states(populations):
     """Each unique address_id should have identical puma/state"""
     for pop in populations:

--- a/src/vivarium_census_prl_synth_pop/components/businesses.py
+++ b/src/vivarium_census_prl_synth_pop/components/businesses.py
@@ -12,6 +12,7 @@ from vivarium_public_health import utilities
 from vivarium_census_prl_synth_pop.constants import data_values, metadata, paths
 from vivarium_census_prl_synth_pop.utilities import (
     filter_by_rate,
+    get_state_puma_options,
     randomly_sample_states_pumas,
 )
 
@@ -56,9 +57,7 @@ class Businesses:
     def setup(self, builder: Builder):
         self.start_time = get_time_stamp(builder.configuration.time.start)
         self.randomness = builder.randomness.get_stream(self.name)
-        self.states_in_artifact = list(
-            builder.data.load("population.households")["state"].drop_duplicates()
-        )
+        self.state_puma_options = get_state_puma_options(builder)
         self.household_details = builder.value.get_value("household_details")
         self.employer_address_id_count = 0
         self.columns_created = [
@@ -298,7 +297,7 @@ class Businesses:
         # Randomly assign employer states/PUMAs
         states_pumas = randomly_sample_states_pumas(
             unit_ids=businesses.index,
-            available_states=self.states_in_artifact,
+            state_puma_options=self.state_puma_options,
             additional_key="initial_business_states_pumas",
             randomness_stream=self.randomness,
         )
@@ -396,7 +395,7 @@ class Businesses:
             ] = self.employer_address_id_count + np.arange(len(moving_business_ids))
             states_pumas = randomly_sample_states_pumas(
                 unit_ids=moving_business_ids,
-                available_states=self.states_in_artifact,
+                state_puma_options=self.state_puma_options,
                 additional_key="update_business_states_pumas",
                 randomness_stream=self.randomness,
             )

--- a/src/vivarium_census_prl_synth_pop/components/businesses.py
+++ b/src/vivarium_census_prl_synth_pop/components/businesses.py
@@ -10,7 +10,10 @@ from vivarium.framework.time import get_time_stamp
 from vivarium_public_health import utilities
 
 from vivarium_census_prl_synth_pop.constants import data_values, metadata, paths
-from vivarium_census_prl_synth_pop.utilities import filter_by_rate
+from vivarium_census_prl_synth_pop.utilities import (
+    filter_by_rate,
+    randomly_sample_states_pumas,
+)
 
 
 class Businesses:
@@ -53,6 +56,9 @@ class Businesses:
     def setup(self, builder: Builder):
         self.start_time = get_time_stamp(builder.configuration.time.start)
         self.randomness = builder.randomness.get_stream(self.name)
+        self.states_in_artifact = list(
+            builder.data.load("population.households")["state"].drop_duplicates()
+        )
         self.household_details = builder.value.get_value("household_details")
         self.employer_address_id_count = 0
         self.columns_created = [
@@ -173,7 +179,7 @@ class Businesses:
             "moving_businesses",
         )
 
-        self.update_business_address_ids(businesses_that_move_idx)
+        self.update_business_addresses(businesses_that_move_idx)
 
         # change jobs by rate as well as if the household moves (only includes
         # working-age simulants and excludes simulants living in military GQ)
@@ -289,6 +295,15 @@ class Businesses:
         )
 
         businesses = pd.concat([known_employers, random_employers], ignore_index=True)
+        # Randomly assign employer states/PUMAs
+        states_pumas = randomly_sample_states_pumas(
+            unit_ids=businesses.index,
+            available_states=self.states_in_artifact,
+            additional_key="initial_business_states_pumas",
+            randomness_stream=self.randomness,
+        )
+        businesses["employer_state_id"] = states_pumas["state_id"]
+        businesses["employer_puma"] = states_pumas["puma"]
         self.employer_address_id_count = len(businesses)  # So next address will be unique
 
         return businesses.set_index("employer_id")
@@ -357,15 +372,18 @@ class Businesses:
         """Source of the business details pipeline"""
         pop = self.population_view.get(idx)[["employer_id"]]
         business_details = pop.join(
-            self.businesses[["employer_name", "employer_address_id"]], on="employer_id"
+            self.businesses[
+                ["employer_name", "employer_address_id", "employer_state_id", "employer_puma"]
+            ],
+            on="employer_id",
         )
 
         return business_details
 
-    def update_business_address_ids(self, moving_business_ids: pd.Index) -> None:
+    def update_business_addresses(self, moving_business_ids: pd.Index) -> None:
         """
-        Change the address_id associated with each of the provided business_ids to
-        a new, unique value.
+        Change the address information associated with each of the provided
+        business_ids to a new, unique address.
 
         Parameters
         ----------
@@ -376,4 +394,14 @@ class Businesses:
             self.businesses.loc[
                 moving_business_ids, "employer_address_id"
             ] = self.employer_address_id_count + np.arange(len(moving_business_ids))
+            states_pumas = randomly_sample_states_pumas(
+                unit_ids=moving_business_ids,
+                available_states=self.states_in_artifact,
+                additional_key="update_business_states_pumas",
+                randomness_stream=self.randomness,
+            )
+            self.businesses.loc[moving_business_ids, "employer_state_id"] = states_pumas[
+                "state_id"
+            ]
+            self.businesses.loc[moving_business_ids, "employer_puma"] = states_pumas["puma"]
             self.employer_address_id_count += len(moving_business_ids)

--- a/src/vivarium_census_prl_synth_pop/components/household.py
+++ b/src/vivarium_census_prl_synth_pop/components/household.py
@@ -8,6 +8,7 @@ from vivarium.framework.time import get_time_stamp
 
 from vivarium_census_prl_synth_pop.constants import data_values
 from vivarium_census_prl_synth_pop.utilities import (
+    get_state_puma_options,
     random_integers,
     randomly_sample_states_pumas,
 )
@@ -43,9 +44,7 @@ class Households:
     def setup(self, builder: Builder):
         self.start_time = get_time_stamp(builder.configuration.time.start)
         self.randomness = builder.randomness.get_stream(self.name)
-        self.states_in_artifact = list(
-            builder.data.load("population.households")["state"].drop_duplicates()
-        )
+        self.state_puma_options = get_state_puma_options(builder)
         self.columns_used = [
             "tracked",
             "household_id",
@@ -62,7 +61,7 @@ class Households:
         )
         states_pumas = randomly_sample_states_pumas(
             unit_ids=gq_household_ids,
-            available_states=self.states_in_artifact,
+            state_puma_options=self.state_puma_options,
             additional_key="gq_states_pumas",
             random_seed=builder.configuration.randomness.random_seed,
         )
@@ -144,7 +143,7 @@ class Households:
             The housing type of the new households.
         states_pumas (optional)
             A dataframe of the households' state_ids and pumas. If it is None, then
-            new states ande pumas will be sampled from ACS data.
+            new states ande pumas will be sampled.
 
         Returns
         -------
@@ -159,7 +158,7 @@ class Households:
         if states_pumas is None:
             states_pumas = randomly_sample_states_pumas(
                 unit_ids=household_ids,
-                available_states=self.states_in_artifact,
+                state_puma_options=self.state_puma_options,
                 additional_key="new_household_states_pumas",
                 randomness_stream=self.randomness,
             )
@@ -197,7 +196,7 @@ class Households:
         po_boxes = self.generate_po_boxes(len(household_ids))
         states_pumas = randomly_sample_states_pumas(
             unit_ids=household_ids,
-            available_states=self.states_in_artifact,
+            state_puma_options=self.state_puma_options,
             additional_key="updated_household_states_pumas",
             randomness_stream=self.randomness,
         )

--- a/src/vivarium_census_prl_synth_pop/components/observers.py
+++ b/src/vivarium_census_prl_synth_pop/components/observers.py
@@ -711,7 +711,12 @@ class TaxW2Observer(BaseObserver):
 
         # merge in employer columns based on employer_id
         emp = business_details.groupby("employer_id").first()
-        for col in ["employer_address_id", "employer_state_id", "employer_puma", "employer_name"]:
+        for col in [
+            "employer_address_id",
+            "employer_state_id",
+            "employer_puma",
+            "employer_name",
+        ]:
             df_w2[col] = df_w2["employer_id"].map(emp[col])
 
         return df_w2[self.output_columns]

--- a/src/vivarium_census_prl_synth_pop/components/observers.py
+++ b/src/vivarium_census_prl_synth_pop/components/observers.py
@@ -563,6 +563,8 @@ class TaxW2Observer(BaseObserver):
         "employer_id",
         "employer_name",
         "employer_address_id",
+        "employer_state_id",
+        "employer_puma",
         "income",
         "housing_type",
         "tax_year",
@@ -709,7 +711,7 @@ class TaxW2Observer(BaseObserver):
 
         # merge in employer columns based on employer_id
         emp = business_details.groupby("employer_id").first()
-        for col in ["employer_address_id", "employer_name"]:
+        for col in ["employer_address_id", "employer_state_id", "employer_puma", "employer_name"]:
             df_w2[col] = df_w2["employer_id"].map(emp[col])
 
         return df_w2[self.output_columns]

--- a/src/vivarium_census_prl_synth_pop/utilities.py
+++ b/src/vivarium_census_prl_synth_pop/utilities.py
@@ -11,7 +11,7 @@ from vivarium.framework.lookup import LookupTable
 from vivarium.framework.randomness import Array, RandomnessStream, get_hash, random
 from vivarium.framework.values import Pipeline
 
-from vivarium_census_prl_synth_pop.constants import metadata
+from vivarium_census_prl_synth_pop.constants import metadata, paths
 
 SeededDistribution = Tuple[str, stats.rv_continuous]
 
@@ -385,3 +385,51 @@ def sample_acs_group_quarters(
     )
 
     return chosen_persons
+
+
+def randomly_sample_states_pumas(
+    unit_ids: pd.Series,
+    available_states: List[int],
+    additional_key: str,
+    randomness_stream: RandomnessStream = None,
+    random_seed: int = None,
+) -> pd.DataFrame:
+    """Randomly sample new states and pumas from the raw data file.
+
+    Args:
+        unit_ids (pd.Series): household_ids or business_ids to sample for
+        available_states (List[int]): states in the artifact data
+        additional_key (str): standard RandomnessStream additional_key
+        randomness_stream (RandomnessStream, optional): Defaults to None.
+        random_seed (int, optional): Only used when trying to call
+            vectorized_choice when no RandomnessStream is available
+            (eg during setup). Defaults to None.
+
+    Returns:
+        pd.DataFrame: Index are the unit_ids and has columns [['state_id', 'puma']]
+    """
+    if random_seed is None and randomness_stream is None:
+        raise RuntimeError("A randomness_stream or random_seed must be provided")
+    if random_seed is not None and randomness_stream is not None:
+        raise RuntimeError("Only one of randomness_stream or random_seed should be provided")
+
+    state_puma_options = pd.read_csv(paths.PUMA_TO_ZIP_DATA_PATH)[
+        ["state", "puma"]
+    ].drop_duplicates()
+    # Subset to only states that exist in the artifact
+    state_puma_options = state_puma_options[
+        state_puma_options["state"].isin(available_states)
+    ]
+
+    states_pumas_idx = vectorized_choice(
+        options=state_puma_options.index,
+        n_to_choose=len(unit_ids),
+        randomness_stream=randomness_stream,
+        additional_key=additional_key,
+        random_seed=random_seed,
+    )
+    states_pumas = state_puma_options.loc[states_pumas_idx]
+    states_pumas.index = unit_ids
+    states_pumas = states_pumas.rename(columns={"state": "state_id"})
+
+    return states_pumas

--- a/src/vivarium_census_prl_synth_pop/utilities.py
+++ b/src/vivarium_census_prl_synth_pop/utilities.py
@@ -439,5 +439,5 @@ def get_state_puma_options(builder: Builder) -> pd.DataFrame:
     state_puma_options = state_puma_options[
         state_puma_options["state"].isin(states_in_artifact)
     ]
-    
+
     return state_puma_options


### PR DESCRIPTION
## Title: Add employer state id and PUMA to sim

### Description
- *Category*: implementation
- *JIRA issue*: [MIC-3831](https://jira.ihme.washington.edu/browse/MIC-3831)
- *Research reference*: na

### Changes and notes
Adds `employer_state_id` and `employer_puma` to the business_details pipeline.
Also updates the w2 observer to include these new columns in the output.

NOTE: This also includes Jira task [MIC-3830](https://jira.ihme.washington.edu/browse/MIC-3830)

### Verification and Testing
All pytests pass and a short sim run.

