### PR TITLE
Pin pandas to version 1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ if __name__ == "__main__":
         "jinja2",
         "loguru",
         "numpy",
-        "pandas",
+        "pandas>=1.0.0, <2.0.0",
         "scipy",
         "tables",
         "pyyaml",


### PR DESCRIPTION
## Pin pandas to version 1

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: misc
- *JIRA issue*: none
- *Research reference*: none

### Changes and notes

CI was failing due to auto-upgrading to version 2.0.0 of Pandas, [which was released today](https://pandas.pydata.org/docs/dev/whatsnew/v2.0.0.html).

It seems unwise to place no constraints on versions of so many packages in general, but I've stuck to the minimal change to fix the problem here.

Alternatively, we could upgrade to pandas v2.0.0, but there are quite a few API changes and I think we'll want to do this intentionally.

### Verification and Testing

None besides CI.