### PR TITLE
floor age and enforce zipcode as int

### DIFF
--- a/src/vivarium_census_prl_synth_pop/results_processing/addresses.py
+++ b/src/vivarium_census_prl_synth_pop/results_processing/addresses.py
@@ -154,7 +154,8 @@ def get_zipcode_map(
             weights=locale_group["proportion"],
             additional_key=f"{additional_key}{column_name}_zip_map_{state_id}_{puma}_{seed}",
         ).to_numpy()
-
+    # Convert to 0-padded strings
+    zip_map = zip_map.astype(str).str.zfill(5)
     # Map against obs_data
     if column_name == "address_id":
         zip_map_dict["zipcode"] = zip_map

--- a/src/vivarium_census_prl_synth_pop/results_processing/addresses.py
+++ b/src/vivarium_census_prl_synth_pop/results_processing/addresses.py
@@ -127,7 +127,7 @@ def get_zipcode_map(
         )
 
     simulation_addresses = obs_data.reset_index()[output_cols].set_index(column_name)
-    zip_map = pd.Series(index=simulation_addresses.index, dtype=int)
+    zip_map = pd.Series(-1, index=simulation_addresses.index, dtype=int)
 
     # Read in CSV and normalize
     groupby_cols = ["state", "puma"]

--- a/src/vivarium_census_prl_synth_pop/results_processing/formatter.py
+++ b/src/vivarium_census_prl_synth_pop/results_processing/formatter.py
@@ -75,6 +75,10 @@ def get_guardian_id(data: pd.DataFrame) -> pd.Series:
     return data["random_seed"].astype(str) + "_" + data["guardian_id"].astype(str)
 
 
+def format_age(data: pd.DataFrame) -> pd.Series:
+    return data["age"].astype(int)
+
+
 # Fixme: Add formatting functions as necessary
 COLUMN_FORMATTERS = {
     "simulant_id": (format_simulant_id, ["simulant_id", "random_seed"]),
@@ -98,6 +102,7 @@ COLUMN_FORMATTERS = {
     ),
     "guardian_id": (get_guardian_id, ["guardian_id", "random_seed"]),
     "ssn_id": (format_ssn_id, ["ssn_id", "random_seed"]),
+    "age": (format_age, ["age"]),
 }
 
 

--- a/src/vivarium_census_prl_synth_pop/tools/make_results.py
+++ b/src/vivarium_census_prl_synth_pop/tools/make_results.py
@@ -309,8 +309,6 @@ def load_data(raw_results_dir: Path, seed: str) -> Dict[str, pd.DataFrame]:
                 else:
                     df = pd.read_csv(file)
                 df["random_seed"] = file.name.split(".")[0].split("_")[-1]
-                if "age" in df.columns:
-                    df["age"] = df["age"].astype(int)
                 df = formatter.format_columns(df)
                 obs_data.append(df)
             obs_data = pd.concat(obs_data)
@@ -334,8 +332,6 @@ def load_data(raw_results_dir: Path, seed: str) -> Dict[str, pd.DataFrame]:
             else:
                 obs_data = pd.read_csv(obs_file)
             obs_data["random_seed"] = seed
-            if "age" in obs_data.columns:
-                obs_data["age"] = obs_data["age"].astype(int)
             obs_data = formatter.format_columns(obs_data)
 
         observers_results[obs_dir.name] = obs_data

--- a/src/vivarium_census_prl_synth_pop/tools/make_results.py
+++ b/src/vivarium_census_prl_synth_pop/tools/make_results.py
@@ -257,6 +257,7 @@ def perform_post_processing(
     )
 
     processed_results = load_data(raw_output_dir, seed)
+
     # Generate all post-processing maps to apply to raw results
     artifact = Artifact(artifact_path)
     all_seeds = get_all_simulation_seeds(raw_output_dir)
@@ -308,6 +309,8 @@ def load_data(raw_results_dir: Path, seed: str) -> Dict[str, pd.DataFrame]:
                 else:
                     df = pd.read_csv(file)
                 df["random_seed"] = file.name.split(".")[0].split("_")[-1]
+                if "age" in df.columns:
+                    df["age"] = df["age"].astype(int)
                 df = formatter.format_columns(df)
                 obs_data.append(df)
             obs_data = pd.concat(obs_data)
@@ -331,6 +334,8 @@ def load_data(raw_results_dir: Path, seed: str) -> Dict[str, pd.DataFrame]:
             else:
                 obs_data = pd.read_csv(obs_file)
             obs_data["random_seed"] = seed
+            if "age" in obs_data.columns:
+                obs_data["age"] = obs_data["age"].astype(int)
             obs_data = formatter.format_columns(obs_data)
 
         observers_results[obs_dir.name] = obs_data

--- a/tests/test_synthetic_pii.py
+++ b/tests/test_synthetic_pii.py
@@ -410,12 +410,12 @@ def test_zipcode_mapping(input_address_col, zipcode_col, state_id_col, puma_col)
         mapper[zipcode_col]
     )
     assert np.isclose(
-        (fake_obs_data[zipcode_col].value_counts()[90723] / len(fake_obs_data[zipcode_col])),
+        (fake_obs_data[zipcode_col].value_counts()["90723"] / len(fake_obs_data[zipcode_col])),
         expected_proportion_90723,
         rtol=0.1,
     )
     assert np.isclose(
-        (fake_obs_data[zipcode_col].value_counts()[90706] / len(fake_obs_data[zipcode_col])),
+        (fake_obs_data[zipcode_col].value_counts()["90706"] / len(fake_obs_data[zipcode_col])),
         expected_proportion_90706,
         rtol=0.1,
     )

--- a/tests/test_synthetic_pii.py
+++ b/tests/test_synthetic_pii.py
@@ -410,16 +410,46 @@ def test_zipcode_mapping(input_address_col, zipcode_col, state_id_col, puma_col)
         mapper[zipcode_col]
     )
     assert np.isclose(
-        (fake_obs_data[zipcode_col].value_counts()["90723"] / len(fake_obs_data[zipcode_col])),
+        (
+            fake_obs_data[zipcode_col].value_counts()["90723"]
+            / len(fake_obs_data[zipcode_col])
+        ),
         expected_proportion_90723,
         rtol=0.1,
     )
     assert np.isclose(
-        (fake_obs_data[zipcode_col].value_counts()["90706"] / len(fake_obs_data[zipcode_col])),
+        (
+            fake_obs_data[zipcode_col].value_counts()["90706"]
+            / len(fake_obs_data[zipcode_col])
+        ),
         expected_proportion_90706,
         rtol=0.1,
     )
     assert (mapper[zipcode_col] != other_seed_mapper[zipcode_col]).any()
+
+
+def test_zipcodes_are_strings():
+    """check that zipcodes are output as strings and allow for starting with 0.
+    state_id 25, puma 1901 contains only zipcodes starting with 0.
+    """
+    num_rows = 1_000
+    dummy_data = pd.DataFrame(
+        {
+            "address_id": [f"123_{n}" for n in range(num_rows)],
+            "state_id": 25,
+            "puma": 1901,
+            "silly_column": "foo",
+        },
+        index=range(num_rows),
+    )
+    mapped_zipcodes = get_zipcode_map(
+        "address_id",
+        dummy_data,
+        randomness,
+        "1",
+    )
+    assert mapped_zipcodes["zipcode"].dtype == "object"
+    assert (mapped_zipcodes["zipcode"].str[0] == "0").all()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Title: Floor age and set zipcodes as int

### Description
- *Category*: bugfix 
- *JIRA issue*: [MIC-3932](https://jira.ihme.washington.edu/browse/MIC-3932)
- *Research reference*: na

### Changes and notes
This PR does two simple things. When post-processing:
- Force zipcodes to be integers (currently they are floats)
- Modify the "real" age (which is a floag, eg 39.384623) to int (eg 39)

### Verification and Testing
spot checked a bit. I'm re-running make_results on the full-pop sim that Jim ran last week.
