### PR TITLE
Add data_columns to to_hdf calls

### DIFF
--- a/src/vivarium_census_prl_synth_pop/constants/data_values.py
+++ b/src/vivarium_census_prl_synth_pop/constants/data_values.py
@@ -142,3 +142,7 @@ class Taxes(NamedTuple):
     PERCENT_W2_RECEIVED = 0.9465
     PERCENT_1099_RECEIVED = 0.0535
     PROBABILITY_OF_JOINT_FILER = 0.95
+
+
+# Needed to allow HDFs to be filtered on these columns
+DATA_COLUMNS = ["year", "event_date", "survey_date", "tax_year"]

--- a/src/vivarium_census_prl_synth_pop/utilities.py
+++ b/src/vivarium_census_prl_synth_pop/utilities.py
@@ -14,7 +14,7 @@ from vivarium.framework.lookup import LookupTable
 from vivarium.framework.randomness import Array, RandomnessStream, get_hash, random
 from vivarium.framework.values import Pipeline
 
-from vivarium_census_prl_synth_pop.constants import metadata, paths
+from vivarium_census_prl_synth_pop.constants import data_values, metadata, paths
 
 SeededDistribution = Tuple[str, stats.rv_continuous]
 
@@ -473,7 +473,14 @@ def write_to_disk(data: pd.DataFrame, path: Path):
         if data[column].dtype.name == "object":
             data[column] = data[column].astype("category")
     if ".hdf" == path.suffix:
-        data.to_hdf(path, "data", format="table", complib="bzip2", complevel=9)
+        data.to_hdf(
+            path,
+            "data",
+            format="table",
+            complib="bzip2",
+            complevel=9,
+            data_columns=data_values.DATA_COLUMNS,
+        )
     elif ".parquet" == path.suffix:
         data.to_parquet(path)
     else:


### PR DESCRIPTION
## Add data_columns to to_hdf calls

### Description

- *Category*: implementation
- *JIRA issue*: [MIC-3909](https://jira.ihme.washington.edu/browse/MIC-3909)
- *Research reference*: n/a

### Changes and notes
- Adds a list of data_columns intended to be filterable with HDFStore.
- Adds that list of data_columns to the to_hdf args.

### Verification and Testing
Ran a sim with 20k and then postprocessed to make sample data.
