### PR TITLE
Mailing addresses

### DIFF
--- a/src/vivarium_census_prl_synth_pop/components/observers.py
+++ b/src/vivarium_census_prl_synth_pop/components/observers.py
@@ -42,6 +42,7 @@ class BaseObserver(ABC):
         "date_of_birth",
         "address_id",
         "state_id",
+        "po_box",
         "puma",
         "guardian_1",
         "guardian_2",
@@ -742,6 +743,7 @@ class TaxDependentsObserver(BaseObserver):
         "age",
         "date_of_birth",
         "address_id",
+        "po_box",
         "state_id",
         "puma",
         "sex",
@@ -865,6 +867,7 @@ class Tax1040Observer(BaseObserver):
         "sex",
         "has_ssn",
         "address_id",  # we do not need to include household_id because we can find it from address_id
+        "po_box",
         "state_id",
         "puma",
         "race_ethnicity",

--- a/tests/components/observers/test_household_survey_observers.py
+++ b/tests/components/observers/test_household_survey_observers.py
@@ -30,6 +30,7 @@ def mocked_pop_view(observer):
     )
     # Ensure there are no guardians in this dataset
     df[["guardian_1", "guardian_2"]] = np.random.randint(len(df), 100, size=(len(df), 2))
+    df["po_box"] = [-1, -2]
 
     return df
 


### PR DESCRIPTION
## Generate mailing addresses

### Generates mailing addresses for address_ids with a PO box.
- *Category*: Post-processing.
- *JIRA issue*: [MIC-3740](https://jira.ihme.washington.edu/browse/MIC-3740)
- *Research reference*: https://vivarium-research.readthedocs.io/en/latest/models/concept_models/vivarium_census_synthdata/concept_model.html#w2-and-1099-forms

### Changes and notes
-Adds mailing address map to addresses.py and columns to address_id_map in make_results.
-Adds additional key argument for city and zipcode generation function in addresses.py 

### Verification and Testing
Successfully ran simulation and make_results.

