### PR TITLE
rename output files to match pseudopeople dataset names

### DIFF
--- a/src/vivarium_census_prl_synth_pop/components/observers.py
+++ b/src/vivarium_census_prl_synth_pop/components/observers.py
@@ -176,7 +176,7 @@ class BaseObserver(ABC):
             self.responses.index.names = ["simulant_id"]
             utilities.write_to_disk(
                 self.responses,
-                output_dir / f"{self.output_name}_{self.seed}.{self.file_extension}"
+                output_dir / f"{self.output_name}_{self.seed}.{self.file_extension}",
             )
 
     ##################
@@ -236,10 +236,9 @@ class HouseholdSurveyObserver(BaseObserver):
 
     @property
     def output_name(self) -> str:
-        return {
-            "acs": metadata.DatasetNames.ACS,
-            "cps": metadata.DatasetNames.CPS
-        }[self.survey]
+        return {"acs": metadata.DatasetNames.ACS, "cps": metadata.DatasetNames.CPS}[
+            self.survey
+        ]
 
     #################
     # Setup methods #

--- a/src/vivarium_census_prl_synth_pop/components/observers.py
+++ b/src/vivarium_census_prl_synth_pop/components/observers.py
@@ -84,6 +84,11 @@ class BaseObserver(ABC):
     def output_columns(self):
         pass
 
+    @property
+    @abstractmethod
+    def output_name(self) -> str:
+        pass
+
     #################
     # Setup methods #
     #################
@@ -163,14 +168,15 @@ class BaseObserver(ABC):
 
     def on_simulation_end(self, _: Event) -> None:
         output_dir = utilities.build_output_dir(
-            self.output_dir / paths.RAW_RESULTS_DIR_NAME / self.name
+            self.output_dir / paths.RAW_RESULTS_DIR_NAME / self.output_name
         )
         if self.responses is None:
-            logger.info(f"No results to write ({self.name})")
+            logger.info(f"No results to write ({self.output_name})")
         else:
             self.responses.index.names = ["simulant_id"]
             utilities.write_to_disk(
-                self.responses, output_dir / f"{self.name}_{self.seed}.{self.file_extension}"
+                self.responses,
+                output_dir / f"{self.output_name}_{self.seed}.{self.file_extension}"
             )
 
     ##################
@@ -227,6 +233,13 @@ class HouseholdSurveyObserver(BaseObserver):
     @property
     def output_columns(self):
         return self.DEFAULT_OUTPUT_COLUMNS + self.ADDITIONAL_OUTPUT_COLUMNS
+
+    @property
+    def output_name(self) -> str:
+        return {
+            "acs": metadata.DatasetNames.ACS,
+            "cps": metadata.DatasetNames.CPS
+        }[self.survey]
 
     #################
     # Setup methods #
@@ -303,6 +316,10 @@ class DecennialCensusObserver(BaseObserver):
     def output_columns(self):
         return self.DEFAULT_OUTPUT_COLUMNS + self.ADDITIONAL_OUTPUT_COLUMNS
 
+    @property
+    def output_name(self) -> str:
+        return metadata.DatasetNames.CENSUS
+
     def setup(self, builder: Builder):
         super().setup(builder)
         self.clock = builder.time.clock()
@@ -364,6 +381,10 @@ class WICObserver(BaseObserver):
         columns = self.DEFAULT_OUTPUT_COLUMNS + self.ADDITIONAL_OUTPUT_COLUMNS
         columns.remove("age")
         return columns
+
+    @property
+    def output_name(self) -> str:
+        return metadata.DatasetNames.WIC
 
     def setup(self, builder: Builder):
         super().setup(builder)
@@ -510,6 +531,10 @@ class SocialSecurityObserver(BaseObserver):
     def output_columns(self):
         return self.OUTPUT_COLUMNS
 
+    @property
+    def output_name(self) -> str:
+        return metadata.DatasetNames.SSA
+
     def setup(self, builder: Builder):
         super().setup(builder)
         self.clock = builder.time.clock()
@@ -624,6 +649,10 @@ class TaxW2Observer(BaseObserver):
     @property
     def output_columns(self):
         return self.OUTPUT_COLUMNS
+
+    @property
+    def output_name(self) -> str:
+        return metadata.DatasetNames.TAXES_W2_1099
 
     def setup(self, builder: Builder):
         super().setup(builder)
@@ -823,6 +852,11 @@ class TaxDependentsObserver(BaseObserver):
     def output_columns(self):
         return self.OUTPUT_COLUMNS
 
+    @property
+    def output_name(self) -> str:
+        # TODO figure out where to store this once 1040 is implemented
+        return metadata.DatasetNames.TAXES_DEPENDENTS
+
     def setup(self, builder: Builder):
         super().setup(builder)
         self.clock = builder.time.clock()
@@ -949,6 +983,10 @@ class Tax1040Observer(BaseObserver):
     @property
     def output_columns(self):
         return self.OUTPUT_COLUMNS
+
+    @property
+    def output_name(self) -> str:
+        return metadata.DatasetNames.TAXES_1040
 
     def setup(self, builder: Builder):
         super().setup(builder)

--- a/src/vivarium_census_prl_synth_pop/constants/metadata.py
+++ b/src/vivarium_census_prl_synth_pop/constants/metadata.py
@@ -275,3 +275,15 @@ PRIORITY_MAP = {
 }
 
 SUPPORTED_EXTENSIONS = ["hdf", "parquet"]
+
+class DatasetNames:
+    """Container for Form names"""
+
+    ACS = "american_community_survey"
+    CENSUS = "decennial_census"
+    CPS = "current_population_survey"
+    SSA = "social_security"
+    TAXES_1040 = "taxes_1040"
+    TAXES_W2_1099 = "taxes_w2_and_1099"
+    TAXES_DEPENDENTS = "taxes_dependents"
+    WIC = "women_infants_and_children"

--- a/src/vivarium_census_prl_synth_pop/constants/metadata.py
+++ b/src/vivarium_census_prl_synth_pop/constants/metadata.py
@@ -278,7 +278,7 @@ SUPPORTED_EXTENSIONS = ["hdf", "parquet"]
 
 
 class DatasetNames:
-    """Container for Form names"""
+    """Container for Dataset names"""
 
     ACS = "american_community_survey"
     CENSUS = "decennial_census"

--- a/src/vivarium_census_prl_synth_pop/constants/metadata.py
+++ b/src/vivarium_census_prl_synth_pop/constants/metadata.py
@@ -276,6 +276,7 @@ PRIORITY_MAP = {
 
 SUPPORTED_EXTENSIONS = ["hdf", "parquet"]
 
+
 class DatasetNames:
     """Container for Form names"""
 

--- a/src/vivarium_census_prl_synth_pop/results_processing/ssn_and_itin.py
+++ b/src/vivarium_census_prl_synth_pop/results_processing/ssn_and_itin.py
@@ -5,6 +5,7 @@ import pandas as pd
 from vivarium import Artifact
 from vivarium.framework.randomness import RandomnessStream
 
+from vivarium_census_prl_synth_pop.constants import metadata
 from vivarium_census_prl_synth_pop.results_processing.formatter import (
     format_data_for_mapping,
 )
@@ -114,10 +115,10 @@ def get_ssn_map(
     all_seeds: List[str],
 ) -> Dict[str, pd.Series]:
     # Anyone in the SSN observer has SSNs by definition
-    need_ssns_ssn = obs_data["social_security_observer"][column_name]
+    need_ssns_ssn = obs_data[metadata.DatasetNames.SSA][column_name]
 
     # Simulants in W2 observer who `has_ssn` need SSNs
-    w2_data = obs_data["tax_w2_observer"][[column_name, "has_ssn", "ssn_id"]]
+    w2_data = obs_data[metadata.DatasetNames.TAXES_W2_1099][[column_name, "has_ssn", "ssn_id"]]
     need_ssns_has_ssn = w2_data.loc[w2_data["has_ssn"], column_name]
 
     # Simulants in W2 observer who are assigned as an `ssn_id` need to have SSNs

--- a/src/vivarium_census_prl_synth_pop/results_processing/ssn_and_itin.py
+++ b/src/vivarium_census_prl_synth_pop/results_processing/ssn_and_itin.py
@@ -118,7 +118,9 @@ def get_ssn_map(
     need_ssns_ssn = obs_data[metadata.DatasetNames.SSA][column_name]
 
     # Simulants in W2 observer who `has_ssn` need SSNs
-    w2_data = obs_data[metadata.DatasetNames.TAXES_W2_1099][[column_name, "has_ssn", "ssn_id"]]
+    w2_data = obs_data[metadata.DatasetNames.TAXES_W2_1099][
+        [column_name, "has_ssn", "ssn_id"]
+    ]
     need_ssns_has_ssn = w2_data.loc[w2_data["has_ssn"], column_name]
 
     # Simulants in W2 observer who are assigned as an `ssn_id` need to have SSNs

--- a/src/vivarium_census_prl_synth_pop/utilities.py
+++ b/src/vivarium_census_prl_synth_pop/utilities.py
@@ -14,7 +14,12 @@ from vivarium.framework.lookup import LookupTable
 from vivarium.framework.randomness import Array, RandomnessStream, get_hash, random
 from vivarium.framework.values import Pipeline
 
-from vivarium_census_prl_synth_pop.constants import data_keys, data_values, metadata, paths
+from vivarium_census_prl_synth_pop.constants import (
+    data_keys,
+    data_values,
+    metadata,
+    paths,
+)
 
 SeededDistribution = Tuple[str, stats.rv_continuous]
 

--- a/src/vivarium_census_prl_synth_pop/utilities.py
+++ b/src/vivarium_census_prl_synth_pop/utilities.py
@@ -14,7 +14,7 @@ from vivarium.framework.lookup import LookupTable
 from vivarium.framework.randomness import Array, RandomnessStream, get_hash, random
 from vivarium.framework.values import Pipeline
 
-from vivarium_census_prl_synth_pop.constants import data_values, metadata, paths
+from vivarium_census_prl_synth_pop.constants import data_keys, data_values, metadata, paths
 
 SeededDistribution = Tuple[str, stats.rv_continuous]
 
@@ -442,7 +442,7 @@ def randomly_sample_states_pumas(
 
 def get_state_puma_options(builder: Builder) -> pd.DataFrame:
     states_in_artifact = list(
-        builder.data.load("population.households")["state"].drop_duplicates()
+        builder.data.load(data_keys.POPULATION.HOUSEHOLDS)["state"].drop_duplicates()
     )
     state_puma_options = pd.read_csv(paths.PUMA_TO_ZIP_DATA_PATH)[
         ["state", "puma"]

--- a/tests/components/observers/test_household_survey_observers.py
+++ b/tests/components/observers/test_household_survey_observers.py
@@ -62,8 +62,8 @@ def test_on_simulation_end(observer, mocker):
     assert (
         observer.output_dir
         / paths.RAW_RESULTS_DIR_NAME
-        / observer.name
-        / f"{observer.name}_{observer.seed}.{observer.file_extension}"
+        / observer.output_name
+        / f"{observer.output_name}_{observer.seed}.{observer.file_extension}"
     ).is_file()
 
 


### PR DESCRIPTION
## Rename output files to match pseudopeople dataset names
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: bugfix
- *JIRA issue*: [MIC-4020](https://jira.ihme.washington.edu/browse/MIC-4020)
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
Rename the output files to match pseudopeople dataset names
Introduce DatasetNames constants and replace all naked string references to them.

### Verification and Testing
CI passes
Ran psimulate and make_results
