### PR TITLE
support writing intermediate outputs as hdf

### DIFF
--- a/src/vivarium_census_prl_synth_pop/constants/metadata.py
+++ b/src/vivarium_census_prl_synth_pop/constants/metadata.py
@@ -273,3 +273,5 @@ PRIORITY_MAP = {
     "businesses.on_time_step": 6,
     "immigration.on_time_step": 7,
 }
+
+SUPPORTED_EXTENSIONS = ["hdf", "csv.bz2"]

--- a/src/vivarium_census_prl_synth_pop/model_specifications/model_spec.yaml
+++ b/src/vivarium_census_prl_synth_pop/model_specifications/model_spec.yaml
@@ -45,3 +45,20 @@ configuration:
     population:
         population_size: 250_000
     # us_population_size: 250_000  # Override the default US population size
+
+    household_survey_observer_acs:
+        file_extension: "hdf"
+    household_survey_observer_cps:
+        file_extension: "hdf"
+    decennial_census_observer:
+        file_extension: "hdf"
+    wic_observer:
+        file_extension: "hdf"
+    social_security_observer:
+        file_extension: "hdf"
+    tax_w2_observer:
+        file_extension: "hdf"
+    tax_dependents_observer:
+        file_extension: "hdf"
+    tax_1040_observer:
+        file_extension: "hdf"

--- a/tests/components/observers/test_household_survey_observers.py
+++ b/tests/components/observers/test_household_survey_observers.py
@@ -8,12 +8,13 @@ from vivarium_census_prl_synth_pop.constants import paths
 # TODO: Broader test coverage
 
 
-@pytest.fixture
-def observer(mocker, tmp_path):
+@pytest.fixture(params=["hdf", "csv.bz2"])
+def observer(mocker, tmp_path, request):
     """Generate post-setup observer with mocked methods to patch as necessary"""
     observer = HouseholdSurveyObserver("acs")
     builder = mocker.MagicMock()
     builder.configuration.output_data.results_directory = tmp_path
+    builder.configuration["household_survey_observer_acs"].file_extension = request.param
     observer.setup(builder)
     return observer
 
@@ -62,7 +63,7 @@ def test_on_simulation_end(observer, mocker):
         observer.output_dir
         / paths.RAW_RESULTS_DIR_NAME
         / observer.name
-        / f"{observer.name}_{observer.seed}.csv.bz2"
+        / f"{observer.name}_{observer.seed}.{observer.file_extension}"
     ).is_file()
 
 


### PR DESCRIPTION
## Support writing intermediate outputs as hdf
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: observers/post-processing
- *JIRA issue*: [MIC-3891](https://jira.ihme.washington.edu/browse/MIC-3891)
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
Support saving intermediate outputs as hdf

### Verification and Testing
Ran a small simulation and successfully ran post-processing
