### PR TITLE
Feature/sbachmei/mic 3854/parallelize jobmon across seed

### DIFF
--- a/src/vivarium_census_prl_synth_pop/tools/jobmon.py
+++ b/src/vivarium_census_prl_synth_pop/tools/jobmon.py
@@ -84,7 +84,16 @@ def run_make_results_workflow(
     # Create tasks
     if seed_arg == "":  # Run all seeds in parallel
         # All raw results are in the format <raw_output_dir>/<observer>/<observer>_<seed>.csv.bz2
-        seeds = sorted(list(set([x.name.split(".")[0].split("_")[-1] for x in raw_output_dir.rglob("*.csv.bz2")])))
+        seeds = sorted(
+            list(
+                set(
+                    [
+                        x.name.split(".")[0].split("_")[-1]
+                        for x in raw_output_dir.rglob("*.csv.bz2")
+                    ]
+                )
+            )
+        )
         seed_args = [f"--seed {seed}" for seed in seeds]
         task_make_results = template_make_results.create_tasks(
             upstream_tasks=[],
@@ -115,6 +124,8 @@ def run_make_results_workflow(
     workflow.bind()
     logger.info(f"Running workflow with ID {workflow.workflow_id}")
     logger.info("For full information see the Jobmon GUI:")
-    logger.info(f"https://jobmon-gui.ihme.washington.edu/#/workflow/{workflow.workflow_id}/tasks")
+    logger.info(
+        f"https://jobmon-gui.ihme.washington.edu/#/workflow/{workflow.workflow_id}/tasks"
+    )
     status = workflow.run(configure_logging=True)
     logger.info(f"Workflow {workflow.workflow_id} completed with status {status}.")

--- a/src/vivarium_census_prl_synth_pop/tools/make_results.py
+++ b/src/vivarium_census_prl_synth_pop/tools/make_results.py
@@ -22,6 +22,7 @@ from vivarium_census_prl_synth_pop.results_processing.ssn_and_itin import (
     do_collide_ssns,
     get_simulant_id_maps,
 )
+from vivarium_census_prl_synth_pop.utilities import build_output_dir
 
 FINAL_OBSERVERS = {
     "decennial_census_observer": {
@@ -268,8 +269,7 @@ def perform_post_processing(
 
         obs_data = obs_data[list(FINAL_OBSERVERS[observer])]
         logger.info(f"Writing final results for {observer}.")
-        obs_dir = final_output_dir / observer
-        obs_dir.mkdir(parents=True, exist_ok=True)
+        obs_dir = build_output_dir(final_output_dir, subdir=observer)
         seed_ext = f"_{seed}" if seed != "" else ""
         obs_data.to_csv(
             obs_dir / f"{observer}{seed_ext}.csv.bz2",


### PR DESCRIPTION
## Title: Parallelize jobmon by seed

### Description
- *Category*: Implementation
- *JIRA issue*: [MIC-3854](https://jira.ihme.washington.edu/browse/MIC-3854)
- *Research reference*: na

### Changes and notes
This allows for jobmon to launch off a separate task for each of the seeds found
in the raw results directory. 

**NOTE: This does not yet properly handle SSNs and ITINs - there will be duplicates!
Do not use until the following PR.**

### Verification and Testing
Ran all combinations of `--jobmon` and `--seed` on a small sim raw results

