### PR TITLE
Updating age perturbation SD from 10 to 1

### DIFF
--- a/src/vivarium_census_prl_synth_pop/components/population.py
+++ b/src/vivarium_census_prl_synth_pop/components/population.py
@@ -1136,7 +1136,7 @@ class Population:
         )
         # Convert to normal distribution with mean=0 and sd=10
         age_shift = pd.Series(
-            data=stats.norm.ppf(age_shift_propensity, loc=0, scale=10),
+            data=stats.norm.ppf(age_shift_propensity, loc=0, scale=1),
             index=age_shift_propensity.index,
         )
         # Map age_shift to households so each member's age is perturbed the same amount
@@ -1176,7 +1176,7 @@ class Population:
             )
             # Convert to normal distribution with mean=0 and sd=10
             age_shift = pd.Series(
-                data=stats.norm.ppf(age_shift_propensity, loc=0, scale=10),
+                data=stats.norm.ppf(age_shift_propensity, loc=0, scale=1),
                 index=age_shift_propensity.index,
             )
 


### PR DESCRIPTION
## Update age perturbation standard deviation.

### Changes age perturbation standard deviation from 10 to 1 year.
- *Category*: Other
- *JIRA issue*: [MIC-3829](https://jira.ihme.washington.edu/browse/MIC-3829)
- *Research reference*:  https://github.com/ihmeuw/vivarium_research/pull/1135

### Changes and notes
-Changes standard deviation of age perturbation for households and individuals from 10 years to 1.

### Verification and Testing
-V&V run .

