### PR TITLE
use complete state categories

### DIFF
--- a/src/vivarium_census_prl_synth_pop/results_processing/formatter.py
+++ b/src/vivarium_census_prl_synth_pop/results_processing/formatter.py
@@ -43,13 +43,17 @@ def format_ssn_id(data: pd.DataFrame) -> pd.Series:
 def get_state_abbreviation(data: pd.DataFrame) -> pd.Series:
     state_id_map = {state: state_id for state_id, state in metadata.CENSUS_STATE_IDS.items()}
     state_name_map = data["state_id"].map(state_id_map)
-    return state_name_map.map(metadata.US_STATE_ABBRV_MAP)
+    state_name_map = state_name_map.map(metadata.US_STATE_ABBRV_MAP)
+    categories = sorted(list(metadata.US_STATE_ABBRV_MAP.values()))
+    return state_name_map.astype(pd.CategoricalDtype(categories=categories))
 
 
 def get_employer_state_abbreviation(data: pd.DataFrame) -> pd.Series:
     state_id_map = {state: state_id for state_id, state in metadata.CENSUS_STATE_IDS.items()}
     state_name_map = data["employer_state_id"].map(state_id_map)
-    return state_name_map.map(metadata.US_STATE_ABBRV_MAP)
+    state_name_map = state_name_map.map(metadata.US_STATE_ABBRV_MAP)
+    categories = sorted(list(metadata.US_STATE_ABBRV_MAP.values()))
+    return state_name_map.astype(pd.CategoricalDtype(categories=categories))
 
 
 def get_household_id(data: pd.DataFrame) -> pd.Series:

--- a/src/vivarium_census_prl_synth_pop/tools/make_results.py
+++ b/src/vivarium_census_prl_synth_pop/tools/make_results.py
@@ -348,6 +348,15 @@ def perform_post_processing(
                 for address_part, address_part_value in PUBLIC_SAMPLE_ADDRESS_PARTS.items():
                     if f"{address_prefix}{address_part}" in obs_data.columns:
                         obs_data[f"{address_prefix}{address_part}"] = address_part_value
+            # Fix the state column dtypes
+            state_categories = sorted(list(metadata.US_STATE_ABBRV_MAP.values())) + [
+                PUBLIC_SAMPLE_ADDRESS_PARTS["state"]
+            ]
+            state_cols = [c for c in obs_data.columns if "state" in c]
+            for col in state_cols:
+                obs_data[col] = obs_data[col].astype(
+                    pd.CategoricalDtype(categories=state_categories)
+                )
 
         logger.info(f"Writing final {observer} results.")
         obs_dir = build_output_dir(final_output_dir, subdir=observer)


### PR DESCRIPTION
## Title: Use complete state categories

### Description
- *Category*: bugfix
- *JIRA issue*: na
- *Research reference*: na

### Changes and notes
This was found while working on MIC-4000 (column-level integration testing).
We are currently setting the state column categorical dtype categories as
whatever states exist in the dataset. This instead uses all states from
metadata regardless of whether they exist in the dataset. Further,
for the sample data, it adds that fake state "US" to the categories.

### Verification and Testing
Re-made sample data and then got pseudopeople pytests to pass
on my MIC-4000 branch.

