### PR TITLE
Add ssns and itins to artifact

### DIFF
--- a/src/vivarium_census_prl_synth_pop/constants/data_keys.py
+++ b/src/vivarium_census_prl_synth_pop/constants/data_keys.py
@@ -31,6 +31,8 @@ class __SyntheticData(NamedTuple):
     FIRST_NAMES: str = "synthetic_data.first_names"
     LAST_NAMES: str = "synthetic_data.last_names"
     ADDRESSES: str = "synthetic_data.addresses"
+    SSNS: str = "synthetic_data.ssns"
+    ITINS: str = "synthetic_data.itins"
 
     @property
     def name(self):

--- a/src/vivarium_census_prl_synth_pop/data/loader.py
+++ b/src/vivarium_census_prl_synth_pop/data/loader.py
@@ -12,6 +12,7 @@ for an example.
 
    No logging is done here. Logging is done in vivarium inputs itself and forwarded.
 """
+from itertools import product
 from pathlib import Path
 from typing import Dict, List
 
@@ -53,6 +54,8 @@ def get_data(lookup_key: str, location: str) -> pd.DataFrame:
         data_keys.SYNTHETIC_DATA.LAST_NAMES: load_last_name_data,
         data_keys.SYNTHETIC_DATA.FIRST_NAMES: load_first_name_data,
         data_keys.SYNTHETIC_DATA.ADDRESSES: load_address_data,
+        data_keys.SYNTHETIC_DATA.SSNS: load_ssn_data,
+        data_keys.SYNTHETIC_DATA.ITINS: load_itin_data,
     }
     return mapping[lookup_key](lookup_key, location)
 
@@ -305,6 +308,58 @@ def load_address_data(key: str, location: str) -> pd.DataFrame:
     return df_deepparse_address_data
 
 
+def load_ssn_data(key: str, location: str) -> pd.DataFrame:
+    """Generate a randomly shuffled dataframe of all possible SSNs where each of
+    the three columns holds the allowable parts of a valid id. SSNs take the
+    form of <area>-<group>-<serial> with the following acceptable ranges:
+        - area: 001-899, excluding 666
+        - group: 01-99
+        - serial: 0001-9999
+    """
+    # Generate allowable integers
+    area = list(range(1, 666)) + list(range(667, 900))
+    group = list(range(1, 100))
+    serial = list(range(1, 10000))
+
+    return _generate_randomized_id_df(area, group, serial)
+
+
+def load_itin_data(key: str, location: str) -> pd.DataFrame:
+    """Generate a randomly shuffled dataframe of all possible ITINs where each of
+    the three columns holds the allowable parts of a valid id. ITINs take the
+    form of <area>-<group>-<serial> with the following acceptable ranges:
+        - area: 900-999
+        - group: 50-65, 70-88, 90-92, 94-99
+        - serial: 0001-9999
+    """
+    # Generate allowable integers
+    area = list(range(900, 1000))
+    group = (
+        list(range(50, 66)) + list(range(70, 89)) + list(range(90, 93)) + list(range(94, 100))
+    )
+    serial = list(range(1, 10000))
+
+    return _generate_randomized_id_df(area, group, serial)
+
+
+#####################
+#  Helper functions #
+#####################
+
+
+def _generate_randomized_id_df(
+    area: List[int], group: List[int], serial: List[int]
+) -> pd.DataFrame:
+    """Given lists of allowable area, group, and serial integers, generate a
+    randomly sorted dataframe of the product of the three groups
+    """
+    parts = [(area, group, serial) for area, group, serial in product(area, group, serial)]
+    ids = pd.DataFrame(data=parts, columns=["area", "group", "serial"])
+    ids = ids.sample(frac=1).reset_index(drop=True)
+
+    return ids
+
+
 def create_draws(df: pd.DataFrame, key: str, location: str):
     """
     Parameters
@@ -327,11 +382,6 @@ def create_draws(df: pd.DataFrame, key: str, location: str):
     )
 
     return draws
-
-
-#####################
-#  Helper functions #
-#####################
 
 
 def _read_and_format_raw_data(

--- a/src/vivarium_census_prl_synth_pop/data/loader.py
+++ b/src/vivarium_census_prl_synth_pop/data/loader.py
@@ -355,7 +355,7 @@ def _generate_randomized_id_df(
     """
     parts = [(area, group, serial) for area, group, serial in product(area, group, serial)]
     ids = pd.DataFrame(data=parts, columns=["area", "group", "serial"])
-    ids = ids.sample(frac=1).reset_index(drop=True)
+    ids = ids.sample(frac=1, random_state=12345).reset_index(drop=True)
 
     return ids
 


### PR DESCRIPTION
## Title: Add SSNs and ITINs to the artifact

### Description
- *Category*: data artifact
- *JIRA issue*: [MIC-3850](https://jira.ihme.washington.edu/browse/MIC-38520)
- *Research reference*: na

### Changes and notes
This adds a randomly shuffled SSN and ITIN dataframes to the artifact
to later be used to sample from instead of generating on the fly. The end goal
of this approach is that we can prevent unwanted SSN collision in different
shards by slicing the dataframe appropriately.

Some notes about these two dataframes:
- They include ALL POSSIBLE combinations
- They have been randomly shuffled
- They consist of three columns of integers which represent the three
  parts to SSNs and ITINs. Processing these into hyphentated strings
  will happen during post-processing. This was the chosen approach
  because it's 5x quicker to load a dataframe w/ integers comnpared
  to a series of processed string IDs. It's then very quick to
  convert from 3 int columns to "xxx-xx-xxxx".

### Verification and Testing
Added to a test artifact and confirmed the data is there.

