### PR TITLE
Support arbitrarily small populations

### DIFF
--- a/src/vivarium_census_prl_synth_pop/components/businesses.py
+++ b/src/vivarium_census_prl_synth_pop/components/businesses.py
@@ -338,7 +338,7 @@ class Businesses:
     def assign_different_employer(self, changing_jobs: pd.Index) -> pd.Series:
         current_employers = self.population_view.subview(["employer_id"]).get(
             changing_jobs, query="tracked"
-        )["employer_id"]
+        ).squeeze(axis=1)
 
         new_employers = current_employers.copy()
 

--- a/src/vivarium_census_prl_synth_pop/components/businesses.py
+++ b/src/vivarium_census_prl_synth_pop/components/businesses.py
@@ -336,9 +336,11 @@ class Businesses:
         )
 
     def assign_different_employer(self, changing_jobs: pd.Index) -> pd.Series:
-        current_employers = self.population_view.subview(["employer_id"]).get(
-            changing_jobs, query="tracked"
-        ).squeeze(axis=1)
+        current_employers = (
+            self.population_view.subview(["employer_id"])
+            .get(changing_jobs, query="tracked")
+            .squeeze(axis=1)
+        )
 
         new_employers = current_employers.copy()
 

--- a/src/vivarium_census_prl_synth_pop/components/businesses.py
+++ b/src/vivarium_census_prl_synth_pop/components/businesses.py
@@ -2,6 +2,7 @@ from typing import Any, Union
 
 import numpy as np
 import pandas as pd
+from loguru import logger
 from scipy import stats
 from vivarium.framework.engine import Builder
 from vivarium.framework.event import Event
@@ -335,24 +336,28 @@ class Businesses:
         )
 
     def assign_different_employer(self, changing_jobs: pd.Index) -> pd.Series:
-        # TODO: This limits employers to those existing in the pop table. If
-        # we want all employers that were initialized to be included, we can
-        # instead use the business data structure.
-        current_employers = (
-            self.population_view.subview(["employer_id"])
-            .get(changing_jobs, query="tracked")
-            .squeeze()
-        )
+        current_employers = self.population_view.subview(["employer_id"]).get(
+            changing_jobs, query="tracked"
+        )["employer_id"]
 
         new_employers = current_employers.copy()
-        additional_seed = 0
-        while (current_employers == new_employers).any():
+
+        for iteration in range(10):
             unchanged_employers = current_employers == new_employers
+            if not unchanged_employers.any():
+                break
+
             new_employers[unchanged_employers] = self.assign_random_employer(
                 sim_index=new_employers[unchanged_employers].index,
-                additional_seed=additional_seed,
+                additional_seed=iteration,
             )
-            additional_seed += 1
+
+        if (current_employers == new_employers).sum() > 0:
+            logger.info(
+                f"Maximum iterations for resampling of employer reached. "
+                f"The number of simulants whose employer_id was not changed despite being "
+                f"selected for an employment change is {(current_employers == new_employers).sum()}"
+            )
 
         return new_employers
 

--- a/src/vivarium_census_prl_synth_pop/components/person_migration.py
+++ b/src/vivarium_census_prl_synth_pop/components/person_migration.py
@@ -226,16 +226,19 @@ class PersonMigration:
         to_move = movers
         household_id_values = pop.loc[movers, "household_id"]
 
-        for iteration in range(10):
-            if to_move.empty:
-                break
+        # There is an edge case in very small populations where there are no households
+        # to move to; in that case, the move is not performed
+        if len(households_with_non_movers) > 0:
+            for iteration in range(10):
+                if to_move.empty:
+                    break
 
-            household_id_values[to_move] = self.randomness.choice(
-                to_move,
-                choices=households_with_non_movers,
-                additional_key=f"non_reference_person_move_household_ids_{iteration}",
-            )
-            to_move = movers[household_id_values == pop.loc[movers, "household_id"]]
+                household_id_values[to_move] = self.randomness.choice(
+                    to_move,
+                    choices=households_with_non_movers,
+                    additional_key=f"non_reference_person_move_household_ids_{iteration}",
+                )
+                to_move = movers[household_id_values == pop.loc[movers, "household_id"]]
 
         if len(to_move) > 0:
             logger.info(


### PR DESCRIPTION
## Support arbitrarily small populations

### Description
- *Category*: misc
- *JIRA issue*: none
- *Research reference*: none

### Changes and notes

In working on "fuzzy testing" I discovered a few places where the simulation itself would error with too small of a population.

### Verification and Testing

Integration tests (at normal population size). Ran simulation to completion with population size of 1 (with two different random seeds). There may still be some rare events that I have missed.