### PR TITLE
Feature/sbachmei/mic 3851 sample ssn from artifact

### DIFF
--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -11,7 +11,6 @@ from vivarium_census_prl_synth_pop.constants import paths
 def sim() -> InteractiveContext:
     """Initialize a simulation for use in tests"""
     simulation = InteractiveContext(paths.MODEL_SPEC_DIR / "model_spec.yaml", setup=False)
-    simulation.configuration.input_data.artifact_path = "/mnt/share/homes/sbachmei/scratch/vivarium/prl/artifacts/ids-dataframe/united_states_of_america.hdf"
     simulation.configuration.population.population_size = 250_000
     simulation.setup()
     return simulation

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -11,6 +11,7 @@ from vivarium_census_prl_synth_pop.constants import paths
 def sim() -> InteractiveContext:
     """Initialize a simulation for use in tests"""
     simulation = InteractiveContext(paths.MODEL_SPEC_DIR / "model_spec.yaml", setup=False)
+    simulation.configuration.input_data.artifact_path = "/mnt/share/homes/sbachmei/scratch/vivarium/prl/artifacts/ids-dataframe/united_states_of_america.hdf"
     simulation.configuration.population.population_size = 250_000
     simulation.setup()
     return simulation

--- a/src/vivarium_census_prl_synth_pop/results_processing/ssn_and_itin.py
+++ b/src/vivarium_census_prl_synth_pop/results_processing/ssn_and_itin.py
@@ -204,7 +204,7 @@ def get_ssn_map(
     )
     ssn_map = pd.Series("", index=simulant_data.index)
     # Load (already-shuffled) SSNs and choose the appropriate number off the top
-    # TODO: look for a more performant method (it took ~3 minutes for ~1 million simulants. Good enough for now.)
+    # TODO: look for a more performant method (it takes several minutes - good enough for now.)
     ssns = artifact.load("synthetic_data.ssns")[: simulant_data["has_ssn"].sum()]
     # Convert to hyphenated string IDs
     ssns = (

--- a/src/vivarium_census_prl_synth_pop/results_processing/ssn_and_itin.py
+++ b/src/vivarium_census_prl_synth_pop/results_processing/ssn_and_itin.py
@@ -204,7 +204,12 @@ def get_ssn_map(
     )
     ssn_map = pd.Series("", index=simulant_data.index)
     # Load (already-shuffled) SSNs and choose the appropriate number off the top
-    ssns = pd.read_hdf(artifact.path, key="/synthetic_data/ssns", start=0, stop=simulant_data["has_ssn"].sum())
+    ssns = pd.read_hdf(
+        artifact.path,
+        key="/synthetic_data/ssns",
+        start=0,
+        stop=simulant_data["has_ssn"].sum(),
+    )
     # Convert to hyphenated string IDs
     ssns = (
         ssns["area"].astype(str).str.zfill(3)

--- a/src/vivarium_census_prl_synth_pop/results_processing/ssn_and_itin.py
+++ b/src/vivarium_census_prl_synth_pop/results_processing/ssn_and_itin.py
@@ -204,6 +204,8 @@ def get_ssn_map(
     )
     ssn_map = pd.Series("", index=simulant_data.index)
     # Load (already-shuffled) SSNs and choose the appropriate number off the top
+    # NOTE: artifact.load does not currently have the option to select specific rows
+    # to load and so that was much slower than using pandas.
     ssns = pd.read_hdf(
         artifact.path,
         key="/synthetic_data/ssns",

--- a/src/vivarium_census_prl_synth_pop/results_processing/ssn_and_itin.py
+++ b/src/vivarium_census_prl_synth_pop/results_processing/ssn_and_itin.py
@@ -204,8 +204,7 @@ def get_ssn_map(
     )
     ssn_map = pd.Series("", index=simulant_data.index)
     # Load (already-shuffled) SSNs and choose the appropriate number off the top
-    # TODO: look for a more performant method (it takes several minutes - good enough for now.)
-    ssns = artifact.load("synthetic_data.ssns")[: simulant_data["has_ssn"].sum()]
+    ssns = pd.read_hdf(artifact.path, key="/synthetic_data/ssns", start=0, stop=simulant_data["has_ssn"].sum())
     # Convert to hyphenated string IDs
     ssns = (
         ssns["area"].astype(str).str.zfill(3)

--- a/src/vivarium_census_prl_synth_pop/results_processing/ssn_and_itin.py
+++ b/src/vivarium_census_prl_synth_pop/results_processing/ssn_and_itin.py
@@ -45,12 +45,16 @@ def get_simulant_id_maps(
 
     # Simulants in W2 observer who `has_ssn` need SSNs
     w2_data = obs_data["tax_w2_observer"][[column_name, "has_ssn", "ssn_id"]]
-    need_ssns = pd.concat([need_ssns, w2_data.loc[w2_data["has_ssn"], column_name]], axis=0).drop_duplicates()
+    need_ssns = pd.concat(
+        [need_ssns, w2_data.loc[w2_data["has_ssn"], column_name]], axis=0
+    ).drop_duplicates()
 
     # Simulants in W2 observer who are assigned as an `ssn_id` need to have SSNs
     # to be copied later
-    need_ssns = pd.concat([need_ssns, w2_data.loc[w2_data["ssn_id"] != "-1", "ssn_id"]], axis=0).drop_duplicates()
-    
+    need_ssns = pd.concat(
+        [need_ssns, w2_data.loc[w2_data["ssn_id"] != "-1", "ssn_id"]], axis=0
+    ).drop_duplicates()
+
     ssn_map = get_ssn_map(pd.DataFrame(index=need_ssns), artifact)  # pd.Index
 
     return ssn_map

--- a/src/vivarium_census_prl_synth_pop/tools/make_results.py
+++ b/src/vivarium_census_prl_synth_pop/tools/make_results.py
@@ -250,7 +250,6 @@ def perform_post_processing(
     # Iterate through expected forms and generate them. Generate columns each of these forms need to have.
     for observer in FINAL_OBSERVERS:
         logger.info(f"Processing data for {observer}...")
-        # Fixme: This code assumes a 1 to 1 relationship of raw to final observers
         obs_data = processed_results[observer]
 
         for column in obs_data.columns:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ import pytest
 from vivarium import Artifact
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def artifact() -> Artifact:
     """Loads the artifact"""
     artifact_path = "/mnt/team/simulation_science/priv/engineering/vivarium_census_prl_synth_pop/data/artifacts/united_states_of_america.hdf"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ import pytest
 from vivarium import Artifact
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture()
 def artifact(mocker):
     artifact_path = Path(
         "/mnt/team/simulation_science/priv/engineering/vivarium_census_prl_synth_pop/data/artifacts/united_states_of_america.hdf"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,16 @@
+from pathlib import Path
 import pytest
 from vivarium import Artifact
 
 
 @pytest.fixture(scope="function")
-def artifact() -> Artifact:
-    """Loads the artifact"""
-    artifact_path = "/mnt/team/simulation_science/priv/engineering/vivarium_census_prl_synth_pop/data/artifacts/united_states_of_america.hdf"
-    return Artifact(artifact_path)
+def artifact(mocker):
+    artifact_path = Path("/mnt/team/simulation_science/priv/engineering/vivarium_census_prl_synth_pop/data/artifacts/united_states_of_america.hdf")
+    if artifact_path.exists():
+        return Artifact(artifact_path)
+    else:
+        # Artifact will generate a new one at the path if it doesn't exist
+        # We do not want this when testing so instead mock the path.
+        artifact = mocker.MagicMock()
+        artifact.path = artifact_path
+        return artifact

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,14 @@
 from pathlib import Path
+
 import pytest
 from vivarium import Artifact
 
 
 @pytest.fixture(scope="function")
 def artifact(mocker):
-    artifact_path = Path("/mnt/team/simulation_science/priv/engineering/vivarium_census_prl_synth_pop/data/artifacts/united_states_of_america.hdf")
+    artifact_path = Path(
+        "/mnt/team/simulation_science/priv/engineering/vivarium_census_prl_synth_pop/data/artifacts/united_states_of_america.hdf"
+    )
     if artifact_path.exists():
         return Artifact(artifact_path)
     else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+
+from vivarium import Artifact
+
+
+@pytest.fixture(scope="session")
+def artifact() -> Artifact:
+    """Loads the artifact"""
+    # artifact_path = "/mnt/team/simulation_science/priv/engineering/vivarium_census_prl_synth_pop/data/artifacts/united_states_of_america.hdf"
+    artifact_path = "/mnt/share/homes/sbachmei/scratch/vivarium/prl/artifacts/ids-dataframe/united_states_of_america.hdf"
+    return Artifact(artifact_path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 import pytest
-
 from vivarium import Artifact
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,5 @@ from vivarium import Artifact
 @pytest.fixture(scope="session")
 def artifact() -> Artifact:
     """Loads the artifact"""
-    # artifact_path = "/mnt/team/simulation_science/priv/engineering/vivarium_census_prl_synth_pop/data/artifacts/united_states_of_america.hdf"
-    artifact_path = "/mnt/share/homes/sbachmei/scratch/vivarium/prl/artifacts/ids-dataframe/united_states_of_america.hdf"
+    artifact_path = "/mnt/team/simulation_science/priv/engineering/vivarium_census_prl_synth_pop/data/artifacts/united_states_of_america.hdf"
     return Artifact(artifact_path)

--- a/tests/test_synthetic_pii.py
+++ b/tests/test_synthetic_pii.py
@@ -469,7 +469,7 @@ def test_employer_name_map(mocker):
     assert not (employer_names["employer_name"].isnull().any())
 
 
-def test_ssn_mapping():
+def test_ssn_mapping(artifact):
     """Tests SSN map creation, uniqueness, and range checking."""
     # Create population observer data
     num_unique_ids = 30_000
@@ -479,7 +479,7 @@ def test_ssn_mapping():
 
     # Get the map
     ssn_map = get_simulant_id_maps(
-        "simulant_id", {"silly_observer": simulants}, None, randomness
+        "simulant_id", {"silly_observer": simulants}, artifact, randomness
     )["ssn"]
 
     # Check that all the SSNs are unique (Half of population size plus one for no SSN)

--- a/tests/test_synthetic_pii.py
+++ b/tests/test_synthetic_pii.py
@@ -469,7 +469,6 @@ def test_employer_name_map(mocker):
     assert not (employer_names["employer_name"].isnull().any())
 
 
-@pytest.mark.slow
 def test_ssn_mapping(artifact):
     """Tests SSN map creation, uniqueness, and range checking."""
     # Create population observer data
@@ -479,9 +478,12 @@ def test_ssn_mapping(artifact):
     simulants["has_ssn"] = [True if n % 2 == 0 else False for n in range(num_unique_ids)]
 
     # Get the map
-    ssn_map = get_simulant_id_maps(
-        "simulant_id", {"silly_observer": simulants}, artifact, randomness
-    )["ssn"]
+    try:
+        ssn_map = get_simulant_id_maps(
+            "simulant_id", {"silly_observer": simulants}, artifact, randomness
+        )["ssn"]
+    except FileNotFoundError:
+        pytest.skip(reason=f"Artifact not found at {artifact.path}")
 
     # Check that all the SSNs are unique (Half of population size plus one for no SSN)
     assert ssn_map.nunique() == num_unique_ids / 2 + 1

--- a/tests/test_synthetic_pii.py
+++ b/tests/test_synthetic_pii.py
@@ -469,6 +469,7 @@ def test_employer_name_map(mocker):
     assert not (employer_names["employer_name"].isnull().any())
 
 
+@pytest.mark.slow
 def test_ssn_mapping(artifact):
     """Tests SSN map creation, uniqueness, and range checking."""
     # Create population observer data

--- a/tests/test_synthetic_pii.py
+++ b/tests/test_synthetic_pii.py
@@ -469,40 +469,6 @@ def test_employer_name_map(mocker):
     assert not (employer_names["employer_name"].isnull().any())
 
 
-def test_ssn_mapping(artifact):
-    """Tests SSN map creation, uniqueness, and range checking."""
-    # Create population observer data
-    num_unique_ids = 30_000
-    simulants = pd.DataFrame()
-    simulants["simulant_id"] = [f"123_{n}" for n in range(num_unique_ids)]
-    simulants["has_ssn"] = [True if n % 2 == 0 else False for n in range(num_unique_ids)]
-
-    # Get the map
-    try:
-        ssn_map = get_simulant_id_maps(
-            "simulant_id", {"silly_observer": simulants}, artifact, randomness
-        )["ssn"]
-    except FileNotFoundError:
-        pytest.skip(reason=f"Artifact not found at {artifact.path}")
-
-    # Check that all the SSNs are unique (Half of population size plus one for no SSN)
-    assert ssn_map.nunique() == num_unique_ids / 2 + 1
-
-    # Check that all SSNs are populated if ssn is True, not if False
-    simulants_indexed = simulants.set_index(["simulant_id"])
-    assert ssn_map[simulants_indexed["has_ssn"]].nunique() == num_unique_ids // 2
-    assert (ssn_map[~simulants_indexed["has_ssn"]] == "").all()
-
-    # Check that area, group, and serial segments are within bounds
-    areas = ssn_map[simulants_indexed["has_ssn"]].apply(lambda x: int(x.split("-")[0]))
-    groups = ssn_map[simulants_indexed["has_ssn"]].apply(lambda x: int(x.split("-")[1]))
-    serials = ssn_map[simulants_indexed["has_ssn"]].apply(lambda x: int(x.split("-")[2]))
-    assert (areas != 666).all()
-    assert (areas >= 1).all() and (areas <= 899).all()
-    assert (groups >= 1).all() and (groups <= 99).all()
-    assert (serials >= 1).all() and (serials <= 9999).all()
-
-
 def test_mailing_address(mocker):
     # Mock necessary artifact and observer data
     addresses = pd.DataFrame(


### PR DESCRIPTION
## Title: Sample SSNs from artifact instead of generating on the fly

### Description
- *Category*: implementation
- *JIRA issue*: [MIC-3851](https://jira.ihme.washington.edu/browse/MIC-3851)
- *Research reference*: na

### Changes and notes
Instead of using the `generate_ssn` method, this PR uses the SSN artifact data.
That data has already been randomly shuffled and is stored that way in the artifact,
so all that is needed is to pick off the top the correct number of SSNs.

### Verification and Testing
Confirmed sim runs and various qc checks.

