### PR TITLE
Test only one spouse/partner per household

### DIFF
--- a/integration_tests/test_household_structure.py
+++ b/integration_tests/test_household_structure.py
@@ -99,6 +99,23 @@ def test_households_only_have_one_reference_person(tracked_live_populations):
         assert len(household_ids) == len(household_ids.unique())
 
 
+def test_households_only_have_one_parter_or_spouse(tracked_live_populations):
+    for pop in tracked_live_populations:
+        household_ids = pop.loc[
+            pop["relation_to_household_head"].isin(
+                [
+                    "Opp-sex spouse",
+                    "Opp-sex partner",
+                    "Same-sex spouse",
+                    "Same-sex partner",
+                ]
+            ),
+            "household_id",
+        ]
+
+        assert household_ids.is_unique
+
+
 def test_housing_type_does_not_change(simulants_on_adjacent_timesteps):
     """Household types should not change for a given household"""
     for before, after in simulants_on_adjacent_timesteps:


### PR DESCRIPTION
## Test only one spouse/partner per household

### Description
- *Category*: test
- *JIRA issue*: none
- *Research reference*: none

### Changes and notes

The simulation has been designed never to create a household with more than one spouse or partner. However, this was not tested.

### Verification and Testing

Integration tests passing.