### PR TITLE
Include all GQ types in public sample data

### DIFF
--- a/src/vivarium_census_prl_synth_pop/tools/make_results.py
+++ b/src/vivarium_census_prl_synth_pop/tools/make_results.py
@@ -293,6 +293,17 @@ def perform_post_processing(
             .sample(frac=PUBLIC_SAMPLE_PUMA_PROPORTION, random_state=0)
         )
 
+        # In order to have all housing types in the sample data, we additionally include
+        # the (up to 6) PUMAs with group quarters in them.
+        gq_pumas = (
+            processed_results["decennial_census_observer"]
+            .pipe(lambda df: df[df["housing_type"] != "Standard"])[["state_id", "puma"]]
+            .drop_duplicates()
+        )
+        pumas_to_keep = pd.concat(
+            [pumas_to_keep, gq_pumas], ignore_index=True
+        ).drop_duplicates()
+
         # For SSA data, we keep the simulants ever observed in that geographic area.
         simulants_to_keep = []
         for observer in FINAL_OBSERVERS:


### PR DESCRIPTION
## Include all GQ types in public sample data

### Description
- *Category*: post-processing
- *JIRA issue*: none
- *Research reference*: discussed [on Slack](https://ihme.slack.com/archives/C02KUQ9LX32/p1681430506326409?thread_ts=1681427923.087059&cid=C02KUQ9LX32)

### Changes and notes

Include additional PUMAs so that all GQ types are present in the public sample.

### Verification and Testing

Ran this with the debugger, verified that it was working as expected and only the carceral GQ's PUMA had previously been selected; verified that all GQ types were in the Census of the public sample data after this change.