### PR TITLE
enable multiple concurrent reads during post-processing

### DIFF
--- a/src/vivarium_census_prl_synth_pop/results_processing/ssn_and_itin.py
+++ b/src/vivarium_census_prl_synth_pop/results_processing/ssn_and_itin.py
@@ -159,7 +159,7 @@ def _load_ids(
     """
     # NOTE: `artifact.load` does not currently have the option to select specific rows
     # to load and so it's much quicker to use `pd.HDFStore.select`
-    with pd.HDFStore(artifact.path) as store:
+    with pd.HDFStore(artifact.path, mode="r") as store:
         num_available_ids = store.get_storer(hdf_key).nrows
         if seed == "":  # all seeds are already concatenated together so just pick off the top
             start_idx = 0


### PR DESCRIPTION
## Enable multiple concurrent reads during post-processing
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: bugfix
- *JIRA issue*: [MIC-XYZ](https://jira.ihme.washington.edu/browse/MIC-XYZ)
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
Fix issue where concurrent reads fail during post-processing because the file is being accessed in append mode 

### Verification and Testing
None yet. Will run post-processing via jobmon and report back.
