### PR TITLE
Implement SSN collision for W2 observer

### DIFF
--- a/src/vivarium_census_prl_synth_pop/results_processing/formatter.py
+++ b/src/vivarium_census_prl_synth_pop/results_processing/formatter.py
@@ -33,7 +33,9 @@ def format_ssn_id(data: pd.DataFrame) -> pd.Series:
     """Format ssn_id column to prepare random_seed to match simulant_id"""
     ssn_ids = pd.Series(data["ssn_id"].astype(str))
     # Only do the prepending where ssn_id points to another simulant
-    ssn_ids[ssn_ids != "-1"] = data["random_seed"].astype(str) + "_" + data["ssn_id"].astype(str)
+    ssn_ids[ssn_ids != "-1"] = (
+        data["random_seed"].astype(str) + "_" + data["ssn_id"].astype(str)
+    )
     return ssn_ids
 
 
@@ -95,7 +97,7 @@ COLUMN_FORMATTERS = {
         ["guardian_2_address_id", "random_seed"],
     ),
     "guardian_id": (get_guardian_id, ["guardian_id", "random_seed"]),
-    "ssn_id":  (format_ssn_id, ["ssn_id", "random_seed"]),
+    "ssn_id": (format_ssn_id, ["ssn_id", "random_seed"]),
 }
 
 

--- a/src/vivarium_census_prl_synth_pop/results_processing/formatter.py
+++ b/src/vivarium_census_prl_synth_pop/results_processing/formatter.py
@@ -29,6 +29,14 @@ def format_address_id(data: pd.DataFrame) -> pd.Series:
     return data["random_seed"].astype(str) + "_" + data["address_id"].astype(str)
 
 
+def format_ssn_id(data: pd.DataFrame) -> pd.Series:
+    """Format ssn_id column to prepare random_seed to match simulant_id"""
+    ssn_ids = pd.Series(data["ssn_id"].astype(str))
+    # Only do the prepending where ssn_id points to another simulant
+    ssn_ids[ssn_ids != "-1"] = data["random_seed"].astype(str) + "_" + data["ssn_id"].astype(str)
+    return ssn_ids
+
+
 def get_state_abbreviation(data: pd.DataFrame) -> pd.Series:
     state_id_map = {state: state_id for state_id, state in metadata.CENSUS_STATE_IDS.items()}
     state_name_map = data["state_id"].map(state_id_map)
@@ -87,6 +95,7 @@ COLUMN_FORMATTERS = {
         ["guardian_2_address_id", "random_seed"],
     ),
     "guardian_id": (get_guardian_id, ["guardian_id", "random_seed"]),
+    "ssn_id":  (format_ssn_id, ["ssn_id", "random_seed"]),
 }
 
 

--- a/src/vivarium_census_prl_synth_pop/results_processing/ssn_and_itin.py
+++ b/src/vivarium_census_prl_synth_pop/results_processing/ssn_and_itin.py
@@ -139,6 +139,7 @@ def generate_ssns(
     size: int,
     additional_key: Any,
     randomness: RandomnessStream,
+    allow_duplicates: bool = False,
 ) -> np.ndarray:
     """
     Generate a np.ndarray of length `size` of unique SSN values.
@@ -150,6 +151,7 @@ def generate_ssns(
     :param size: The number of itins to generate
     :param additional_key: Additional key to be used by randomness
     :param randomness: RandomnessStream stream to use
+    :param allow_duplicates: True if duplicates are allowed, False (default) otherwise
 
     """
 
@@ -200,7 +202,7 @@ def generate_ssns(
     ssns = pd.Series(generate_ssn(size, additional_key))
     duplicate_mask = ssns.duplicated()
     counter = 0
-    while duplicate_mask.sum() > 0:
+    while duplicate_mask.sum() > 0 and not allow_duplicates:
         if counter >= 10:
             logger.info(
                 f"Resampled SSN {counter} times and data still contains {duplicate_mask.sum()}"
@@ -232,3 +234,19 @@ def get_ssn_map(
     # Map against obs_data
     ssn_map_dict["ssn"] = ssn_map.fillna("").astype(str)
     return ssn_map_dict
+
+
+def do_collide_ssns(obs_data: pd.DataFrame, ssn_map: pd.Series) -> pd.DataFrame:
+
+    # Mask off ssn_id != -1, employer_id != -1, ssn = "", has_ssn = False,
+    # use ssn_map to map
+    use_ssn_id = (obs_data["ssn_id"] != -1) & (obs_data["employer_id"] != -1)
+
+    # Mask off ssn_id == -1, employer_id != -1, ssn = "", has_ssn = False,
+    # generate a new SSN for each, duplicates don't matter.
+
+
+
+
+    return obs_data
+

--- a/src/vivarium_census_prl_synth_pop/tools/make_results.py
+++ b/src/vivarium_census_prl_synth_pop/tools/make_results.py
@@ -22,6 +22,7 @@ from vivarium_census_prl_synth_pop.results_processing.names import (
 )
 from vivarium_census_prl_synth_pop.results_processing.ssn_and_itin import (
     get_simulant_id_maps,
+    do_collide_ssns,
 )
 
 FINAL_OBSERVERS = {
@@ -249,6 +250,11 @@ def perform_post_processing(
                 if target_column_name not in FINAL_OBSERVERS[observer]:
                     continue
                 obs_data[target_column_name] = obs_data[column].map(column_map)
+
+        # if observer == "tax_w2_observer":
+        #     # For w2, we need to post-process to allow for SSN collisions in the data in cases where
+        #     #  the simulant has no SSN but is employed (they'd need to have supplied an SSN to their employer)
+        #     obs_data = do_collide_ssns(obs_data, maps["simulant_id"]["ssn"])
 
         obs_data = obs_data[FINAL_OBSERVERS[observer]]
         logger.info(f"Writing final results for {observer}.")

--- a/src/vivarium_census_prl_synth_pop/tools/make_results.py
+++ b/src/vivarium_census_prl_synth_pop/tools/make_results.py
@@ -21,8 +21,8 @@ from vivarium_census_prl_synth_pop.results_processing.names import (
     get_middle_initial_map,
 )
 from vivarium_census_prl_synth_pop.results_processing.ssn_and_itin import (
-    get_simulant_id_maps,
     do_collide_ssns,
+    get_simulant_id_maps,
 )
 
 FINAL_OBSERVERS = {
@@ -232,10 +232,16 @@ def create_results_link(output_dir: Path, link_name: Path) -> None:
 def perform_post_processing(
     raw_output_dir: Path, final_output_dir: Path, artifact_path: Path
 ) -> None:
+    # Create RandomnessStream for post-processing
+    key = "post_processing_maps"
+    clock = lambda: pd.Timestamp("2020-04-01")
+    seed = 0
+    randomness = RandomnessStream(key=key, clock=clock, seed=seed)
+
     processed_results = load_data(raw_output_dir)
     # Generate all post-processing maps to apply to raw results
     artifact = Artifact(artifact_path)
-    maps = generate_maps(processed_results, artifact)
+    maps = generate_maps(processed_results, artifact, randomness)
 
     # Iterate through expected forms and generate them. Generate columns each of these forms need to have.
     for observer in FINAL_OBSERVERS:
@@ -251,12 +257,12 @@ def perform_post_processing(
                     continue
                 obs_data[target_column_name] = obs_data[column].map(column_map)
 
-        # if observer == "tax_w2_observer":
-        #     # For w2, we need to post-process to allow for SSN collisions in the data in cases where
-        #     #  the simulant has no SSN but is employed (they'd need to have supplied an SSN to their employer)
-        #     obs_data = do_collide_ssns(obs_data, maps["simulant_id"]["ssn"])
+        if observer == "tax_w2_observer":
+            # For w2, we need to post-process to allow for SSN collisions in the data in cases where
+            #  the simulant has no SSN but is employed (they'd need to have supplied an SSN to their employer)
+            obs_data = do_collide_ssns(obs_data, maps["simulant_id"]["ssn"], randomness)
 
-        obs_data = obs_data[FINAL_OBSERVERS[observer]]
+        obs_data = obs_data[list(FINAL_OBSERVERS[observer])]
         logger.info(f"Writing final results for {observer}.")
         obs_data.to_csv(
             final_output_dir / f"{observer}.csv.bz2",
@@ -294,24 +300,19 @@ def load_data(raw_results_dir: Path) -> Dict[str, pd.DataFrame]:
 
 
 def generate_maps(
-    obs_data: Dict[str, pd.DataFrame], artifact: Artifact
+    obs_data: Dict[str, pd.DataFrame], artifact: Artifact, randomness: RandomnessStream
 ) -> Dict[str, Dict[str, pd.Series]]:
     """
     Parameters:
         obs_data: Dictionary of raw observer outputs with key being the observer name and the value being a dataframe.
         artifact: Artifact that contains data needed to generate values.
+        randomness: RandomnessStream to use in creating maps.
 
     Returns:
         maps: Dictionary with key being string of the name of the column to be mapped.  Example first_name_id or
           address_id.  Values for each key will be a dictionary named with the column to be mapped to as the key with a
           corresponding series containing the mapped values.
     """
-
-    # Create RandomnessStream for post-processing
-    key = "post_processing_maps"
-    clock = lambda: pd.Timestamp("2020-04-01")
-    seed = 0
-    randomness = RandomnessStream(key=key, clock=clock, seed=seed)
 
     # Add column maps to mapper here
     # The key should be the index of the map and the mapping function the value


### PR DESCRIPTION
## Implement SSN collision for W2 observer

### Description
- *Category*: implementation
- *JIRA issue*: [MIC-3763](https://jira.ihme.washington.edu/browse/MIC-3763)
- *Research reference*: https://vivarium-research.readthedocs.io/en/latest/models/concept_models/vivarium_census_synthdata/concept_model.html#id99

### Changes and notes
- Implements a post-processing of the post-processing to select SSNs for employed simulants without them

### Verification and Testing
Ran make_results on recently generated results, with expected output.

