### PR TITLE
Feature/sbachmei/mic 3887 map itins

### DIFF
--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -11,7 +11,6 @@ from vivarium_census_prl_synth_pop.constants import paths
 def sim() -> InteractiveContext:
     """Initialize a simulation for use in tests"""
     simulation = InteractiveContext(paths.MODEL_SPEC_DIR / "model_spec.yaml", setup=False)
-    simulation.configuration.input_data.artifact_path = "/mnt/share/homes/sbachmei/scratch/vivarium/prl/artifacts/ids-dataframe/united_states_of_america.hdf"
     simulation.configuration.population.population_size = 250_000
     simulation.setup()
     return simulation

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -11,6 +11,7 @@ from vivarium_census_prl_synth_pop.constants import paths
 def sim() -> InteractiveContext:
     """Initialize a simulation for use in tests"""
     simulation = InteractiveContext(paths.MODEL_SPEC_DIR / "model_spec.yaml", setup=False)
+    simulation.configuration.input_data.artifact_path = "/mnt/share/homes/sbachmei/scratch/vivarium/prl/artifacts/ids-dataframe/united_states_of_america.hdf"
     simulation.configuration.population.population_size = 250_000
     simulation.setup()
     return simulation

--- a/src/vivarium_census_prl_synth_pop/results_processing/ssn_and_itin.py
+++ b/src/vivarium_census_prl_synth_pop/results_processing/ssn_and_itin.py
@@ -247,6 +247,8 @@ def do_collide_ssns(
         & (obs_data["employer_id"] != -1)
         & (~obs_data["has_ssn"])
     )
+    # TODO: Replace with sampling from the artifact data if we figure out a
+    # more performant way of doing so (eg querying the hdf with randomized idx)
     obs_data.loc[create_ssn_mask, "ssn"] = generate_ssns(
         size=create_ssn_mask.sum(),
         additional_key="collide",

--- a/src/vivarium_census_prl_synth_pop/results_processing/ssn_and_itin.py
+++ b/src/vivarium_census_prl_synth_pop/results_processing/ssn_and_itin.py
@@ -175,7 +175,7 @@ def get_itin_map(
     )
 
     itins = _convert_to_hyphenated_strings(itins)
-    
+
     # Assign ITINs and create dictionary item
     itin_map = pd.Series("", index=simulant_data.index)
     itin_map[itin_mask] = itins

--- a/src/vivarium_census_prl_synth_pop/tools/make_results.py
+++ b/src/vivarium_census_prl_synth_pop/tools/make_results.py
@@ -168,6 +168,7 @@ FINAL_OBSERVERS = {
         "housing_type",
         "joint_filer",
         "ssn",
+        "itin",
     },
     "tax_dependents_observer": {
         # Metadata is for a dependent.  This should capture each dependent/guardian pair.  Meaning that if a dependent

--- a/tests/test_synthetic_pii.py
+++ b/tests/test_synthetic_pii.py
@@ -17,10 +17,8 @@ from vivarium_census_prl_synth_pop.results_processing.names import (
     get_given_name_map,
     get_last_name_map,
 )
-from vivarium_census_prl_synth_pop.results_processing.ssn_and_itin import (
-    generate_itins,
-    get_simulant_id_maps,
-)
+from vivarium_census_prl_synth_pop.results_processing.ssn_and_itin import get_simulant_id_maps, generate_ssns
+
 
 key = "test_synthetic_data_generation"
 clock = lambda: pd.Timestamp("2020-09-01")
@@ -32,25 +30,6 @@ def get_draw(self, index, additional_key=None) -> pd.Series:
     # Mock get draw function
     s = np.random.uniform(size=len(index))
     return pd.Series(data=s, index=index)
-
-
-def test_itin_generation():
-    """Tests for uniqueness of ITINs and their ranges."""
-    itins = pd.Series(generate_itins(10_000, "test_itin_generation", randomness))
-
-    assert itins.nunique() == 10_000
-
-    areas = itins.apply(lambda x: int(x.split("-")[0]))
-    groups = itins.apply(lambda x: int(x.split("-")[1]))
-    serials = itins.apply(lambda x: int(x.split("-")[2]))
-    assert (areas >= 900).all() and (areas <= 999).all()
-    assert (
-        ((groups >= 50) & (groups <= 65))
-        | ((groups >= 70) & (groups <= 88))
-        | ((groups >= 90) & (groups <= 92))
-        | ((groups >= 94) & (groups <= 99))
-    ).all()
-    assert (serials >= 1).all() and (serials <= 9999).all()
 
 
 @pytest.fixture()
@@ -113,6 +92,16 @@ def fake_obs_data():
             }
         )
     }
+
+
+@pytest.fixture()
+def simulants():
+    num_unique_ids = 30_000
+    simulants = pd.DataFrame()
+    simulants["simulant_id"] = [f"123_{n}" for n in range(num_unique_ids)]
+    simulants["has_ssn"] = [True if n % 2 == 0 else False for n in range(num_unique_ids)]
+    
+    return simulants
 
 
 def get_name_frequency_proportions(
@@ -467,6 +456,80 @@ def test_employer_name_map(mocker):
     assert len(fake_obs_data["fake_observer"]) == len(employer_names["employer_name"])
     assert employer_names["employer_name"].duplicated().sum() == 0
     assert not (employer_names["employer_name"].isnull().any())
+
+
+@pytest.mark.parametrize(
+    "ssn_type",
+    ["assigned", "generated"]
+)
+def test_ssn_mapping(ssn_type, simulants, artifact):
+    """Tests SSN map creation, uniqueness, and range checking."""
+    
+    # Get the map
+    if ssn_type == "assigned":
+        try:
+            ssn_map = get_simulant_id_maps(
+                "simulant_id", {"silly_observer": simulants}, artifact, randomness
+            )["ssn"]
+        except FileNotFoundError:
+            pytest.skip(reason=f"Artifact not found at {artifact.path}")
+    else:
+        ssn_map = pd.Series("", index=simulants["simulant_id"])
+        generated_ssns = generate_ssns(
+            simulants["has_ssn"].sum(),
+            "test_ssn_generation",
+            randomness
+        )
+        ssn_map[simulants.set_index("simulant_id")["has_ssn"]] = generated_ssns
+
+    # Check that all the SSNs are unique (Half of population size plus one for no SSN)
+    assert ssn_map.nunique() == len(simulants) / 2 + 1
+
+    # Check that all SSNs are populated if ssn is True, not if False
+    simulants_indexed = simulants.set_index(["simulant_id"])
+    assert ssn_map[simulants_indexed["has_ssn"]].nunique() == len(simulants) // 2
+    assert (ssn_map[~simulants_indexed["has_ssn"]] == "").all()
+
+    # Check that area, group, and serial segments are within bounds
+    areas = ssn_map[simulants_indexed["has_ssn"]].apply(lambda x: int(x.split("-")[0]))
+    groups = ssn_map[simulants_indexed["has_ssn"]].apply(lambda x: int(x.split("-")[1]))
+    serials = ssn_map[simulants_indexed["has_ssn"]].apply(lambda x: int(x.split("-")[2]))
+    assert (areas != 666).all()
+    assert (areas >= 1).all() and (areas <= 899).all()
+    assert (groups >= 1).all() and (groups <= 99).all()
+    assert (serials >= 1).all() and (serials <= 9999).all()
+
+
+def test_itin_mapping(simulants, artifact):
+    """Tests for uniqueness of ITINs and their ranges."""
+    
+    # Get the map
+    try:
+        itins = get_simulant_id_maps(
+            "simulant_id", {"silly_observer": simulants}, artifact, randomness
+        )["itin"]
+    except FileNotFoundError:
+        pytest.skip(reason=f"Artifact not found at {artifact.path}")
+
+    # Check that all the ITINs are unique (Half of population size plus one for no SSN)
+    assert itins.nunique() == len(simulants) / 2 + 1
+
+    # Check that all ITINs are populated if ssn is False, not if True
+    simulants_indexed = simulants.set_index(["simulant_id"])
+    assert itins[~simulants_indexed["has_ssn"]].nunique() == len(simulants) // 2
+    assert (itins[simulants_indexed["has_ssn"]] == "").all()
+
+    areas = itins[~simulants_indexed["has_ssn"]].apply(lambda x: int(x.split("-")[0]))
+    groups = itins[~simulants_indexed["has_ssn"]].apply(lambda x: int(x.split("-")[1]))
+    serials = itins[~simulants_indexed["has_ssn"]].apply(lambda x: int(x.split("-")[2]))
+    assert (areas >= 900).all() and (areas <= 999).all()
+    assert (
+        ((groups >= 50) & (groups <= 65))
+        | ((groups >= 70) & (groups <= 88))
+        | ((groups >= 90) & (groups <= 92))
+        | ((groups >= 94) & (groups <= 99))
+    ).all()
+    assert (serials >= 1).all() and (serials <= 9999).all()
 
 
 def test_mailing_address(mocker):

--- a/tests/test_synthetic_pii.py
+++ b/tests/test_synthetic_pii.py
@@ -17,8 +17,10 @@ from vivarium_census_prl_synth_pop.results_processing.names import (
     get_given_name_map,
     get_last_name_map,
 )
-from vivarium_census_prl_synth_pop.results_processing.ssn_and_itin import get_simulant_id_maps, generate_ssns
-
+from vivarium_census_prl_synth_pop.results_processing.ssn_and_itin import (
+    generate_ssns,
+    get_simulant_id_maps,
+)
 
 key = "test_synthetic_data_generation"
 clock = lambda: pd.Timestamp("2020-09-01")
@@ -100,7 +102,7 @@ def simulants():
     simulants = pd.DataFrame()
     simulants["simulant_id"] = [f"123_{n}" for n in range(num_unique_ids)]
     simulants["has_ssn"] = [True if n % 2 == 0 else False for n in range(num_unique_ids)]
-    
+
     return simulants
 
 
@@ -458,13 +460,10 @@ def test_employer_name_map(mocker):
     assert not (employer_names["employer_name"].isnull().any())
 
 
-@pytest.mark.parametrize(
-    "ssn_type",
-    ["assigned", "generated"]
-)
+@pytest.mark.parametrize("ssn_type", ["assigned", "generated"])
 def test_ssn_mapping(ssn_type, simulants, artifact):
     """Tests SSN map creation, uniqueness, and range checking."""
-    
+
     # Get the map
     if ssn_type == "assigned":
         try:
@@ -476,9 +475,7 @@ def test_ssn_mapping(ssn_type, simulants, artifact):
     else:
         ssn_map = pd.Series("", index=simulants["simulant_id"])
         generated_ssns = generate_ssns(
-            simulants["has_ssn"].sum(),
-            "test_ssn_generation",
-            randomness
+            simulants["has_ssn"].sum(), "test_ssn_generation", randomness
         )
         ssn_map[simulants.set_index("simulant_id")["has_ssn"]] = generated_ssns
 
@@ -502,7 +499,7 @@ def test_ssn_mapping(ssn_type, simulants, artifact):
 
 def test_itin_mapping(simulants, artifact):
     """Tests for uniqueness of ITINs and their ranges."""
-    
+
     # Get the map
     try:
         itins = get_simulant_id_maps(


### PR DESCRIPTION
## Title: Add ITINs to 1040 form

### Description
- *Category*: implementation
- *JIRA issue*: [MIC-3887](https://jira.ihme.washington.edu/browse/MIC-3851)
- *Research reference*: na

### Changes and notes
This adds the ITIN column to the 1040 form results. It also refactors so that
instead of generating ITINs on the fly it samples off the top of the ITIN 
artifact.


### Verification and Testing
tests pass and post-processing a small simulation confirmed that the 1040
form includes ITIN wherever a simulant does not have an SSN

