### PR TITLE
implement CRNs for business move dynamics across parallel runs

### DIFF
--- a/src/vivarium_census_prl_synth_pop/components/population.py
+++ b/src/vivarium_census_prl_synth_pop/components/population.py
@@ -31,6 +31,8 @@ PARTNERS = [
 
 
 class Population:
+    configuration_defaults = {"us_population_size": data_values.US_POPULATION}
+
     @property
     def name(self):
         return "population"

--- a/src/vivarium_census_prl_synth_pop/constants/data_values.py
+++ b/src/vivarium_census_prl_synth_pop/constants/data_values.py
@@ -11,6 +11,7 @@ from vivarium_census_prl_synth_pop.constants import paths
 
 # TODO: implement gbd call (vivarium_inputs.get_population_structure("United States"))
 US_POPULATION = 333339776
+PROPORTION_18_PLUS = 0.7756
 
 MAX_HOUSEHOLD_SIZE = 17
 PROP_POPULATION_IN_GQ = 0.03

--- a/src/vivarium_census_prl_synth_pop/constants/data_values.py
+++ b/src/vivarium_census_prl_synth_pop/constants/data_values.py
@@ -11,7 +11,7 @@ from vivarium_census_prl_synth_pop.constants import paths
 
 # TODO: implement gbd call (vivarium_inputs.get_population_structure("United States"))
 US_POPULATION = 333339776
-PROPORTION_18_PLUS = 0.7756
+PROPORTION_WORKING_AGE = 0.7756
 
 MAX_HOUSEHOLD_SIZE = 17
 PROP_POPULATION_IN_GQ = 0.03

--- a/src/vivarium_census_prl_synth_pop/model_specifications/model_spec.yaml
+++ b/src/vivarium_census_prl_synth_pop/model_specifications/model_spec.yaml
@@ -44,3 +44,4 @@ configuration:
         step_size: 28 # Days
     population:
         population_size: 250_000
+    # us_population_size: 250_000  # Override the default US population size


### PR DESCRIPTION
## Title: Implement business move dynamics CRN

### Description
- *Category*: Implementation
- *JIRA issue*: [MIC-3836](https://jira.ihme.washington.edu/browse/MIC-3836)
- *Research reference*: na

### Changes and notes
Business are different than households in that new businesses are never generated
during the sim. Currently, parallel simulations have no idea what businesses are
moving in the other sims. This utilizes a new RandomnessStream that does 
not use simulation random_seed for such dynamics

Other notes:

- Added a us_population_size key to the config file (mostly for debugging purposes
    probably) - it overrides the real US population in data_values
- Fundamentally changed the way the "bank" of employers is built. Instead of scaling
    with the number of 18+ simulants (which lead to different sized banks) we now
    rely on the actual up_population_size and a since percentage scalar.
- Changed randomness.choice to vectorized_choice when assigning employer_ids
    b/c it was way too memory-intensive when building up the initial sim using the much
    larger bank of employers


### Verification and Testing
- pytests pass
- ensured that tax w2 observer reports a single address for each employer now
- loads of other qc

