### PR TITLE
Feature/hdf

### DIFF
--- a/src/vivarium_census_prl_synth_pop/components/observers.py
+++ b/src/vivarium_census_prl_synth_pop/components/observers.py
@@ -171,7 +171,7 @@ class BaseObserver(ABC):
             self.responses.index.names = ["simulant_id"]
             filepath = output_dir / f"{self.name}_{self.seed}.{self.file_extension}"
             if "hdf" == self.file_extension:
-                self.responses.to_hdf(filepath, "data", format="table")
+                self.responses.to_hdf(filepath, "data", format="table", complib=9)
             else:
                 self.responses.to_csv(filepath)
 

--- a/src/vivarium_census_prl_synth_pop/components/observers.py
+++ b/src/vivarium_census_prl_synth_pop/components/observers.py
@@ -171,7 +171,9 @@ class BaseObserver(ABC):
             self.responses.index.names = ["simulant_id"]
             filepath = output_dir / f"{self.name}_{self.seed}.{self.file_extension}"
             if "hdf" == self.file_extension:
-                self.responses.to_hdf(filepath, "data", format="table", complib=9)
+                self.responses.to_hdf(
+                    filepath, "data", format="table", complib="bzip2", complevel=9
+                )
             else:
                 self.responses.to_csv(filepath)
 

--- a/src/vivarium_census_prl_synth_pop/model_specifications/model_spec.yaml
+++ b/src/vivarium_census_prl_synth_pop/model_specifications/model_spec.yaml
@@ -43,7 +43,7 @@ configuration:
             day: 1
         step_size: 28 # Days
     population:
-        population_size: 250_000
+        population_size: 1_000_000
     # us_population_size: 250_000  # Override the default US population size
 
     household_survey_observer_acs:

--- a/src/vivarium_census_prl_synth_pop/tools/make_results.py
+++ b/src/vivarium_census_prl_synth_pop/tools/make_results.py
@@ -1,4 +1,3 @@
-import csv
 from itertools import chain
 from pathlib import Path
 from typing import Dict, List, Union
@@ -284,10 +283,12 @@ def perform_post_processing(
         logger.info(f"Writing final results for {observer}.")
         obs_dir = build_output_dir(final_output_dir, subdir=observer)
         seed_ext = f"_{seed}" if seed != "" else ""
-        obs_data.to_csv(
-            obs_dir / f"{observer}{seed_ext}.csv.bz2",
-            index=False,
-            quoting=csv.QUOTE_NONNUMERIC,
+        obs_data.to_hdf(
+            obs_dir / f"{observer}{seed_ext}.hdf",
+            "data",
+            format="table",
+            complib="bzip2",
+            complevel=9,
         )
 
 


### PR DESCRIPTION
## Write output of sim as hdf rather than csv
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: observers/post-processing
- *JIRA issue*: [MIC-3942](https://jira.ihme.washington.edu/browse/MIC-3942)
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
Write output of sim and of post-processing as bzip2 compressed hdf files. 
Updated default simulation size to 1 million simulants.

### Verification and Testing
Ran simulation and post-processing and verified that files are written out correctly and can be read back using `pd.read_hdf`

