### PR TITLE
remove age column from wic observer

### DIFF
--- a/src/vivarium_census_prl_synth_pop/components/observers.py
+++ b/src/vivarium_census_prl_synth_pop/components/observers.py
@@ -361,7 +361,9 @@ class WICObserver(BaseObserver):
 
     @property
     def output_columns(self):
-        return self.DEFAULT_OUTPUT_COLUMNS + self.ADDITIONAL_OUTPUT_COLUMNS
+        columns = self.DEFAULT_OUTPUT_COLUMNS + self.ADDITIONAL_OUTPUT_COLUMNS
+        columns.remove("age")
+        return columns
 
     def setup(self, builder: Builder):
         super().setup(builder)

--- a/src/vivarium_census_prl_synth_pop/tools/make_results.py
+++ b/src/vivarium_census_prl_synth_pop/tools/make_results.py
@@ -109,7 +109,6 @@ FINAL_OBSERVERS = {
         "first_name",
         "middle_initial",
         "last_name",
-        "age",
         "date_of_birth",
         "street_number",
         "street_name",


### PR DESCRIPTION
## Remove age column from WIC observer
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: observers
- *JIRA issue*: [MIC-3918](https://jira.ihme.washington.edu/browse/MIC-3918)
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
RT has noted that we don't want the age column in the WIC observer. Dropped that column in the sim and in post-processing. 

### Verification and Testing
Ran small sim and post-processing
