### PR TITLE
fix bug in borrowing ssns from household members

### DIFF
--- a/src/vivarium_census_prl_synth_pop/components/observers.py
+++ b/src/vivarium_census_prl_synth_pop/components/observers.py
@@ -1,7 +1,6 @@
 import datetime as dt
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import List
 
 import numpy as np
 import pandas as pd
@@ -594,9 +593,7 @@ class TaxW2Observer(BaseObserver):
         super().setup(builder)
         self.clock = builder.time.clock()
 
-        vivarium_randomness = builder.randomness.get_stream(
-            self.name, for_initialization=True
-        )
+        vivarium_randomness = builder.randomness.get_stream(self.name)
         np_random_seed = 12345 + int(vivarium_randomness.seed)
         self.np_randomness = np.random.default_rng(np_random_seed)
 
@@ -694,9 +691,7 @@ class TaxW2Observer(BaseObserver):
 
         # for simulants without ssn, record a simulant_id for a random household
         # member with an ssn, if one exists
-        simulants_wo_ssn = pd.Series(
-            df_w2[~df_w2["has_ssn"]].index, index=df_w2[~df_w2["has_ssn"]].index
-        )
+        simulants_wo_ssn = df_w2.loc[~df_w2["has_ssn"], "address_id"]
         household_members_w_ssn = (
             pop[pop["has_ssn"]].groupby("address_id").apply(lambda df_g: list(df_g.index))
         )


### PR DESCRIPTION
## Fix bug in borrowing ssns from household members
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: bugfix
- *JIRA issue*: [MIC-3843](https://jira.ihme.washington.edu/browse/MIC-3843)
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
Fixes bug where we were not properly having simulants without an SSN borrow one from a member of their household 
Also fixed usage of randomness stream in W2 observer (the `for_initialization` flag was being used inappropriately)

### Verification and Testing
Ran simulation and verified that SSNs are now correctly chosen.
