### PR TITLE
Post processing column handling

### DIFF
--- a/src/vivarium_census_prl_synth_pop/components/observers.py
+++ b/src/vivarium_census_prl_synth_pop/components/observers.py
@@ -308,8 +308,16 @@ class WICObserver(BaseObserver):
     """Class for observing columns relevant to WIC administrative data."""
 
     INPUT_VALUES = ["income", "household_details"]
-    ADDITIONAL_INPUT_COLUMNS = ["household_id", "relation_to_household_head",]
-    ADDITIONAL_OUTPUT_COLUMNS = ["wic_year", "household_id", "housing_type", "relation_to_household_head"]
+    ADDITIONAL_INPUT_COLUMNS = [
+        "household_id",
+        "relation_to_household_head",
+    ]
+    ADDITIONAL_OUTPUT_COLUMNS = [
+        "wic_year",
+        "household_id",
+        "housing_type",
+        "relation_to_household_head",
+    ]
     WIC_BASELINE_SALARY = 16_410
     WIC_SALARY_PER_HOUSEHOLD_MEMBER = 8_732
     WIC_RACE_ETHNICITIES = ["White", "Black", "Latino", "Other"]

--- a/src/vivarium_census_prl_synth_pop/components/observers.py
+++ b/src/vivarium_census_prl_synth_pop/components/observers.py
@@ -308,7 +308,7 @@ class WICObserver(BaseObserver):
     """Class for observing columns relevant to WIC administrative data."""
 
     INPUT_VALUES = ["income", "household_details"]
-    ADDITIONAL_INPUT_COLUMNS = ["household_id", "housing_type"]
+    ADDITIONAL_INPUT_COLUMNS = ["household_id"]
     ADDITIONAL_OUTPUT_COLUMNS = ["wic_year", "household_id", "housing_type"]
     WIC_BASELINE_SALARY = 16_410
     WIC_SALARY_PER_HOUSEHOLD_MEMBER = 8_732

--- a/src/vivarium_census_prl_synth_pop/components/observers.py
+++ b/src/vivarium_census_prl_synth_pop/components/observers.py
@@ -308,8 +308,8 @@ class WICObserver(BaseObserver):
     """Class for observing columns relevant to WIC administrative data."""
 
     INPUT_VALUES = ["income", "household_details"]
-    ADDITIONAL_INPUT_COLUMNS = ["household_id"]
-    ADDITIONAL_OUTPUT_COLUMNS = ["wic_year", "household_id"]
+    ADDITIONAL_INPUT_COLUMNS = ["household_id", "housing_type"]
+    ADDITIONAL_OUTPUT_COLUMNS = ["wic_year", "household_id", "housing_type"]
     WIC_BASELINE_SALARY = 16_410
     WIC_SALARY_PER_HOUSEHOLD_MEMBER = 8_732
     WIC_RACE_ETHNICITIES = ["White", "Black", "Latino", "Other"]

--- a/src/vivarium_census_prl_synth_pop/components/observers.py
+++ b/src/vivarium_census_prl_synth_pop/components/observers.py
@@ -308,6 +308,7 @@ class WICObserver(BaseObserver):
     """Class for observing columns relevant to WIC administrative data."""
 
     INPUT_VALUES = ["income", "household_details"]
+    ADDITIONAL_INPUT_COLUMNS = ["household_id"]
     ADDITIONAL_OUTPUT_COLUMNS = ["wic_year", "household_id"]
     WIC_BASELINE_SALARY = 16_410
     WIC_SALARY_PER_HOUSEHOLD_MEMBER = 8_732
@@ -322,7 +323,7 @@ class WICObserver(BaseObserver):
 
     @property
     def input_columns(self):
-        return self.DEFAULT_INPUT_COLUMNS
+        return self.DEFAULT_INPUT_COLUMNS + self.ADDITIONAL_INPUT_COLUMNS
 
     @property
     def input_values(self):

--- a/src/vivarium_census_prl_synth_pop/components/observers.py
+++ b/src/vivarium_census_prl_synth_pop/components/observers.py
@@ -308,8 +308,8 @@ class WICObserver(BaseObserver):
     """Class for observing columns relevant to WIC administrative data."""
 
     INPUT_VALUES = ["income", "household_details"]
-    ADDITIONAL_INPUT_COLUMNS = ["household_id"]
-    ADDITIONAL_OUTPUT_COLUMNS = ["wic_year", "household_id", "housing_type"]
+    ADDITIONAL_INPUT_COLUMNS = ["household_id", "relation_to_household_head",]
+    ADDITIONAL_OUTPUT_COLUMNS = ["wic_year", "household_id", "housing_type", "relation_to_household_head"]
     WIC_BASELINE_SALARY = 16_410
     WIC_SALARY_PER_HOUSEHOLD_MEMBER = 8_732
     WIC_RACE_ETHNICITIES = ["White", "Black", "Latino", "Other"]

--- a/src/vivarium_census_prl_synth_pop/components/observers.py
+++ b/src/vivarium_census_prl_synth_pop/components/observers.py
@@ -48,6 +48,7 @@ class BaseObserver(ABC):
         "guardian_2",
         "guardian_1_address_id",
         "guardian_2_address_id",
+        # todo: add necessary guardian address columns
     ]
 
     def __repr__(self):
@@ -307,7 +308,7 @@ class WICObserver(BaseObserver):
     """Class for observing columns relevant to WIC administrative data."""
 
     INPUT_VALUES = ["income", "household_details"]
-    ADDITIONAL_OUTPUT_COLUMNS = ["wic_year"]
+    ADDITIONAL_OUTPUT_COLUMNS = ["wic_year", "household_id"]
     WIC_BASELINE_SALARY = 16_410
     WIC_SALARY_PER_HOUSEHOLD_MEMBER = 8_732
     WIC_RACE_ETHNICITIES = ["White", "Black", "Latino", "Other"]
@@ -569,6 +570,7 @@ class TaxW2Observer(BaseObserver):
         "housing_type",
         "tax_year",
         "race_ethnicity",
+        "is_w2",
     ]
 
     def __repr__(self):
@@ -716,6 +718,8 @@ class TaxW2Observer(BaseObserver):
             df_w2[col] = df_w2["employer_id"].map(business_details[col])
 
         df_w2 = df_w2.set_index(["simulant_id"])
+
+        df_w2["is_w2"] = True
         return df_w2[self.output_columns]
 
 

--- a/src/vivarium_census_prl_synth_pop/results_processing/addresses.py
+++ b/src/vivarium_census_prl_synth_pop/results_processing/addresses.py
@@ -43,6 +43,7 @@ def get_address_id_maps(
     A dictionary of pd.Series suitable for pd.Series.map, indexed by `address_id`
 
     """
+
     try:
         output_cols_superset = {
             "address_id": [column_name, "state_id", "state", "puma", "po_box"],
@@ -146,6 +147,7 @@ def get_zipcode_map(
         zip_map_dict["zipcode"] = zip_map
     else:
         zip_map_dict["employer_zipcode"] = zip_map
+
     return zip_map_dict
 
 
@@ -191,6 +193,7 @@ def get_city_map(
     randomness: RandomnessStream,
     additional_key: str = "",
 ) -> Dict[str, pd.Series]:
+
     # Load addresses data from artifact
     addresses = artifact.load(data_keys.SYNTHETIC_DATA.ADDRESSES).reset_index()
     # Get observer data to map
@@ -221,6 +224,7 @@ def get_city_map(
         city_map = {"city": city_data[city_col]}
     else:
         city_map = {"employer_city": city_data[city_col]}
+
     return city_map
 
 

--- a/src/vivarium_census_prl_synth_pop/results_processing/formatter.py
+++ b/src/vivarium_census_prl_synth_pop/results_processing/formatter.py
@@ -41,6 +41,18 @@ def get_employer_state_abbreviation(data: pd.DataFrame) -> pd.Series:
     return state_name_map.map(metadata.US_STATE_ABBRV_MAP)
 
 
+def get_household_id(data: pd.DataFrame) -> pd.Series:
+    return data["random_seed"].astype(str) + "_" + data["household_id"].astype(str)
+
+
+def get_guardian_1_id(data: pd.DataFrame) -> pd.Series:
+    return data["random_seed"].astype(str) + "_" + data["guardian_1"].astype(str)
+
+
+def get_guardian_2_id(data: pd.DataFrame) -> pd.Series:
+    return data["random_seed"].astype(str) + "_" + data["guardian_2"].astype(str)
+
+
 # Fixme: Add formatting functions as necessary
 COLUMN_FORMATTERS = {
     "simulant_id": (format_simulant_id, ["simulant_id", "random_seed"]),
@@ -51,6 +63,9 @@ COLUMN_FORMATTERS = {
     "state": (get_state_abbreviation, ["state_id"]),
     "address_id": (format_address_id, ["address_id", "random_seed"]),
     "employer_state": (get_employer_state_abbreviation, ["employer_state_id"]),
+    "household_id": (get_household_id, ["household_id", "random_seed"]),
+    "guardian_1": (get_guardian_1_id, ["guardian_1", "random_seed"]),
+    "guardian_2": (get_guardian_2_id, ["guardian_2", "random_seed"]),
 }
 
 

--- a/src/vivarium_census_prl_synth_pop/results_processing/formatter.py
+++ b/src/vivarium_census_prl_synth_pop/results_processing/formatter.py
@@ -74,8 +74,14 @@ COLUMN_FORMATTERS = {
     "household_id": (get_household_id, ["household_id", "random_seed"]),
     "guardian_1": (get_guardian_1_id, ["guardian_1", "random_seed"]),
     "guardian_2": (get_guardian_2_id, ["guardian_2", "random_seed"]),
-    "guardian_1_address_id": (get_guardian_1_id, ["guardian_1_address_id", "random_seed"]),
-    "guardian_2_address_id": (get_guardian_2_id, ["guardian_2_address_id", "random_seed"]),
+    "guardian_1_address_id": (
+        get_guardian_1_address_id,
+        ["guardian_1_address_id", "random_seed"],
+    ),
+    "guardian_2_address_id": (
+        get_guardian_2_address_id,
+        ["guardian_2_address_id", "random_seed"],
+    ),
 }
 
 

--- a/src/vivarium_census_prl_synth_pop/results_processing/formatter.py
+++ b/src/vivarium_census_prl_synth_pop/results_processing/formatter.py
@@ -53,6 +53,14 @@ def get_guardian_2_id(data: pd.DataFrame) -> pd.Series:
     return data["random_seed"].astype(str) + "_" + data["guardian_2"].astype(str)
 
 
+def get_guardian_1_address_id(data: pd.DataFrame) -> pd.Series:
+    return data["random_seed"].astype(str) + "_" + data["guardian_1_address_id"].astype(str)
+
+
+def get_guardian_2_address_id(data: pd.DataFrame) -> pd.Series:
+    return data["random_seed"].astype(str) + "_" + data["guardian_2_address_id"].astype(str)
+
+
 # Fixme: Add formatting functions as necessary
 COLUMN_FORMATTERS = {
     "simulant_id": (format_simulant_id, ["simulant_id", "random_seed"]),
@@ -66,6 +74,8 @@ COLUMN_FORMATTERS = {
     "household_id": (get_household_id, ["household_id", "random_seed"]),
     "guardian_1": (get_guardian_1_id, ["guardian_1", "random_seed"]),
     "guardian_2": (get_guardian_2_id, ["guardian_2", "random_seed"]),
+    "guardian_1_address_id": (get_guardian_1_id, ["guardian_1_address_id", "random_seed"]),
+    "guardian_2_address_id": (get_guardian_2_id, ["guardian_2_address_id", "random_seed"]),
 }
 
 

--- a/src/vivarium_census_prl_synth_pop/results_processing/names.py
+++ b/src/vivarium_census_prl_synth_pop/results_processing/names.py
@@ -169,8 +169,10 @@ def random_last_names(
     # fixme: Nan in artifact data for last names.
     df_census_names = df_census_names.loc[~df_census_names["name"].isnull()]
     if len(df_census_names) < l:
-        logger.info("Artifact contains missing values for last names data."
-                    "Removing null values from last name data...")
+        logger.info(
+            "Artifact contains missing values for last names data."
+            "Removing null values from last name data..."
+        )
 
     # randomly sample last names
     last_names = vectorized_choice(

--- a/src/vivarium_census_prl_synth_pop/results_processing/names.py
+++ b/src/vivarium_census_prl_synth_pop/results_processing/names.py
@@ -170,7 +170,7 @@ def random_last_names(
     df_census_names = df_census_names.loc[~df_census_names["name"].isnull()]
     if len(df_census_names) < l:
         logger.info(
-            "Artifact contains missing values for last names data."
+            "Artifact contains missing values for last names data.  "
             "Removing null values from last name data..."
         )
 

--- a/src/vivarium_census_prl_synth_pop/results_processing/names.py
+++ b/src/vivarium_census_prl_synth_pop/results_processing/names.py
@@ -169,7 +169,8 @@ def random_last_names(
     # fixme: Nan in artifact data for last names.
     df_census_names = df_census_names.loc[~df_census_names["name"].isnull()]
     if len(df_census_names) < l:
-        logger.info("Artifact contains missing values for last names data...")
+        logger.info("Artifact contains missing values for last names data."
+                    "Removing null values from last name data...")
 
     # randomly sample last names
     last_names = vectorized_choice(

--- a/src/vivarium_census_prl_synth_pop/tools/make_results.py
+++ b/src/vivarium_census_prl_synth_pop/tools/make_results.py
@@ -72,7 +72,7 @@ FINAL_OBSERVERS = {
         "housing_type",
     },
     "household_survey_observer_cps": {
-        "household-id",
+        "household_id",
         "simulant_id",
         "first_name",
         "middle_initial",

--- a/src/vivarium_census_prl_synth_pop/tools/make_results.py
+++ b/src/vivarium_census_prl_synth_pop/tools/make_results.py
@@ -44,8 +44,8 @@ FINAL_OBSERVERS = {
         "guardian_1",
         "guardian_2",
         # todo: Update with additional address columns in MIC-3846
-        "guardian_1_addrress_id",
-        "guardian_2_address_id",
+        # "guardian_1_addrress_id",
+        # "guardian_2_address_id",
         "housing_type",
     },
     "household_survey_observer_acs": {
@@ -66,8 +66,8 @@ FINAL_OBSERVERS = {
         "guardian_1",
         "guardian_2",
         # todo: Update with additional address columns in MIC-3846
-        "guardian_1_addrress_id",
-        "guardian_2_address_id",
+        # "guardian_1_addrress_id",
+        # "guardian_2_address_id",
         "housing_type",
         "housing_type",
     },
@@ -89,8 +89,8 @@ FINAL_OBSERVERS = {
         "guardian_1",
         "guardian_2",
         # todo: Update with additional address columns in MIC-3846
-        "guardian_1_addrress_id",
-        "guardian_2_address_id",
+        # "guardian_1_addrress_id",
+        # "guardian_2_address_id",
         "housing_type",
         "housing_type",
     },
@@ -114,8 +114,8 @@ FINAL_OBSERVERS = {
         "guardian_1",
         "guardian_2",
         # todo: Update with additional address columns in MIC-3846
-        "guardian_1_addrress_id",
-        "guardian_2_address_id",
+        # "guardian_1_addrress_id",
+        # "guardian_2_address_id",
         "housing_type",
     },
     "social_security_observer": {

--- a/src/vivarium_census_prl_synth_pop/tools/make_results.py
+++ b/src/vivarium_census_prl_synth_pop/tools/make_results.py
@@ -69,7 +69,6 @@ FINAL_OBSERVERS = {
         # "guardian_1_addrress_id",
         # "guardian_2_address_id",
         "housing_type",
-        "housing_type",
     },
     "household_survey_observer_cps": {
         "household_id",
@@ -91,7 +90,6 @@ FINAL_OBSERVERS = {
         # todo: Update with additional address columns in MIC-3846
         # "guardian_1_addrress_id",
         # "guardian_2_address_id",
-        "housing_type",
         "housing_type",
     },
     "wic_observer": {

--- a/src/vivarium_census_prl_synth_pop/tools/make_results.py
+++ b/src/vivarium_census_prl_synth_pop/tools/make_results.py
@@ -1,7 +1,7 @@
 import csv
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, Tuple, NamedTuple
+from typing import Dict, NamedTuple, Tuple
 
 import pandas as pd
 from loguru import logger
@@ -23,7 +23,6 @@ from vivarium_census_prl_synth_pop.results_processing.names import (
 from vivarium_census_prl_synth_pop.results_processing.ssn_and_itin import (
     get_simulant_id_maps,
 )
-
 
 FINAL_OBSERVERS = {
     "decennial_census_observer": {

--- a/src/vivarium_census_prl_synth_pop/tools/make_results.py
+++ b/src/vivarium_census_prl_synth_pop/tools/make_results.py
@@ -45,7 +45,8 @@ FINAL_OBSERVERS = {
         "guardian_2",
         # todo: Update with additional address columns in MIC-3846
         "guardian_1_addrress_id",
-        "guardian_2_address_id" "housing_type",
+        "guardian_2_address_id",
+        "housing_type",
     },
     "household_survey_observer_acs": {
         "simulant_id",
@@ -66,7 +67,8 @@ FINAL_OBSERVERS = {
         "guardian_2",
         # todo: Update with additional address columns in MIC-3846
         "guardian_1_addrress_id",
-        "guardian_2_address_id" "housing_type",
+        "guardian_2_address_id",
+        "housing_type",
         "housing_type",
     },
     "household_survey_observer_cps": {
@@ -88,7 +90,8 @@ FINAL_OBSERVERS = {
         "guardian_2",
         # todo: Update with additional address columns in MIC-3846
         "guardian_1_addrress_id",
-        "guardian_2_address_id" "housing_type",
+        "guardian_2_address_id",
+        "housing_type",
         "housing_type",
     },
     "wic_observer": {
@@ -146,7 +149,8 @@ FINAL_OBSERVERS = {
         "employer_unit_number",
         "employer_city",
         "employer_zipcode",
-        "employer_state" "ssn",
+        "employer_state",
+        "ssn",
         "is_w2",
     },
     # todo: Add tax 1040 observer

--- a/src/vivarium_census_prl_synth_pop/tools/make_results.py
+++ b/src/vivarium_census_prl_synth_pop/tools/make_results.py
@@ -24,7 +24,7 @@ from vivarium_census_prl_synth_pop.results_processing.ssn_and_itin import (
     get_simulant_id_maps,
 )
 
-# todo: add columns for each observer from documentation
+
 FINAL_OBSERVERS = {
     "decennial_census_observer": {
         "simulant_id",
@@ -44,6 +44,7 @@ FINAL_OBSERVERS = {
         "race_ethnicity",
         "guardian_1",
         "guardian_2",
+        # todo: Update with additional address columns in MIC-3846
         "guardian_1_addrress_id",
         "guardian_2_address_id" "housing_type",
     },
@@ -64,6 +65,7 @@ FINAL_OBSERVERS = {
         "state",
         "guardian_1",
         "guardian_2",
+        # todo: Update with additional address columns in MIC-3846
         "guardian_1_addrress_id",
         "guardian_2_address_id" "housing_type",
         "housing_type",
@@ -85,6 +87,7 @@ FINAL_OBSERVERS = {
         "state",
         "guardian_1",
         "guardian_2",
+        # todo: Update with additional address columns in MIC-3846
         "guardian_1_addrress_id",
         "guardian_2_address_id" "housing_type",
         "housing_type",
@@ -108,8 +111,10 @@ FINAL_OBSERVERS = {
         "race_ethnicity",
         "guardian_1",
         "guardian_2",
+        # todo: Update with additional address columns in MIC-3846
         "guardian_1_addrress_id",
-        "guardian_2_address_id" "housing_type",
+        "guardian_2_address_id",
+        "housing_type",
     },
     "social_security_observer": {
         "simulant_id",
@@ -275,9 +280,16 @@ def generate_maps(
         column: mapper(column, obs_data, artifact, randomness)
         for column, mapper in mappers.items()
     }
-    # maps["guardian_1_address_id"] = {"guardian_1_address_" + str(maps["address_id"])
-    # maps["guardian_2_address_id"] = maps["address_id"]
-    # todo: fix keys for guardian addresses
+    # todo: Include with MIC-3846
+    # Add guardian address details and change dict keys for address_ids map to be clear.
+    # maps["guardian_1_address_id"] = {
+    #   outer_k: {"uardian_1_"+ inner_k: inner_v for inner_k, inner_v in outer_v.items()}
+    #   for outer_k, outer_v in maps["address_id.items()
+    #   }
+    # maps["guardian_2_address_id"] = {
+    #   outer_k: {"uardian_2_"+ inner_k: inner_v for inner_k, inner_v in outer_v.items()}
+    #   for outer_k, outer_v in maps["address_id.items()
+    #   }
 
     return maps
 

--- a/src/vivarium_census_prl_synth_pop/tools/make_results.py
+++ b/src/vivarium_census_prl_synth_pop/tools/make_results.py
@@ -26,12 +26,126 @@ from vivarium_census_prl_synth_pop.results_processing.ssn_and_itin import (
 
 # todo: add columns for each observer from documentation
 FINAL_OBSERVERS = {
-    "decennial_census_observer": {},
-    "household_survey_observer_acs": {},
-    "household_survey_observer_cps": {},
-    "wic_observer": {},
-    "social_security_observer": {},
-    "tax_w2_observer": {},
+    "decennial_census_observer": {
+        "simulant_id",
+        "first_name",
+        "middle_initial",
+        "last_name",
+        "age",
+        "date_of_birth",
+        "street_number",
+        "street_name",
+        "unit_number",
+        "city",
+        "zipcode",
+        "state",
+        "relation_to_household_head",
+        "sex",
+        "race_ethnicity",
+        "guardian_1",
+        "guardian_2",
+        "guardian_1_addrress_id",
+        "guardian_2_address_id" "housing_type",
+    },
+    "household_survey_observer_acs": {
+        "simulant_id",
+        "household_id",
+        "first_name",
+        "middle_initial",
+        "last_name",
+        "age",
+        "date_of_birth",
+        "sex",
+        "street_number",
+        "street_name",
+        "unit_number",
+        "city",
+        "zipcode",
+        "state",
+        "guardian_1",
+        "guardian_2",
+        "guardian_1_addrress_id",
+        "guardian_2_address_id" "housing_type",
+        "housing_type",
+    },
+    "household_survey_observer_cps": {
+        "household-id",
+        "simulant_id",
+        "first_name",
+        "middle_initial",
+        "last_name",
+        "age",
+        "date_of_birth",
+        "sex",
+        "street_number",
+        "street_name",
+        "unit_number",
+        "city",
+        "zipcode",
+        "state",
+        "guardian_1",
+        "guardian_2",
+        "guardian_1_addrress_id",
+        "guardian_2_address_id" "housing_type",
+        "housing_type",
+    },
+    "wic_observer": {
+        "simulant_id",
+        "household_id",
+        "first_name",
+        "middle_initial",
+        "last_name",
+        "age",
+        "date_of_birth",
+        "street_number",
+        "street_name",
+        "unit_number",
+        "city",
+        "zipcode",
+        "state",
+        "relation_to_household_head",
+        "sex",
+        "race_ethnicity",
+        "guardian_1",
+        "guardian_2",
+        "guardian_1_addrress_id",
+        "guardian_2_address_id" "housing_type",
+    },
+    "social_security_observer": {
+        "simulant_id",
+        "first_name",
+        "middle_initial",
+        "last_name",
+        "date_of_birth",
+        "ssn",
+        "event_type",
+        "event_date",
+    },
+    "tax_w2_observer": {
+        "simulant_id",
+        "first_name",
+        "middle_initial",
+        "last_name",
+        "age",
+        "date_of_birth",
+        "mailing_address_street_number",
+        "mailing_address_street_name",
+        "mailing_address_unit_number",
+        "mailing_address_city",
+        "mailing_address_zipcode",
+        "mailing_address_state",
+        "income",
+        "employer_id",
+        "employer_name",
+        "employer_street_number",
+        "employer_street_name",
+        "employer_unit_number",
+        "employer_city",
+        "employer_zipcode",
+        "employer_state" "ssn",
+        "is_w2",
+    },
+    # todo: Add tax 1040 observer
 }
 
 
@@ -91,7 +205,6 @@ def perform_post_processing(
 
         obs_data = obs_data[FINAL_OBSERVERS[observer]]
         logger.info(f"Writing final results for {observer}.")
-        # fixme: Process columns for final outputs - columns being mapped are no longer dropped
         obs_data.to_csv(
             final_output_dir / f"{observer}.csv.bz2",
             index=False,
@@ -162,6 +275,9 @@ def generate_maps(
         column: mapper(column, obs_data, artifact, randomness)
         for column, mapper in mappers.items()
     }
+    # maps["guardian_1_address_id"] = {"guardian_1_address_" + str(maps["address_id"])
+    # maps["guardian_2_address_id"] = maps["address_id"]
+    # todo: fix keys for guardian addresses
 
     return maps
 


### PR DESCRIPTION
## Post-processing subset columns.

### Changes how we are writing final results to only include columns desired for each observer outline in the research documentation.
- *Category*: Observers/post-processing
- *JIRA issue*: [MIC-3844](https://jira.ihme.washington.edu/browse/MIC-3844)
- *Research reference*: https://vivarium-research.readthedocs.io/en/latest/models/concept_models/vivarium_census_synthdata/concept_model.html#periodic-observations-of-attributes-through-survey-census-and-registry

### Changes and notes
-Updates observers to return necessary columns desired in final results.
-Changes post-processing to go through each observer, and map only columns in that observer to write to file.
--Improves logging for names mapping.

### Verification and Testing
Successfully ran parallel sim and post-processing.

