### PR TITLE
re-enable simulant_id maps

### DIFF
--- a/src/vivarium_census_prl_synth_pop/tools/make_results.py
+++ b/src/vivarium_census_prl_synth_pop/tools/make_results.py
@@ -159,8 +159,7 @@ def generate_maps(
         "last_name_id": get_last_name_map,
         "address_id": get_address_id_maps,
         "employer_id": get_employer_name_map,
-        # "simulant_id": get_simulant_id_maps,
-        # fixme: MIC-3841 issue with W2 observer
+        "simulant_id": get_simulant_id_maps,
     }
     maps = {
         column: mapper(column, obs_data, artifact, randomness)


### PR DESCRIPTION
## Re-enable simulant_id maps

### Description
- *Category*: implementation
- *JIRA issue*: [MIC-3841](https://jira.ihme.washington.edu/browse/MIC-3841)


### Changes and notes
 - After fix to MIC-3841 via #227, we can map SSNs, this uncomments code waiting for that fix.

### Verification and Testing
Ran post processing, SSN strings appeared in w2 tax observer final results output.

