### PR TITLE
Add persistent ITIN for stimulants without SSN

### DIFF
--- a/src/vivarium_census_prl_synth_pop/results_processing/ssn_and_itin.py
+++ b/src/vivarium_census_prl_synth_pop/results_processing/ssn_and_itin.py
@@ -48,7 +48,7 @@ def generate_itin(
     pre_shift_groups = itin["group"].copy()
     itin.loc[pre_shift_groups <= 16, "group"] += 49
     itin.loc[((pre_shift_groups <= 35) & (pre_shift_groups >= 17)), "group"] += 53
-    itin.loc[((pre_shift_groups <= 38) & (pre_shift_groups >= 36)), "group"] += 52
+    itin.loc[((pre_shift_groups <= 38) & (pre_shift_groups >= 36)), "group"] += 54
     itin.loc[pre_shift_groups >= 39, "group"] += 55
 
     # Serial numbers 1-9999 inclusive

--- a/src/vivarium_census_prl_synth_pop/results_processing/ssn_and_itin.py
+++ b/src/vivarium_census_prl_synth_pop/results_processing/ssn_and_itin.py
@@ -8,9 +8,9 @@ from vivarium_census_prl_synth_pop.utilities import random_integers
 
 
 def generate_itin(
-        size: int,
-        additional_key: Any,
-        randomness: RandomnessStream,
+    size: int,
+    additional_key: Any,
+    randomness: RandomnessStream,
 ) -> np.ndarray:
     """
     Generate a np.ndarray of length `size` of hopefully unique ITIN values.
@@ -60,7 +60,9 @@ def generate_itin(
         additional_key=f"{additional_key}_itin_serial",
     )
     itin["itin"] = ""
-    itin["itin"] += itin["area"].astype(str) + "-"  # no zfill needed, values should be 900-999
+    itin["itin"] += (
+        itin["area"].astype(str) + "-"
+    )  # no zfill needed, values should be 900-999
     itin["itin"] += itin["group"].astype(str) + "-"  # no zfill needed likewise
     itin["itin"] += itin["serial"].astype(str).str.zfill(4)
 

--- a/src/vivarium_census_prl_synth_pop/results_processing/ssn_and_itin.py
+++ b/src/vivarium_census_prl_synth_pop/results_processing/ssn_and_itin.py
@@ -1,0 +1,67 @@
+from typing import Any
+
+import numpy as np
+import pandas as pd
+from vivarium.framework.randomness import RandomnessStream
+
+from vivarium_census_prl_synth_pop.utilities import random_integers
+
+
+def generate_itin(
+        size: int,
+        additional_key: Any,
+        randomness: RandomnessStream,
+) -> np.ndarray:
+    """
+    Generate a np.ndarray of length `size` of hopefully unique ITIN values.
+
+        first three digits 900-999, followed by dash
+        next two digits between 50-65, 70-88, 90-92, or 94-99, followed by a dash
+        last four digits between 1-9999
+
+    :param size: The number of itins to generate
+    :param additional_key: Additional key to be used by randomness
+    :param randomness: RandomnessStream stream to use
+
+    """
+    itin = pd.DataFrame(index=pd.Index(range(size)))
+
+    # Area numbers have range 900-999, inclusive
+    itin["area"] = random_integers(
+        min_val=900,
+        max_val=999,
+        index=itin.index,
+        randomness=randomness,
+        additional_key=f"{additional_key}_itin_area",
+    )
+
+    # Group numbers have range 50-65, 70-88, 90-92, or 94-99, inclusive
+    itin["group"] = random_integers(
+        min_val=1,
+        max_val=44,  # (65-50+1)+(88-70+1)+(92-90+1)+(99-94+1)
+        index=itin.index,
+        randomness=randomness,
+        additional_key=f"{additional_key}_itin_group",
+    )
+
+    # Rescale the group digits to match expected ranges
+    pre_shift_groups = itin["group"].copy()
+    itin.loc[pre_shift_groups <= 16, "group"] += 49
+    itin.loc[((pre_shift_groups <= 35) & (pre_shift_groups >= 17)), "group"] += 53
+    itin.loc[((pre_shift_groups <= 38) & (pre_shift_groups >= 36)), "group"] += 52
+    itin.loc[pre_shift_groups >= 39, "group"] += 55
+
+    # Serial numbers 1-9999 inclusive
+    itin["serial"] = random_integers(
+        min_val=1,
+        max_val=9999,
+        index=itin.index,
+        randomness=randomness,
+        additional_key=f"{additional_key}_itin_serial",
+    )
+    itin["itin"] = ""
+    itin["itin"] += itin["area"].astype(str) + "-"  # no zfill needed, values should be 900-999
+    itin["itin"] += itin["group"].astype(str) + "-"  # no zfill needed likewise
+    itin["itin"] += itin["serial"].astype(str).str.zfill(4)
+
+    return itin["itin"].to_numpy()

--- a/tests/test_synthetic_pii.py
+++ b/tests/test_synthetic_pii.py
@@ -65,11 +65,11 @@ def test_itin_generation():
     serials = itins.apply(lambda x: int(x.split("-")[2]))
     assert (areas >= 900).all() and (areas <= 999).all()
     assert (
-            ((groups >= 50) & (groups <= 65))
-            | ((groups >= 70) & (groups <= 88))
-            | ((groups >= 90) & (groups <= 92))
-            | ((groups >= 94) & (groups <= 99))
-            ).all()
+        ((groups >= 50) & (groups <= 65))
+        | ((groups >= 70) & (groups <= 88))
+        | ((groups >= 90) & (groups <= 92))
+        | ((groups >= 94) & (groups <= 99))
+    ).all()
     assert (serials >= 1).all() and (serials <= 9999).all()
 
 

--- a/tests/test_synthetic_pii.py
+++ b/tests/test_synthetic_pii.py
@@ -18,6 +18,7 @@ from vivarium_census_prl_synth_pop.results_processing.names import (
     get_given_name_map,
     get_last_name_map,
 )
+from vivarium_census_prl_synth_pop.results_processing.ssn_and_itin import generate_itin
 
 key = "test_synthetic_data_generation"
 clock = lambda: pd.Timestamp("2020-09-01")
@@ -51,6 +52,25 @@ def test_ssn(mocker):
     assert len(group) == 2
     assert len(serial) == 4
     # todo: Add test of uniqueness
+
+
+def test_itin_generation():
+    itins = pd.Series(generate_itin(10_000, "test_itin_generation", randomness))
+
+    # FIXME: Uniqueness test accepts duplicates pending resolution of MIC-3837
+    assert itins.duplicated().sum() < 5
+
+    areas = itins.apply(lambda x: int(x.split("-")[0]))
+    groups = itins.apply(lambda x: int(x.split("-")[1]))
+    serials = itins.apply(lambda x: int(x.split("-")[2]))
+    assert (areas >= 900).all() and (areas <= 999).all()
+    assert (
+            ((groups >= 50) & (groups <= 65))
+            | ((groups >= 70) & (groups <= 88))
+            | ((groups >= 90) & (groups <= 92))
+            | ((groups >= 94) & (groups <= 99))
+            ).all()
+    assert (serials >= 1).all() and (serials <= 9999).all()
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Add persistent ITIN for stimulants without SSN

### Description
- *Category*:  implementation
- *JIRA issue*: [MIC-3573](https://jira.ihme.washington.edu/browse/MIC-3573)
- *Research reference*: https://vivarium-research.readthedocs.io/en/latest/models/concept_models/vivarium_census_synthdata/concept_model.html#itin-generation

### Changes and notes
- Adds a generate ITIN function and related tests
- Problem of collisions is deferred for [MIC-3837](https://jira.ihme.washington.edu/browse/MIC-3837)

### Verification and Testing
Unit tests pass

