### PR TITLE
Set w2 observation index to simulant_id

### DIFF
--- a/src/vivarium_census_prl_synth_pop/components/observers.py
+++ b/src/vivarium_census_prl_synth_pop/components/observers.py
@@ -715,6 +715,7 @@ class TaxW2Observer(BaseObserver):
         ]:
             df_w2[col] = df_w2["employer_id"].map(business_details[col])
 
+        df_w2 = df_w2.set_index(["simulant_id"])
         return df_w2[self.output_columns]
 
 


### PR DESCRIPTION
## Set w2 observation index to simulant_id

### Description
- *Category*: bugfix
- *JIRA issue*: [MIC-3841](https://jira.ihme.washington.edu/browse/MIC-3841)


### Changes and notes
- Previous behavior was that the w2 observer had simulant_ids that were assigned to different logical simulants. That was a result of not using/returning the index in the observation DataFrame.
- Issue is resolved by indexing on simulant_id, however a probably better approach would be to have all the observers output the simulant_id column and then post-processing doesn't have to assume the index is the simulant_id.

### Verification and Testing
w2 observer before (simulant_id 10 is assigned to several different logical simulants):

```
(base) tax_w2_observer mkappel$ egrep "^10," tax_w2_observer_2284.csv
10,16,16,16,31.81839999497025,1989-02-13,Male,True,-1,1,13,2900,0,642828,not implemented,642828,12,903,14633.887842150314,Nursing home,2020,Black
10,14,14,14,69.10976193642514,1952-10-29,Male,True,-1,10,22,100,0,994236,not implemented,994236,29,600,24520.678971485107,Standard,2021,White
10,16,16,16,33.81155536800248,1989-02-13,Male,True,-1,1,13,2900,0,642828,not implemented,642828,12,903,17560.665410580375,Nursing home,2022,Black
10,16,16,16,34.8081330545186,1989-02-13,Male,True,-1,5922,42,2002,0,1230428,not implemented,1230428,12,1104,5454.081201511688,Standard,2023,Black
10,14,14,14,72.0994949959735,1952-10-29,Male,True,-1,10,22,100,0,265541,not implemented,265541,39,3100,30674.35697516665,Standard,2024,White
10,8,8,7,37.6980238642602,1988-04-20,Female,True,-1,12567,27,1900,0,1238780,not implemented,2661400,45,1204,15374.651980036979,Standard,2025,Asian
10,13,13,10,30.637533595077162,1996-05-11,Male,True,-1,9,34,1202,0,59734,not implemented,59734,9,102,3513.385835293687,Standard,2026,AIAN
10,11,11,10,61.38519572464014,1966-08-10,Female,True,-1,9,34,1202,0,845158,not implemented,845158,25,4303,7936.251672310572,Standard,2027,Latino
10,11,11,10,62.38177341115626,1966-08-10,Female,True,-1,9,34,1202,0,845158,not implemented,845158,25,4303,6715.289876570484,Standard,2028,Latino
10,10,10,10,69.95816783697943,1960-01-11,Male,False,15,9,34,1202,0,1034373,not implemented,2193309,48,2002,130466.68187094288,Standard,2029,Latino
```

After fix:
```
(prl) tax_w2_observer mkappel$ egrep "^10," tax_w2_observer_2284.csv
10,10,10,10,60.91230883629466,1960-01-11,Male,False,12,9,34,1202,0,650079,not implemented,650079,17,3532,158485.5533633832,Standard,2020,Latino
10,10,10,10,61.90888652281078,1960-01-11,Male,False,11,9,34,1202,0,650079,not implemented,650079,17,3532,126788.44269070655,Standard,2021,Latino
10,10,10,10,61.90888652281078,1960-01-11,Male,False,13,9,34,1202,0,871147,not implemented,1925227,13,1008,55215.40760097568,Standard,2021,Latino
10,10,10,10,62.9054642093269,1960-01-11,Male,False,12,9,34,1202,0,416204,not implemented,416204,34,601,140795.1519692534,Standard,2022,Latino
10,10,10,10,62.9054642093269,1960-01-11,Male,False,11,9,34,1202,0,871147,not implemented,1925227,13,1008,11043.081520195137,Standard,2022,Latino
10,10,10,10,63.90204189584302,1960-01-11,Male,False,13,9,34,1202,0,789494,not implemented,789494,21,1100,133818.9414083211,Standard,2023,Latino
10,10,10,10,64.89861958235913,1960-01-11,Male,False,13,9,34,1202,0,789494,not implemented,789494,21,1100,133818.9414083211,Standard,2024,Latino
10,10,10,10,65.97185709091495,1960-01-11,Male,False,13,9,34,1202,0,789494,not implemented,789494,21,1100,113231.41196088708,Standard,2025,Latino
10,10,10,10,65.97185709091495,1960-01-11,Male,False,13,9,34,1202,0,1742994,not implemented,2158634,48,4633,45390.58628625412,Standard,2025,Latino
10,10,10,10,66.96843477743107,1960-01-11,Male,False,11,9,34,1202,0,1742994,not implemented,2919431,48,2308,196692.5405737679,Standard,2026,Latino
10,10,10,10,67.96501246394719,1960-01-11,Male,False,13,9,34,1202,0,752301,not implemented,752301,47,300,46498.375145242404,Standard,2027,Latino
10,10,10,10,67.96501246394719,1960-01-11,Male,False,13,9,34,1202,0,1742994,not implemented,2919431,48,2308,136171.7588587624,Standard,2027,Latino
10,10,10,10,68.96159015046331,1960-01-11,Male,False,11,9,34,1202,0,752301,not implemented,752301,47,300,11624.593786310601,Standard,2028,Latino
10,10,10,10,68.96159015046331,1960-01-11,Male,False,11,9,34,1202,0,1034373,not implemented,2193309,48,2002,120430.78326548573,Standard,2028,Latino
10,10,10,10,69.95816783697943,1960-01-11,Male,False,11,9,34,1202,0,1034373,not implemented,2193309,48,2002,130466.68187094288,Standard,2029,Latino
```


