### PR TITLE
implement seed arg for jobmon

### DIFF
--- a/src/vivarium_census_prl_synth_pop/results_processing/ssn_and_itin.py
+++ b/src/vivarium_census_prl_synth_pop/results_processing/ssn_and_itin.py
@@ -2,7 +2,6 @@ from typing import Any, Dict
 
 import numpy as np
 import pandas as pd
-from loguru import logger
 from vivarium import Artifact
 from vivarium.framework.randomness import RandomnessStream
 

--- a/src/vivarium_census_prl_synth_pop/tools/cli.py
+++ b/src/vivarium_census_prl_synth_pop/tools/cli.py
@@ -85,6 +85,7 @@ def make_artifacts(
     "--seed",
     type=str,
     default="",
+    show_default=True,
     help="Provide seed in order to run only on the files corresponding to that "
     "seed. If no seed it provided, will run on all files.",
 )
@@ -191,6 +192,15 @@ def make_results(
     is_flag=True,
 )
 @click.option(
+    "-s",
+    "--seed",
+    type=str,
+    default="",
+    show_default=True,
+    help="Provide seed in order to run only on the files corresponding to that "
+    "seed. If no seed it provided, will run on all files.",
+)
+@click.option(
     "-i", "--artifact-path", type=click.Path(exists=True), default=paths.DEFAULT_ARTIFACT
 )
 def jobmon_make_results_runner(
@@ -199,8 +209,9 @@ def jobmon_make_results_runner(
     verbose: int,
     mark_best: bool,
     test_run: bool,
+    seed: str,
     artifact_path: Union[str, Path],
 ) -> None:
     configure_logging_to_terminal(verbose)
     main = handle_exceptions(func=build_results, logger=logger, with_debugger=False)
-    main(raw_output_dir, final_output_dir, mark_best, test_run, artifact_path)
+    main(raw_output_dir, final_output_dir, mark_best, test_run, seed, artifact_path)

--- a/src/vivarium_census_prl_synth_pop/tools/make_results.py
+++ b/src/vivarium_census_prl_synth_pop/tools/make_results.py
@@ -250,7 +250,7 @@ def perform_post_processing(
 
     # Iterate through expected forms and generate them. Generate columns each of these forms need to have.
     for observer in FINAL_OBSERVERS:
-        logger.info(f"Processing data for {observer}...")
+        logger.info(f"Processing data for {observer}.")
         obs_data = processed_results[observer]
 
         for column in obs_data.columns:
@@ -268,8 +268,11 @@ def perform_post_processing(
 
         obs_data = obs_data[list(FINAL_OBSERVERS[observer])]
         logger.info(f"Writing final results for {observer}.")
+        obs_dir = final_output_dir / observer
+        obs_dir.mkdir(parents=True, exist_ok=False)
+        seed_ext = f"_{seed}" if seed != "" else ""
         obs_data.to_csv(
-            final_output_dir / f"{observer}.csv.bz2",
+            obs_dir / f"{observer}{seed_ext}.csv.bz2",
             index=False,
             quoting=csv.QUOTE_NONNUMERIC,
         )
@@ -281,7 +284,7 @@ def load_data(raw_results_dir: Path, seed: str) -> Dict[str, pd.DataFrame]:
     for observer in FINAL_OBSERVERS:
         obs_dir = raw_results_dir / observer
         if seed == "":
-            logger.info(f"Loading data for {obs_dir.name}...")
+            logger.info(f"Loading data for {obs_dir.name}")
             obs_files = obs_dir.glob("*.csv.bz2")
             obs_data = []
             for file in obs_files:
@@ -292,7 +295,7 @@ def load_data(raw_results_dir: Path, seed: str) -> Dict[str, pd.DataFrame]:
             obs_data = pd.concat(obs_data)
         else:
             filename = f"{obs_dir.name}_{seed}.csv.bz2"
-            logger.info(f"Loading data for {filename}...")
+            logger.info(f"Loading data for {filename}")
             obs_data = pd.read_csv(obs_dir / filename)
             obs_data["random_seed"] = seed
             obs_data = formatter.format_columns(obs_data)

--- a/src/vivarium_census_prl_synth_pop/tools/make_results.py
+++ b/src/vivarium_census_prl_synth_pop/tools/make_results.py
@@ -269,7 +269,7 @@ def perform_post_processing(
         obs_data = obs_data[list(FINAL_OBSERVERS[observer])]
         logger.info(f"Writing final results for {observer}.")
         obs_dir = final_output_dir / observer
-        obs_dir.mkdir(parents=True, exist_ok=False)
+        obs_dir.mkdir(parents=True, exist_ok=True)
         seed_ext = f"_{seed}" if seed != "" else ""
         obs_data.to_csv(
             obs_dir / f"{observer}{seed_ext}.csv.bz2",


### PR DESCRIPTION
## Title: Add `seed` arg to jobmon workflow

### Description
- *Category*: Implementation
- *JIRA issue*: [MIC-3853](https://jira.ihme.washington.edu/browse/MIC-3853)
- *Research reference*: na

### Changes and notes
- Adds `seed` argument logic to the jobmon workflow
- If empty, continues to run on all seeds and concat observer results
- If not empty, saves seed-specific files to respective observer folders

### Verification and Testing
works on small sim

