### PR TITLE
add seed-specific keys for seed specific maps (i.e. non-employer)

### DIFF
--- a/src/vivarium_census_prl_synth_pop/results_processing/addresses.py
+++ b/src/vivarium_census_prl_synth_pop/results_processing/addresses.py
@@ -24,7 +24,7 @@ def get_address_id_maps(
     artifact: Artifact,
     randomness: RandomnessStream,
     seed: str,
-) -> Dict:
+) -> Dict[str, pd.Series]:
     """
     Get all maps that are indexed by `address_id`.
 
@@ -69,6 +69,7 @@ def get_address_id_maps(
         output_columns=output_cols_superset,
     )
 
+    # We need a single seed that doesn't vary for employer details
     seed = "0" if column_name == "employer_address_id" else seed
 
     maps.update(get_zipcode_map(column_name, formatted_obs_data, randomness, seed))

--- a/src/vivarium_census_prl_synth_pop/results_processing/ssn_and_itin.py
+++ b/src/vivarium_census_prl_synth_pop/results_processing/ssn_and_itin.py
@@ -6,9 +6,6 @@ from loguru import logger
 from vivarium import Artifact
 from vivarium.framework.randomness import RandomnessStream
 
-from vivarium_census_prl_synth_pop.results_processing.formatter import (
-    format_data_for_mapping,
-)
 from vivarium_census_prl_synth_pop.utilities import random_integers
 
 
@@ -16,8 +13,8 @@ def get_simulant_id_maps(
     column_name: str,
     obs_data: Dict[str, pd.DataFrame],
     artifact: Artifact,
-    randomness: RandomnessStream,
-) -> Dict[str, pd.Series]:
+    *_: Any,
+):
     """
     Get all maps that are indexed by `simulant_id`.
 
@@ -29,8 +26,6 @@ def get_simulant_id_maps(
         Observer DataFrame with key for the observer name
     artifact
         A vivarium Artifact object needed by mapper
-    randomness
-        RandomnessStream to use in choosing zipcodes proportionally
 
     Returns
     -------
@@ -188,7 +183,7 @@ def generate_ssns(
 
 
 def get_ssn_map(
-    obs_data: pd.DataFrame,
+    obs_data: Dict[str, pd.DataFrame],
     column_name: str,
     artifact: Artifact,
 ) -> Dict[str, pd.Series]:

--- a/src/vivarium_census_prl_synth_pop/results_processing/ssn_and_itin.py
+++ b/src/vivarium_census_prl_synth_pop/results_processing/ssn_and_itin.py
@@ -14,7 +14,7 @@ def get_simulant_id_maps(
     obs_data: Dict[str, pd.DataFrame],
     artifact: Artifact,
     *_: Any,
-):
+) -> Dict[str, pd.Series]:
     """
     Get all maps that are indexed by `simulant_id`.
 


### PR DESCRIPTION
## Add seed-specific keys for seed specific maps (i.e. non-employer)
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: post-processing
- *JIRA issue*: [MIC-3894](https://jira.ihme.washington.edu/browse/MIC-3894)
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
Utilized vivarium seeds to get distinct values in different parallel runs.
Made sure not to do this for business details. 
Stopped using `pathlib.glob` to load files, since that doesn't guarantee the file read order

### Verification and Testing
Ran post-processing and confirmed that we get different values when we run on different seeds.
