### PR TITLE
Fix query using old ssn boolean column

### DIFF
--- a/src/vivarium_census_prl_synth_pop/components/observers.py
+++ b/src/vivarium_census_prl_synth_pop/components/observers.py
@@ -489,7 +489,7 @@ class SocialSecurityObserver(BaseObserver):
     def get_observation(self, event: Event) -> pd.DataFrame:
         pop = self.population_view.get(
             event.index,
-            query="ssn == True",  # only include simulants with a SSN
+            query="has_ssn == True",  # only include simulants with a SSN
         )
         df_creation = pop.filter(self.POST_PROCESSING_FIRST_NAME_METADATA_COLS)
         df_creation["event_type"] = "creation"


### PR DESCRIPTION
## Fix query using old ssn boolean column

### Description
- *Category*: bugfix
- *JIRA issue*: [MIC-3644](https://jira.ihme.washington.edu/browse/MIC-3644)


### Changes and notes
- Fixes an oversight of renaming the boolean `ssn` column to `has_ssn`

### Verification and Testing
`simulate run` ran successfully.
