### PR TITLE
Changing year column names to be consistent

### DIFF
--- a/src/vivarium_census_prl_synth_pop/components/observers.py
+++ b/src/vivarium_census_prl_synth_pop/components/observers.py
@@ -282,7 +282,7 @@ class DecennialCensusObserver(BaseObserver):
     ADDITIONAL_INPUT_COLUMNS = ["relation_to_household_head"]
     ADDITIONAL_OUTPUT_COLUMNS = [
         "relation_to_household_head",
-        "census_year",
+        "year",
         "housing_type",
     ]
 
@@ -323,7 +323,7 @@ class DecennialCensusObserver(BaseObserver):
         )
         pop = self.add_address(pop)
         pop = utilities.add_guardian_address_ids(pop)
-        pop["census_year"] = event.time.year
+        pop["year"] = event.time.year
 
         return pop[self.output_columns]
 
@@ -337,7 +337,7 @@ class WICObserver(BaseObserver):
         "relation_to_household_head",
     ]
     ADDITIONAL_OUTPUT_COLUMNS = [
-        "wic_year",
+        "year",
         "household_id",
         "housing_type",
         "relation_to_household_head",
@@ -384,7 +384,7 @@ class WICObserver(BaseObserver):
         pop["income"] = self.pipelines["income"](pop.index)
 
         # add columns for output
-        pop["wic_year"] = event.time.year
+        pop["year"] = event.time.year
         pop = self.add_address(pop)
         pop = utilities.add_guardian_address_ids(pop)
 

--- a/src/vivarium_census_prl_synth_pop/tools/make_results.py
+++ b/src/vivarium_census_prl_synth_pop/tools/make_results.py
@@ -52,7 +52,7 @@ FINAL_OBSERVERS = {
         # "guardian_1_addrress_id",
         # "guardian_2_address_id",
         "housing_type",
-        "census_year",
+        "year",
     },
     "household_survey_observer_acs": {
         "simulant_id",
@@ -123,7 +123,7 @@ FINAL_OBSERVERS = {
         # "guardian_1_addrress_id",
         # "guardian_2_address_id",
         "housing_type",
-        "wic_year",
+        "year",
     },
     "social_security_observer": {
         "simulant_id",


### PR DESCRIPTION
## Rename year columns in observers

### Renames wic_year and census_year to year to be consistent. 
- *Category*: Observers
- *JIRA issue*: [MIC-3896](https://jira.ihme.washington.edu/browse/MIC-3896)
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
-Renames wic_year and census_year to year

### Verification and Testing
V&V run and make_results ran successfully with correct column names in outputs.

