### PR TITLE
Enforce uniique SSNs and ITINs across seeds

### DIFF
--- a/src/vivarium_census_prl_synth_pop/results_processing/addresses.py
+++ b/src/vivarium_census_prl_synth_pop/results_processing/addresses.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from typing import Any, Dict
 
 import pandas as pd
 from vivarium import Artifact
@@ -24,7 +24,7 @@ def get_address_id_maps(
     artifact: Artifact,
     randomness: RandomnessStream,
     seed: str,
-    _: List[int],
+    *_: Any,
 ) -> Dict[str, pd.Series]:
     """
     Get all maps that are indexed by `address_id`.

--- a/src/vivarium_census_prl_synth_pop/results_processing/addresses.py
+++ b/src/vivarium_census_prl_synth_pop/results_processing/addresses.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, List
 
 import pandas as pd
 from vivarium import Artifact
@@ -24,6 +24,7 @@ def get_address_id_maps(
     artifact: Artifact,
     randomness: RandomnessStream,
     seed: str,
+    _: List[int],
 ) -> Dict[str, pd.Series]:
     """
     Get all maps that are indexed by `address_id`.

--- a/src/vivarium_census_prl_synth_pop/results_processing/names.py
+++ b/src/vivarium_census_prl_synth_pop/results_processing/names.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 import numpy as np
 import pandas as pd
@@ -19,6 +19,7 @@ def get_given_name_map(
     artifact: Artifact,
     randomness: RandomnessStream,
     seed: str,
+    _: List[int],
 ) -> Dict[str, pd.Series]:
     """
     Parameters:
@@ -57,6 +58,7 @@ def get_middle_initial_map(
     artifact: Artifact,
     randomness: RandomnessStream,
     seed: str,
+    all_seeds: List[int],
 ) -> Dict[str, pd.Series]:
     """
     Parameters:
@@ -72,7 +74,9 @@ def get_middle_initial_map(
     Dict with column name as key and pd.Series with middle initial as index and
     string names as values
     """
-    middle_name_map = get_given_name_map(column_name, obs_data, artifact, randomness, seed)
+    middle_name_map = get_given_name_map(
+        column_name, obs_data, artifact, randomness, seed, all_seeds
+    )
     middle_initial_map = middle_name_map[column_name.removesuffix("_id")].str[0]
 
     return {"middle_initial": middle_initial_map}
@@ -84,6 +88,7 @@ def get_last_name_map(
     artifact: Artifact,
     randomness: RandomnessStream,
     seed: str,
+    _: List[int],
 ) -> Dict[str, pd.Series]:
     """
     Parameters:
@@ -259,7 +264,7 @@ def get_employer_name_map(
     obs_data: Dict[str, pd.DataFrame],
     _: Artifact,
     randomness: RandomnessStream,
-    __: str,
+    *__: Any,
 ) -> Dict[str, pd.Series]:
     """
     column_name: Name of column that is being mapped - employer_id

--- a/src/vivarium_census_prl_synth_pop/results_processing/names.py
+++ b/src/vivarium_census_prl_synth_pop/results_processing/names.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import Any, Dict
 
 import numpy as np
 import pandas as pd
@@ -19,7 +19,7 @@ def get_given_name_map(
     artifact: Artifact,
     randomness: RandomnessStream,
     seed: str,
-    _: List[int],
+    *_: Any,
 ) -> Dict[str, pd.Series]:
     """
     Parameters:
@@ -58,7 +58,7 @@ def get_middle_initial_map(
     artifact: Artifact,
     randomness: RandomnessStream,
     seed: str,
-    all_seeds: List[int],
+    *_: Any,
 ) -> Dict[str, pd.Series]:
     """
     Parameters:
@@ -75,7 +75,7 @@ def get_middle_initial_map(
     string names as values
     """
     middle_name_map = get_given_name_map(
-        column_name, obs_data, artifact, randomness, seed, all_seeds
+        column_name, obs_data, artifact, randomness, seed
     )
     middle_initial_map = middle_name_map[column_name.removesuffix("_id")].str[0]
 
@@ -88,7 +88,7 @@ def get_last_name_map(
     artifact: Artifact,
     randomness: RandomnessStream,
     seed: str,
-    _: List[int],
+    *_: Any,
 ) -> Dict[str, pd.Series]:
     """
     Parameters:
@@ -262,13 +262,14 @@ def random_last_names(
 def get_employer_name_map(
     column_name: str,
     obs_data: Dict[str, pd.DataFrame],
-    _: Artifact,
+    _: Any,
     randomness: RandomnessStream,
     *__: Any,
 ) -> Dict[str, pd.Series]:
     """
     column_name: Name of column that is being mapped - employer_id
     obs_data: Raw results from observer outputs
+    randomness: randomness stream used to assign names
 
     Returns: Dict with key "employer_name" and value is series of names.
     Note:  For clarity on variable names, business names refers to the generated business_names.  Employer names will

--- a/src/vivarium_census_prl_synth_pop/results_processing/names.py
+++ b/src/vivarium_census_prl_synth_pop/results_processing/names.py
@@ -74,9 +74,7 @@ def get_middle_initial_map(
     Dict with column name as key and pd.Series with middle initial as index and
     string names as values
     """
-    middle_name_map = get_given_name_map(
-        column_name, obs_data, artifact, randomness, seed
-    )
+    middle_name_map = get_given_name_map(column_name, obs_data, artifact, randomness, seed)
     middle_initial_map = middle_name_map[column_name.removesuffix("_id")].str[0]
 
     return {"middle_initial": middle_initial_map}

--- a/src/vivarium_census_prl_synth_pop/results_processing/ssn_and_itin.py
+++ b/src/vivarium_census_prl_synth_pop/results_processing/ssn_and_itin.py
@@ -15,7 +15,7 @@ def get_simulant_id_maps(
     column_name: str,
     obs_data: Dict[str, pd.DataFrame],
     artifact: Artifact,
-    _: RandomnessStream,
+    _: Any,
     seed: str,
     all_seeds: List[str],
 ) -> Dict[str, pd.Series]:

--- a/src/vivarium_census_prl_synth_pop/results_processing/ssn_and_itin.py
+++ b/src/vivarium_census_prl_synth_pop/results_processing/ssn_and_itin.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 import numpy as np
 import pandas as pd
@@ -15,7 +15,9 @@ def get_simulant_id_maps(
     column_name: str,
     obs_data: Dict[str, pd.DataFrame],
     artifact: Artifact,
-    *_: Any,
+    _: RandomnessStream,
+    seed: str,
+    all_seeds: List[str],
 ) -> Dict[str, pd.Series]:
     """
     Get all maps that are indexed by `simulant_id`.
@@ -28,6 +30,10 @@ def get_simulant_id_maps(
         Observer DataFrame with key for the observer name
     artifact
         A vivarium Artifact object needed by mapper
+    seed
+        The random seed of the simulation of interest
+    all_seeds
+        List of all seeds found in raw results
 
     Returns
     -------
@@ -37,8 +43,9 @@ def get_simulant_id_maps(
     if column_name != "simulant_id":
         raise ValueError(f"Expected `simulant_id`, got `{column_name}`")
     maps = dict()
-    maps.update(get_ssn_map(obs_data, column_name, artifact))
-    maps.update(get_itin_map(obs_data, column_name, artifact))
+    maps.update(get_ssn_map(obs_data, column_name, artifact, seed, all_seeds))
+    maps.update(get_itin_map(obs_data, column_name, artifact, seed, all_seeds))
+
     return maps
 
 
@@ -103,6 +110,8 @@ def get_ssn_map(
     obs_data: Dict[str, pd.DataFrame],
     column_name: str,
     artifact: Artifact,
+    seed: str,
+    all_seeds: List[str],
 ) -> Dict[str, pd.Series]:
     # Anyone in the SSN observer has SSNs by definition
     need_ssns_ssn = obs_data["social_security_observer"][column_name]
@@ -118,17 +127,7 @@ def get_ssn_map(
     need_ssns = pd.concat(
         [need_ssns_ssn, need_ssns_has_ssn, need_ssns_ssn_id], axis=0
     ).drop_duplicates()
-
-    # Load (already-shuffled) SSNs and choose the appropriate number off the top
-    # NOTE: artifact.load does not currently have the option to select specific rows
-    # to load and so that was much slower than using pandas.
-    ssns = pd.read_hdf(
-        artifact.path,
-        key="/synthetic_data/ssns",
-        start=0,
-        stop=len(need_ssns),
-    )
-    ssns = _convert_to_hyphenated_strings(ssns)
+    ssns = _load_ids(artifact, "/synthetic_data/ssns", len(need_ssns), seed, all_seeds)
 
     return {"ssn": pd.Series(ssns, index=need_ssns, name="ssn")}
 
@@ -137,6 +136,8 @@ def get_itin_map(
     obs_data: Dict[str, pd.DataFrame],
     column_name: str,
     artifact: Artifact,
+    seed: str,
+    all_seeds: List[str],
 ):
     formatted_obs_data = format_data_for_mapping(
         index_name=column_name,
@@ -144,29 +145,50 @@ def get_itin_map(
         output_columns=[column_name, "has_ssn"],
     )
     simulant_data = formatted_obs_data.reset_index().drop_duplicates().set_index(column_name)
-    # Load (already-shuffled) ITINs and choose the appropriate number off the top
-    # NOTE: artifact.load does not currently have the option to select specific rows
-    # to load and so that was much slower than using pandas.
     itin_mask = ~simulant_data["has_ssn"]
-    itins = pd.read_hdf(
-        artifact.path,
-        key="/synthetic_data/itins",
-        start=0,
-        stop=itin_mask.sum(),
-    )
-    itins = _convert_to_hyphenated_strings(itins)
+    itins = _load_ids(artifact, "/synthetic_data/itins", itin_mask.sum(), seed, all_seeds)
 
     return {"itin": pd.Series(itins, index=simulant_data.index[itin_mask], name="itin")}
 
 
-def _convert_to_hyphenated_strings(ids: pd.DataFrame) -> np.array:
-    return (
+def _load_ids(
+    artifact: Artifact, hdf_key: str, num_need_ids: int, seed: str, all_seeds: List[str]
+) -> np.array:
+    """Load (already-shuffled) IDs from unique-by-seed chunks of the full
+    artifact data and convert to hyphenated strings
+    """
+    # NOTE: `artifact.load` does not currently have the option to select specific rows
+    # to load and so it's much quicker to use `pd.HDFStore.select`
+    with pd.HDFStore(artifact.path) as store:
+        num_available_ids = store.get_storer(hdf_key).nrows
+        if seed == "":  # all seeds are already concatenated together so just pick off the top
+            start_idx = 0
+            chunksize = num_available_ids
+        else:  # we are dealing with a single seed
+            chunksize = int(num_available_ids / len(all_seeds))
+            seed_position = all_seeds.index(seed)
+            start_idx = seed_position * chunksize
+        if num_need_ids > chunksize:
+            raise IndexError(
+                f"You are requesting {num_need_ids} IDs from seed {seed}'s unique "
+                f"chunk, but this chunk only has {chunksize} available (hdf_key "
+                f"{hdf_key} and {len(all_seeds)} simulation seeds)."
+            )
+        ids = store.select(
+            hdf_key,
+            start=start_idx,
+            stop=start_idx + num_need_ids,
+        )
+    # Convert id section columns to hyphenated string IDs
+    ids = (
         ids["area"].astype(str).str.zfill(3)
         + "-"
         + ids["group"].astype(str).str.zfill(2)
         + "-"
         + ids["serial"].astype(str).str.zfill(4)
     ).to_numpy()
+
+    return ids
 
 
 def do_collide_ssns(

--- a/src/vivarium_census_prl_synth_pop/tools/jobmon.py
+++ b/src/vivarium_census_prl_synth_pop/tools/jobmon.py
@@ -6,7 +6,10 @@ from typing import Union
 from jobmon.client.tool import Tool
 from loguru import logger
 
-from vivarium_census_prl_synth_pop.utilities import build_output_dir
+from vivarium_census_prl_synth_pop.utilities import (
+    build_output_dir,
+    get_all_simulation_seeds,
+)
 
 
 def run_make_results_workflow(
@@ -82,18 +85,9 @@ def run_make_results_workflow(
     )
 
     # Create tasks
-    if seed_arg == "":  # Run all seeds in parallel
+    if seed_arg == "":  # Process all seeds in parallel
         # All raw results are in the format <raw_output_dir>/<observer>/<observer>_<seed>.csv.bz2
-        seeds = sorted(
-            list(
-                set(
-                    [
-                        x.name.split(".")[0].split("_")[-1]
-                        for x in raw_output_dir.rglob("*.csv.bz2")
-                    ]
-                )
-            )
-        )
+        seeds = get_all_simulation_seeds(raw_output_dir)
         seed_args = [f"--seed {seed}" for seed in seeds]
         task_make_results = template_make_results.create_tasks(
             upstream_tasks=[],
@@ -106,7 +100,7 @@ def run_make_results_workflow(
             artifact_path=artifact_path,
         )
         workflow.add_tasks(task_make_results)
-    else:  # run a single job
+    else:  # Process the single provided seed
         task_make_results = template_make_results.create_task(
             name="make_results_task",
             upstream_tasks=[],

--- a/src/vivarium_census_prl_synth_pop/utilities.py
+++ b/src/vivarium_census_prl_synth_pop/utilities.py
@@ -1,5 +1,6 @@
 import os
 from datetime import datetime
+from itertools import chain
 from pathlib import Path
 from typing import Any, List, Optional, Tuple, Union
 
@@ -453,13 +454,8 @@ def get_state_puma_options(builder: Builder) -> pd.DataFrame:
 
 
 def get_all_simulation_seeds(raw_output_dir: Path) -> List[str]:
-    return sorted(
-        list(
-            set(
-                [
-                    x.name.split(".")[0].split("_")[-1]
-                    for x in raw_output_dir.rglob("*.csv.bz2")
-                ]
-            )
-        )
+    raw_results_files = list(
+        chain(*[raw_output_dir.rglob(f"*.{ext}") for ext in metadata.SUPPORTED_EXTENSIONS])
     )
+
+    return sorted(list(set([x.name.split(".")[0].split("_")[-1] for x in raw_results_files])))

--- a/src/vivarium_census_prl_synth_pop/utilities.py
+++ b/src/vivarium_census_prl_synth_pop/utilities.py
@@ -450,3 +450,16 @@ def get_state_puma_options(builder: Builder) -> pd.DataFrame:
     ]
 
     return state_puma_options
+
+
+def get_all_simulation_seeds(raw_output_dir: Path) -> List[str]:
+    return sorted(
+        list(
+            set(
+                [
+                    x.name.split(".")[0].split("_")[-1]
+                    for x in raw_output_dir.rglob("*.csv.bz2")
+                ]
+            )
+        )
+    )

--- a/tests/test_synthetic_pii.py
+++ b/tests/test_synthetic_pii.py
@@ -651,7 +651,7 @@ def test_id_uniqueness(artifact, hdf_key, num_need_ids, random_seed):
     all_seeds = [str(seed) for seed in range(1, 301)]
     try:
         ids = _load_ids(artifact, hdf_key, num_need_ids, random_seed, all_seeds)
-    except FileNotFoundError:
+    except FileNotFoundError:  # Allows it to be skipped for CI
         pytest.mark.skip(reason=f"Cannot find artifact at {artifact.path}")
     else:
         assert len(np.unique(ids)) == num_need_ids

--- a/tests/test_synthetic_pii.py
+++ b/tests/test_synthetic_pii.py
@@ -126,7 +126,6 @@ def test_first_and_middle_names(mocker, given_names, fake_obs_data):
         artifact,
         randomness,
         "1234",
-        ["dummy_list"],
     )
     first_name_proportions = get_name_frequency_proportions(
         first_names["first_name"],
@@ -144,7 +143,6 @@ def test_first_and_middle_names(mocker, given_names, fake_obs_data):
         artifact,
         randomness,
         "2345",
-        ["dummy_list"],
     )
 
     assert (first_names["first_name"] != other_seed_first_names["first_name"]).any()
@@ -155,7 +153,6 @@ def test_first_and_middle_names(mocker, given_names, fake_obs_data):
         artifact,
         randomness,
         "1234",
-        ["dummy_list"],
     )
     middle_name_proportions = get_name_frequency_proportions(
         middle_names["middle_name"], fake_obs_data["fake_observer"], ["year_of_birth", "sex"]
@@ -194,7 +191,6 @@ def test_last_names_proportions(mocker, last_names, fake_obs_data):
         artifact,
         randomness,
         "1234",
-        ["dummy_list"],
     )
     last_name_proportions = get_name_frequency_proportions(
         last_names_map["last_name"],
@@ -213,7 +209,6 @@ def test_last_names_proportions(mocker, last_names, fake_obs_data):
         artifact,
         randomness,
         "2345",
-        ["dummy_list"],
     )
 
     assert (last_names_map["last_name"] != other_seed_last_names_map["last_name"]).any()
@@ -281,7 +276,6 @@ def test_last_name_from_oldest_member(mocker):
         artifact,
         randomness,
         "1234",
-        ["dummy_list"],
     )
     expected = pd.Series(data=["Name A", "Name B", "Name C"], index=[1, 2, 3])
 

--- a/tests/test_synthetic_pii.py
+++ b/tests/test_synthetic_pii.py
@@ -652,5 +652,6 @@ def test_id_uniqueness(artifact, hdf_key, num_need_ids, random_seed):
     try:
         ids = _load_ids(artifact, hdf_key, num_need_ids, random_seed, all_seeds)
     except FileNotFoundError:
-        @pytest.mark.skip(reason=f"Cannot find artifact at {artifact.path}")
-    assert len(np.unique(ids)) == num_need_ids
+        pytest.mark.skip(reason=f"Cannot find artifact at {artifact.path}")
+    else:
+        assert len(np.unique(ids)) == num_need_ids

--- a/tests/test_synthetic_pii.py
+++ b/tests/test_synthetic_pii.py
@@ -649,5 +649,8 @@ def test_mailing_address(mocker):
 def test_id_uniqueness(artifact, hdf_key, num_need_ids, random_seed):
     """Ensure that SSNs and ITINs are unique after assigning from artifact"""
     all_seeds = [str(seed) for seed in range(1, 301)]
-    ids = _load_ids(artifact, hdf_key, num_need_ids, random_seed, all_seeds)
+    try:
+        ids = _load_ids(artifact, hdf_key, num_need_ids, random_seed, all_seeds)
+    except FileNotFoundError:
+        @pytest.mark.skip(reason=f"Cannot find artifact at {artifact.path}")
     assert len(np.unique(ids)) == num_need_ids


### PR DESCRIPTION
## Title: Use seed-specific chunks of artifact data when assigning IDs

### Description
- *Category*: implementation
- *JIRA issue*: [MIC-3855](https://jira.ihme.washington.edu/browse/MIC-3855)
- *Research reference*: na

### Changes and notes
Currently we have SSN and ITIN duplication when each simulation seed is
processed in parallel because they all pick off the top of the artifact data.
This PR assigns unique chunks of the artifact data to each seed to
then choose from

### Verification and Testing
added pytest. Ran small make_results to make sure files are still output.

