### PR TITLE
Remove unnecessary household sampling

### DIFF
--- a/src/vivarium_census_prl_synth_pop/components/population.py
+++ b/src/vivarium_census_prl_synth_pop/components/population.py
@@ -594,18 +594,6 @@ class Population:
         new_simulants = self.assign_general_population_guardians(new_simulants, full_pop)
         new_simulants = self.assign_college_simulants_guardians(new_simulants, full_pop)
 
-        # Ensure these stay integers -- they will have become floats in the existing_simulants due to
-        # the addition of NaNs
-        link_cols = [
-            "first_name_id",
-            "middle_name_id",
-            "last_name_id",
-            "guardian_1",
-            "guardian_2",
-        ]
-        for link_col in link_cols:
-            new_simulants[link_col] = new_simulants[link_col].astype(int)
-
         return new_simulants
 
     def assign_general_population_guardians(
@@ -1258,9 +1246,13 @@ class Population:
         # a simulants_to_assign row were both linked *to* and linked *from* here!
         # That only one or the other occurs is guaranteed by our relation_to_household_head
         # criteria above.
-        simulants_to_assign.loc[relatives_idx, "last_name_id"] = simulants_to_assign.loc[
-            relatives_idx, "household_id"
-        ].map(reference_person_last_name_ids)
+        # We have to set the type because it will have become a float with the addition of
+        # NaNs.
+        simulants_to_assign.loc[relatives_idx, "last_name_id"] = (
+            simulants_to_assign.loc[relatives_idx, "household_id"]
+            .map(reference_person_last_name_ids)
+            .astype(int)
+        )
 
         return simulants_to_assign
 

--- a/src/vivarium_census_prl_synth_pop/data/loader.py
+++ b/src/vivarium_census_prl_synth_pop/data/loader.py
@@ -154,6 +154,8 @@ def load_households(key: str, location: str) -> pd.DataFrame:
     data = data[data["census_household_id"].isin(persons["census_household_id"])]
 
     # merge in person weights for GQ
+    # FIXME -- this is no longer necessary, since person_weights in the household file
+    # are not used by the simulation anymore.
     gq_households = data[data["household_type"] != "Housing unit"]
     gq_persons = persons[
         persons["census_household_id"].isin(gq_households["census_household_id"])

--- a/src/vivarium_census_prl_synth_pop/utilities.py
+++ b/src/vivarium_census_prl_synth_pop/utilities.py
@@ -364,51 +364,14 @@ def sample_acs_standard_households(
     return chosen_households, chosen_persons
 
 
-def sample_acs_group_quarters(
-    target_number_sims: int,
-    acs_households: pd.DataFrame,
-    acs_persons: pd.DataFrame,
-    randomness: RandomnessStream,
-) -> Tuple[pd.DataFrame, pd.DataFrame]:
-    """
-    Samples GQ people from ACS.
-    The persons returned include the state and puma columns
-    (currently in households data only, hence the need for the acs_households argument).
-    """
-
-    # group quarters each house one person per census_household_id
-    # they have NA household weights, but appropriately weighted person weights.
-    chosen_units_index = vectorized_choice(
-        options=acs_households.index,
-        n_to_choose=target_number_sims,
-        randomness_stream=randomness,
-        weights=acs_households["person_weight"],
-        additional_key="choose_gq_units",
-    )
-    chosen_units = acs_households.loc[chosen_units_index]
-
-    # get simulants per GQ unit
-    # Once state and puma are in the households pipeline, we will not need to do this
-    chosen_persons = pd.merge(
-        chosen_units[["state", "puma", "census_household_id"]],
-        acs_persons[metadata.PERSONS_COLUMNS_TO_INITIALIZE],
-        on="census_household_id",
-        how="left",
-    )
-
-    return chosen_persons
-
-
 def sample_acs_persons(
     target_number_sims: int,
-    acs_households: pd.DataFrame,
     acs_persons: pd.DataFrame,
     randomness: RandomnessStream,
+    additional_key: str,
 ) -> pd.DataFrame:
     """
     Samples persons from ACS individually with person weights.
-    The persons returned include the state and puma columns
-    (currently in households data only, hence the need for the acs_households argument).
     """
 
     chosen_persons_index = vectorized_choice(
@@ -416,16 +379,7 @@ def sample_acs_persons(
         n_to_choose=target_number_sims,
         randomness_stream=randomness,
         weights=acs_persons["person_weight"],
-        additional_key="choose_acs_persons",
-    )
-    chosen_persons = acs_persons.loc[chosen_persons_index]
-
-    # Once state and puma are in the households pipeline, we will not need to do this
-    chosen_persons = pd.merge(
-        chosen_persons,
-        acs_households[["state", "puma", "census_household_id"]],
-        on="census_household_id",
-        how="left",
+        additional_key=additional_key,
     )
 
-    return chosen_persons
+    return acs_persons.loc[chosen_persons_index].reset_index(drop=True)


### PR DESCRIPTION
## Remove unnecessary household sampling

### Description
- *Category*: refactor
- *JIRA issue*: none
- *Research reference*: none

### Changes and notes

Revises #174 for the changes that have recently been made in main, removing the state and PUMA columns from the state table.

I plan to squash this with #174 before merging the epic to main.

### Verification and Testing

Integration tests passing.