### PR TITLE
Feature/categorize strings

### DIFF
--- a/src/vivarium_census_prl_synth_pop/components/observers.py
+++ b/src/vivarium_census_prl_synth_pop/components/observers.py
@@ -171,9 +171,7 @@ class BaseObserver(ABC):
             self.responses.index.names = ["simulant_id"]
             filepath = output_dir / f"{self.name}_{self.seed}.{self.file_extension}"
             if "hdf" == self.file_extension:
-                self.responses.to_hdf(
-                    filepath, "data", format="table", complib="bzip2", complevel=9
-                )
+                utilities.write_hdf(self.responses, filepath)
             else:
                 self.responses.to_csv(filepath)
 

--- a/src/vivarium_census_prl_synth_pop/components/observers.py
+++ b/src/vivarium_census_prl_synth_pop/components/observers.py
@@ -51,7 +51,7 @@ class BaseObserver(ABC):
         # todo: add necessary guardian address columns
     ]
 
-    configuration_defaults = {"observer": {"file_extension": "csv.bz2"}}
+    configuration_defaults = {"observer": {"file_extension": "hdf"}}
 
     def __init__(self):
         self.configuration_defaults = self._get_configuration_defaults()
@@ -169,11 +169,9 @@ class BaseObserver(ABC):
             logger.info(f"No results to write ({self.name})")
         else:
             self.responses.index.names = ["simulant_id"]
-            filepath = output_dir / f"{self.name}_{self.seed}.{self.file_extension}"
-            if "hdf" == self.file_extension:
-                utilities.write_hdf(self.responses, filepath)
-            else:
-                self.responses.to_csv(filepath)
+            utilities.write_to_disk(
+                self.responses, output_dir / f"{self.name}_{self.seed}.{self.file_extension}"
+            )
 
     ##################
     # Helper methods #

--- a/src/vivarium_census_prl_synth_pop/constants/metadata.py
+++ b/src/vivarium_census_prl_synth_pop/constants/metadata.py
@@ -274,4 +274,4 @@ PRIORITY_MAP = {
     "immigration.on_time_step": 7,
 }
 
-SUPPORTED_EXTENSIONS = ["hdf", "csv.bz2"]
+SUPPORTED_EXTENSIONS = ["hdf"]

--- a/src/vivarium_census_prl_synth_pop/model_specifications/model_spec.yaml
+++ b/src/vivarium_census_prl_synth_pop/model_specifications/model_spec.yaml
@@ -46,19 +46,19 @@ configuration:
         population_size: 1_000_000
     # us_population_size: 250_000  # Override the default US population size
 
-    household_survey_observer_acs:
-        file_extension: "hdf"
-    household_survey_observer_cps:
-        file_extension: "hdf"
-    decennial_census_observer:
-        file_extension: "hdf"
-    wic_observer:
-        file_extension: "hdf"
-    social_security_observer:
-        file_extension: "hdf"
-    tax_w2_observer:
-        file_extension: "hdf"
-    tax_dependents_observer:
-        file_extension: "hdf"
-    tax_1040_observer:
-        file_extension: "hdf"
+#    household_survey_observer_acs:
+#        file_extension: "hdf"
+#    household_survey_observer_cps:
+#        file_extension: "hdf"
+#    decennial_census_observer:
+#        file_extension: "hdf"
+#    wic_observer:
+#        file_extension: "hdf"
+#    social_security_observer:
+#        file_extension: "hdf"
+#    tax_w2_observer:
+#        file_extension: "hdf"
+#    tax_dependents_observer:
+#        file_extension: "hdf"
+#    tax_1040_observer:
+#        file_extension: "hdf"

--- a/src/vivarium_census_prl_synth_pop/tools/make_results.py
+++ b/src/vivarium_census_prl_synth_pop/tools/make_results.py
@@ -26,6 +26,7 @@ from vivarium_census_prl_synth_pop.results_processing.ssn_and_itin import (
 from vivarium_census_prl_synth_pop.utilities import (
     build_output_dir,
     get_all_simulation_seeds,
+    write_hdf,
 )
 
 FINAL_OBSERVERS = {
@@ -334,13 +335,7 @@ def perform_post_processing(
         logger.info(f"Writing final results for {observer}.")
         obs_dir = build_output_dir(final_output_dir, subdir=observer)
         seed_ext = f"_{seed}" if seed != "" else ""
-        obs_data.to_hdf(
-            obs_dir / f"{observer}{seed_ext}.hdf",
-            "data",
-            format="table",
-            complib="bzip2",
-            complevel=9,
-        )
+        write_hdf(obs_data, obs_dir / f"{observer}{seed_ext}.hdf")
 
 
 def load_data(raw_results_dir: Path, seed: str) -> Dict[str, pd.DataFrame]:

--- a/src/vivarium_census_prl_synth_pop/tools/make_results.py
+++ b/src/vivarium_census_prl_synth_pop/tools/make_results.py
@@ -26,7 +26,7 @@ from vivarium_census_prl_synth_pop.results_processing.ssn_and_itin import (
 from vivarium_census_prl_synth_pop.utilities import (
     build_output_dir,
     get_all_simulation_seeds,
-    write_hdf,
+    write_to_disk,
 )
 
 FINAL_OBSERVERS = {
@@ -335,7 +335,7 @@ def perform_post_processing(
         logger.info(f"Writing final results for {observer}.")
         obs_dir = build_output_dir(final_output_dir, subdir=observer)
         seed_ext = f"_{seed}" if seed != "" else ""
-        write_hdf(obs_data, obs_dir / f"{observer}{seed_ext}.hdf")
+        write_to_disk(obs_data.copy(), obs_dir / f"{observer}{seed_ext}.hdf")
 
 
 def load_data(raw_results_dir: Path, seed: str) -> Dict[str, pd.DataFrame]:

--- a/src/vivarium_census_prl_synth_pop/utilities.py
+++ b/src/vivarium_census_prl_synth_pop/utilities.py
@@ -461,7 +461,7 @@ def get_all_simulation_seeds(raw_output_dir: Path) -> List[str]:
     return sorted(list(set([x.name.split(".")[0].split("_")[-1] for x in raw_results_files])))
 
 
-def write_hdf(data: pd.DataFrame, path: Path):
+def write_to_disk(data: pd.DataFrame, path: Path):
     """
     Converts all object dtypes to categorical and then writes to an hdf file
     with bzip2 compression.
@@ -477,4 +477,10 @@ def write_hdf(data: pd.DataFrame, path: Path):
     for column in data.columns:
         if data[column].dtype.name == "object":
             data[column] = data[column].astype("category")
-    data.to_hdf(path, "data", format="table", complib="bzip2", complevel=9)
+    if ".hdf" == path.suffix:
+        data.to_hdf(path, "data", format="table", complib="bzip2", complevel=9)
+    else:
+        raise ValueError(
+            f"Supported extensions are {metadata.SUPPORTED_EXTENSIONS}. "
+            f"{path.suffix[1:]} was provided."
+        )

--- a/src/vivarium_census_prl_synth_pop/utilities.py
+++ b/src/vivarium_census_prl_synth_pop/utilities.py
@@ -459,3 +459,22 @@ def get_all_simulation_seeds(raw_output_dir: Path) -> List[str]:
     )
 
     return sorted(list(set([x.name.split(".")[0].split("_")[-1] for x in raw_results_files])))
+
+
+def write_hdf(data: pd.DataFrame, path: Path):
+    """
+    Converts all object dtypes to categorical and then writes to an hdf file
+    with bzip2 compression.
+    Parameters
+    ----------
+    data
+    path
+
+    Returns
+    -------
+
+    """
+    for column in data.columns:
+        if data[column].dtype.name == "object":
+            data[column] = data[column].astype("category")
+    data.to_hdf(path, "data", format="table", complib="bzip2", complevel=9)

--- a/tests/components/observers/test_household_survey_observers.py
+++ b/tests/components/observers/test_household_survey_observers.py
@@ -8,7 +8,7 @@ from vivarium_census_prl_synth_pop.constants import paths
 # TODO: Broader test coverage
 
 
-@pytest.fixture(params=["hdf", "csv.bz2"])
+@pytest.fixture(params=["hdf"])
 def observer(mocker, tmp_path, request):
     """Generate post-setup observer with mocked methods to patch as necessary"""
     observer = HouseholdSurveyObserver("acs")


### PR DESCRIPTION
## Convert string columns to categorical columns
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: implementation
- *JIRA issue*: [MIC-3984](https://jira.ihme.washington.edu/browse/MIC-3984)
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
Converts all string columns to categorical to save both space and read time.
Removes support for csvs 

### Verification and Testing
Ran automated tests.
Ran a parallel simulation, made results both for a single seed (non-parallel) and in parallel using jobmon, and verified that results can be read by pseudopeople. 

