### PR TITLE
Public sample data fixes

### DIFF
--- a/src/vivarium_census_prl_synth_pop/components/observers.py
+++ b/src/vivarium_census_prl_synth_pop/components/observers.py
@@ -246,7 +246,7 @@ class HouseholdSurveyObserver(BaseObserver):
             * builder.configuration.time.step_size
             / DAYS_PER_YEAR
             * builder.configuration.population.population_size
-            / builder.configuration.us_population_size
+            / data_values.US_POPULATION
         )
 
     ########################

--- a/src/vivarium_census_prl_synth_pop/tools/make_results.py
+++ b/src/vivarium_census_prl_synth_pop/tools/make_results.py
@@ -212,7 +212,7 @@ PUBLIC_SAMPLE_PUMA_PROPORTION = 0.5
 PUBLIC_SAMPLE_ADDRESS_PARTS = {
     "city": "Anytown",
     "state": "US",
-    "zipcode": "99999",
+    "zipcode": "00000",
 }
 
 

--- a/src/vivarium_census_prl_synth_pop/tools/make_results.py
+++ b/src/vivarium_census_prl_synth_pop/tools/make_results.py
@@ -326,7 +326,7 @@ def perform_post_processing(
                 "state": "US",
                 "zipcode": 90210,
             }
-            for address_prefix in ["", "mailing_address_"]:
+            for address_prefix in ["", "mailing_address_", "employer_"]:
                 for address_part, address_part_value in address_part_values.items():
                     if f"{address_prefix}{address_part}" in obs_data.columns:
                         obs_data[f"{address_prefix}{address_part}"] = address_part_value

--- a/src/vivarium_census_prl_synth_pop/tools/make_results.py
+++ b/src/vivarium_census_prl_synth_pop/tools/make_results.py
@@ -209,6 +209,12 @@ FINAL_OBSERVERS = {
 
 PUBLIC_SAMPLE_PUMA_PROPORTION = 0.5
 
+PUBLIC_SAMPLE_ADDRESS_PARTS = {
+    "city": "Anytown",
+    "state": "US",
+    "zipcode": "99999",
+}
+
 
 def build_results(
     raw_output_dir: Union[str, Path],
@@ -321,13 +327,8 @@ def perform_post_processing(
         obs_data = obs_data[list(FINAL_OBSERVERS[observer])]
 
         if public_sample:
-            address_part_values = {
-                "city": "Anytown",
-                "state": "US",
-                "zipcode": 90210,
-            }
             for address_prefix in ["", "mailing_address_", "employer_"]:
-                for address_part, address_part_value in address_part_values.items():
+                for address_part, address_part_value in PUBLIC_SAMPLE_ADDRESS_PARTS.items():
                     if f"{address_prefix}{address_part}" in obs_data.columns:
                         obs_data[f"{address_prefix}{address_part}"] = address_part_value
 


### PR DESCRIPTION
## Public sample data fixes

### Description
- *Category*: other
- *JIRA issue*: none
- *Research reference*: will be described in pseudopeople docs

### Changes and notes

No longer uses the us_population_size configuration value when calculating the ACS sample rate.
I think this configuration value is a misnomer; it is intended to capture the full size of a parallel run,
and therefore the number of employers that should be generated, since those are shared for the
entire parallel run.

I can also change the name of the configuration option, if desired.

Also, updates the dummy ZIP code to 00000, and makes employer addresses follow the "Anytown, US 00000" pattern.

### Verification and Testing

* Ran simulation with configuration values: population_size = 20_000, us_population_size = 20_000
* Ran post-processing with `--public-sample`
* Did manual V&V of the results: https://github.com/ihmeuw/vivarium_research_prl/pull/39