### PR TITLE
Fuzzy test domestic migration rates

### DIFF
--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -261,7 +261,7 @@ def fuzzy_tester() -> FuzzyTester:
         # Do not update this if it is not the only thing that is failing!
         # Early exits from failing tests can make the number of asserts actually performed
         # different than what it would be with passing tests.
-        num_comparisons=601,
+        num_comparisons=684,
         # Probability of getting any failure by chance when all the values are truly in the
         # ranges asserted (false alarm).
         # The lower this number is, the less sensitive we will be to true issues.

--- a/integration_tests/test_domestic_migration.py
+++ b/integration_tests/test_domestic_migration.py
@@ -1,16 +1,63 @@
+import json
+import os
+from pathlib import Path
+
 import numpy as np
 import pandas as pd
 import pytest
+from vivarium.framework.utilities import from_yearly
 
 from vivarium_census_prl_synth_pop.constants import data_values, metadata, paths
 
 from .conftest import FuzzyTester
 
 
-def test_individuals_move(simulants_on_adjacent_timesteps):
-    for before, after in simulants_on_adjacent_timesteps:
+@pytest.fixture(scope="module")
+def target_migration_rates(sim):
+    assert (
+        metadata.UNITED_STATES_LOCATIONS == []
+    ), "Integration tests do not support subsets by US state"
+
+    with open(
+        Path(os.path.dirname(__file__)) / "v_and_v_inputs/domestic_migration.json"
+    ) as f:
+        targets = json.load(f)
+
+    targets["individual_migration_rate_per_year"]["total"] = sum(
+        [v for v in targets["individual_migration_rate_per_year"].values()]
+    )
+
+    targets["household"] = from_yearly(
+        targets["household_migration_rate_per_year"],
+        pd.Timedelta(days=sim.configuration.time.step_size),
+    )
+
+    targets["individual"] = {}
+    for k in targets["individual_migration_rate_per_year"].keys():
+        targets["individual"][k] = from_yearly(
+            targets["individual_migration_rate_per_year"][k],
+            pd.Timedelta(days=sim.configuration.time.step_size),
+        )
+
+    return targets
+
+
+def test_individuals_move(
+    simulants_on_adjacent_timesteps, fuzzy_tester: FuzzyTester, target_migration_rates
+):
+    for time_steps, (before, after) in enumerate(simulants_on_adjacent_timesteps):
         individual_movers = before["household_id"] != after["household_id"]
-        assert individual_movers.any()
+        fuzzy_tester.fuzzy_assert_proportion(
+            "Individual migration rate",
+            individual_movers,
+            # We say it could vary by up to 1% per timestep because of demographic
+            # change over the sim
+            true_value_min=target_migration_rates["individual"]["total"]
+            * pow(0.99, time_steps),
+            true_value_max=target_migration_rates["individual"]["total"]
+            * pow(1.01, time_steps),
+            name_addl=f"Time step {time_steps}",
+        )
         assert (
             before[individual_movers]["household_details.address_id"]
             != after[individual_movers]["household_details.address_id"]
@@ -18,8 +65,10 @@ def test_individuals_move(simulants_on_adjacent_timesteps):
         check_po_box_collisions(after, before, individual_movers)
 
 
-def test_individuals_move_into_new_households(simulants_on_adjacent_timesteps):
-    for before, after in simulants_on_adjacent_timesteps:
+def test_individuals_move_into_new_households(
+    simulants_on_adjacent_timesteps, fuzzy_tester: FuzzyTester, target_migration_rates
+):
+    for time_step, (before, after) in enumerate(simulants_on_adjacent_timesteps):
         # NOTE: This set is not exactly the same as "new-household movers," as
         # implemented in the component, because it can in rare cases include
         # non-reference-person movers who join a household that was *just*
@@ -29,7 +78,6 @@ def test_individuals_move_into_new_households(simulants_on_adjacent_timesteps):
             & (after["household_details.housing_type"] == "Standard")
             & (~after["household_id"].isin(before["household_id"]))
         )
-        assert movers_into_new_households.any()
 
         assert (
             after[movers_into_new_households]["relation_to_household_head"]
@@ -42,7 +90,25 @@ def test_individuals_move_into_new_households(simulants_on_adjacent_timesteps):
         new_household_movers = movers_into_new_households & (
             after["relation_to_household_head"] == "Reference person"
         )
-        assert new_household_movers.any()
+        fuzzy_tester.fuzzy_assert_proportion(
+            "Domestic migration joining recently created households",
+            # This case -- people who joined a just-created household -- should be exceedingly rare.
+            movers_into_new_households & (~new_household_movers),
+            true_value_min=0,
+            true_value_max=0.001,
+            name_addl=f"Time step {time_step}",
+        )
+        fuzzy_tester.fuzzy_assert_proportion(
+            "Domestic migration creating new households",
+            new_household_movers,
+            # We say it could vary by up to 1% per timestep because of demographic
+            # change over the sim
+            true_value_min=target_migration_rates["individual"]["new_household"]
+            * pow(0.99, time_step),
+            true_value_max=target_migration_rates["individual"]["new_household"]
+            * pow(1.01, time_step),
+            name_addl=f"Time step {time_step}",
+        )
         # There is exactly one new-household mover for each new household.
         assert (
             new_household_movers[movers_into_new_households]
@@ -50,11 +116,6 @@ def test_individuals_move_into_new_households(simulants_on_adjacent_timesteps):
             .sum()
             == 1
         ).all()
-        # These should be the vast majority, since non-reference-person moves to
-        # new households will be quite rare.
-        # NOTE: This is sensitive to small population size, eg running 20k simulants
-        # was causing it to break w/ a ratio 19/20 = 0.95
-        assert new_household_movers.sum() / movers_into_new_households.sum() >= 0.95
 
         # Household IDs moved to are unique
         new_households = after[new_household_movers]["household_id"]
@@ -66,13 +127,33 @@ def test_individuals_move_into_new_households(simulants_on_adjacent_timesteps):
         assert not new_addresses.isin(before["household_details.address_id"]).any()
 
 
-def test_individuals_move_into_group_quarters(simulants_on_adjacent_timesteps):
-    for before, after in simulants_on_adjacent_timesteps:
+def test_individuals_move_into_group_quarters(
+    simulants_on_adjacent_timesteps, fuzzy_tester: FuzzyTester, target_migration_rates
+):
+    for time_step, (before, after) in enumerate(simulants_on_adjacent_timesteps):
         gq_movers = (before["household_id"] != after["household_id"]) & (
             after["household_details.housing_type"] != "Standard"
         )
-        assert gq_movers.any()
-        assert (before[gq_movers]["household_details.housing_type"] == "Standard").any()
+        fuzzy_tester.fuzzy_assert_proportion(
+            "Domestic migration into GQ",
+            gq_movers,
+            # We say it could vary by up to 1% per timestep because of demographic
+            # change over the sim
+            true_value_min=target_migration_rates["individual"]["gq_person"]
+            * pow(0.99, time_step),
+            true_value_max=target_migration_rates["individual"]["gq_person"]
+            * pow(1.01, time_step),
+            name_addl=f"Time step {time_step}",
+        )
+        fuzzy_tester.fuzzy_assert_proportion(
+            "Domestic migration into GQ from GQ",
+            # Since this is sampled randomly from the population only based on demographics, it should
+            # be around 3%, with some leeway for demographics correlations
+            (before[gq_movers]["household_details.housing_type"] != "Standard"),
+            true_value_min=data_values.PROP_POPULATION_IN_GQ * 0.5,
+            true_value_max=data_values.PROP_POPULATION_IN_GQ * 3,
+            name_addl=f"Time step {time_step}",
+        )
         assert after[gq_movers]["household_id"].isin(data_values.GQ_HOUSING_TYPE_MAP).all()
         assert (
             after[gq_movers]["relation_to_household_head"]
@@ -96,14 +177,26 @@ def get_households_with_stable_reference_person(after, before):
     return in_household_with_reference_person
 
 
-def test_individual_movers_have_correct_relationship(simulants_on_adjacent_timesteps):
-    for before, after in simulants_on_adjacent_timesteps:
+def test_individual_movers_have_correct_relationship(
+    simulants_on_adjacent_timesteps, fuzzy_tester: FuzzyTester, target_migration_rates
+):
+    for time_step, (before, after) in enumerate(simulants_on_adjacent_timesteps):
         non_reference_person_movers = (
             (before["household_id"] != after["household_id"])
             & (after["household_details.housing_type"] == "Standard")
             & (after["household_id"].isin(before["household_id"]))
         )
-        assert non_reference_person_movers.any()
+        fuzzy_tester.fuzzy_assert_proportion(
+            "Domestic migration into existing households",
+            non_reference_person_movers,
+            # We say it could vary by up to 1% per timestep because of demographic
+            # change over the sim
+            true_value_min=target_migration_rates["individual"]["non_reference_person"]
+            * pow(0.99, time_step),
+            true_value_max=target_migration_rates["individual"]["non_reference_person"]
+            * pow(1.01, time_step),
+            name_addl=f"Time step {time_step}",
+        )
 
         # They move in as nonrelative, which doesn't change unless the reference person
         # of their new household also moved or died
@@ -129,12 +222,22 @@ def test_individual_movers_have_correct_relationship(simulants_on_adjacent_times
         ).all()
 
 
-def test_households_move(simulants_on_adjacent_timesteps):
-    for before, after in simulants_on_adjacent_timesteps:
+def test_households_move(
+    simulants_on_adjacent_timesteps, fuzzy_tester: FuzzyTester, target_migration_rates
+):
+    for time_step, (before, after) in enumerate(simulants_on_adjacent_timesteps):
         household_movers = (before["household_id"] == after["household_id"]) & (
             before["household_details.address_id"] != after["household_details.address_id"]
         )
-        assert household_movers.any()
+        fuzzy_tester.fuzzy_assert_proportion(
+            "Domestic migration of households",
+            household_movers.groupby(before["household_id"]).first(),
+            # We say it could vary by up to 1% per timestep because of demographic
+            # change over the sim
+            true_value_min=target_migration_rates["household"] * pow(0.99, time_step),
+            true_value_max=target_migration_rates["household"] * pow(1.01, time_step),
+            name_addl=f"Time step {time_step}",
+        )
 
         # Household moves don't change household structure unless the reference person left
         in_household_with_reference_person = get_households_with_stable_reference_person(
@@ -296,10 +399,13 @@ def test_addresses_during_moves(
     address_id_col,
     state_id_col,
     puma_col,
+    sim,
     fuzzy_tester: FuzzyTester,
+    target_migration_rates,
 ):
     """Check that unit (household and business) address details change after a move."""
     address_cols = [address_id_col, state_id_col, puma_col]
+
     state_puma_options = pd.read_csv(paths.PUMA_TO_ZIP_DATA_PATH)[
         ["state", "puma"]
     ].drop_duplicates()
@@ -315,7 +421,7 @@ def test_addresses_during_moves(
         (state_puma_options.groupby("state").size() / len(state_puma_options)) ** 2
     ).sum()
 
-    total_num_moved = 0
+    all_time_moved = []
     for time_step, (before, after) in enumerate(simulants_on_adjacent_timesteps):
         # get the unique unit (household or employer) dataset for before and after
         before_units = before.groupby(unit_id_col)[address_cols].first()
@@ -325,10 +431,8 @@ def test_addresses_during_moves(
         before_units = before_units.reindex(total_index)
         after_units = after_units.reindex(total_index)
         mask_moved_units = before_units[address_id_col] != after_units[address_id_col]
-        if not mask_moved_units.any():
-            continue
 
-        total_num_moved += mask_moved_units.sum()
+        all_time_moved.append(mask_moved_units)
 
         # address details do not change if address_id does not change
         pd.testing.assert_frame_equal(
@@ -358,28 +462,43 @@ def test_addresses_during_moves(
         )
 
     # Check that at least some units moved during the sim
-    assert total_num_moved > 0
+    all_time_moved = pd.concat(all_time_moved, ignore_index=True)
+    if unit_id_col == "employer_id":
+        fuzzy_tester.fuzzy_assert_proportion(
+            "Domestic migration of businesses",
+            all_time_moved,
+            true_value=from_yearly(
+                data_values.BUSINESS_MOVE_RATE_YEARLY,
+                pd.Timedelta(days=sim.configuration.time.step_size),
+            ),
+        )
+    else:
+        fuzzy_tester.fuzzy_assert_proportion(
+            "Domestic migration of households",
+            all_time_moved,
+            # We say it could vary by up to 10% because of demographic
+            # change over the sim
+            true_value_min=target_migration_rates["household"] * 0.9,
+            true_value_max=target_migration_rates["household"] * 1.1,
+        )
 
 
-def test_po_box(tracked_live_populations):
+def test_po_box(tracked_live_populations, fuzzy_tester: FuzzyTester):
     """Tests the prevalence of PO Boxes."""
-    for pop in tracked_live_populations:
-        # Check that actual proportion of households without PO Boxes (i.e., physical
-        # address is the same as mailing) is close to the expected proportion
-        assert np.isclose(
-            pop[pop["household_details.po_box"] == data_values.NO_PO_BOX][
-                "household_id"
-            ].nunique()
-            / pop["household_id"].nunique(),
-            data_values.PROBABILITY_OF_SAME_MAILING_PHYSICAL_ADDRESS,
-            rtol=0.01,
+    for time_step, pop in enumerate(tracked_live_populations):
+        po_box_values = pop.groupby("household_id")["household_details.po_box"].first()
+        fuzzy_tester.fuzzy_assert_proportion(
+            "Proportion without PO box",
+            po_box_values == data_values.NO_PO_BOX,
+            true_value=data_values.PROBABILITY_OF_SAME_MAILING_PHYSICAL_ADDRESS,
+            name_addl=f"Time step {time_step}",
         )
 
         # Check that PO Boxes are within the min and max defined in constants
         assert (
-            (pop["household_details.po_box"] == data_values.NO_PO_BOX)
+            (po_box_values == data_values.NO_PO_BOX)
             | (
-                (pop["household_details.po_box"] <= data_values.MAX_PO_BOX)
-                & (pop["household_details.po_box"] >= data_values.MIN_PO_BOX)
+                (po_box_values <= data_values.MAX_PO_BOX)
+                & (po_box_values >= data_values.MIN_PO_BOX)
             )
         ).all()

--- a/integration_tests/v_and_v_inputs/domestic_migration.json
+++ b/integration_tests/v_and_v_inputs/domestic_migration.json
@@ -1,0 +1,8 @@
+{
+    "household_migration_rate_per_year": 0.06865104510078264,
+    "individual_migration_rate_per_year": {
+        "gq_person": 0.010854666688840622,
+        "new_household": 0.01978582439294686,
+        "non_reference_person": 0.02348931693394372
+    }
+}


### PR DESCRIPTION
## Fuzzy test domestic migration rates

### Description
- *Category*: test
- *JIRA issue*: [SSCI-995](https://jira.ihme.washington.edu/browse/SSCI-995) (research ticket)
- *Research reference*: none

### Changes and notes

Based on #256.

Uses V&V target values [calculated on the research side](https://github.com/ihmeuw/vivarium_research_prl/pull/29).

### Verification and Testing

Ran integration tests with several population sizes.

Intentionally doubled the person migration rate and verified that these tests will fail (even with only 20k population size).