### PR TITLE
Feature/sbachmei/mic 4067 implement vivarium v1.1.0

### DIFF
--- a/integration_tests/test_domestic_migration.py
+++ b/integration_tests/test_domestic_migration.py
@@ -314,28 +314,23 @@ def test_addresses_during_moves(
             continue
 
         total_num_moved += mask_moved_units.sum()
-        # Check that the number of moved units that have the same details is very low
-        # NOTE: we cannot assert that all moved units have different details
-        # because they are free to move within the same state or even PUMA
-        assert (
-            (
-                before_units.loc[mask_moved_units, address_cols]
-                == after_units.loc[mask_moved_units, address_cols]
-            )
-            .all(axis=1)
-            .mean()
-        ) < 0.001  # TODO: pick a smarter number?
-        # address details do not change if address_id does not change
+
+        # Check that address details do not change if address_id does not change
         pd.testing.assert_frame_equal(
             before_units[~mask_moved_units], after_units[~mask_moved_units]
         )
 
         # Check that most movers are in a new state-PUMA combination
+        # NOTE: we cannot assert that all moved units have different details
+        # because they are free to move within the same state and PUMA. The
+        # threshold applied below is a somewhat arbitrarily-chosen small number
+        # since PUMAs are different sizes and so it is difficult to estimate
+        # the chance of a simulant moving into the same one.
         if mask_moved_units.sum() > 1:
             assert (
                 before_units.loc[mask_moved_units, [state_id_col, puma_col]]
                 == after_units.loc[mask_moved_units, [state_id_col, puma_col]]
-            ).all(axis=1).mean() < 100 * 1 / len(states_pumas)
+            ).all(axis=1).mean() < 0.01
 
     # Check that at least some units moved during the sim
     assert total_num_moved > 0

--- a/integration_tests/test_household_structure.py
+++ b/integration_tests/test_household_structure.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pandas as pd
-import pytest
 
 from vivarium_census_prl_synth_pop.constants import data_values, metadata
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ if __name__ == "__main__":
         long_description = f.read()
 
     install_requirements = [
-        "vivarium==1.0.2",
+        "vivarium>=1.1.0",
         "vivarium_public_health==0.10.22",
         "click",
         "gbd_mapping>=3.0.6, <4.0.0",

--- a/src/vivarium_census_prl_synth_pop/components/businesses.py
+++ b/src/vivarium_census_prl_synth_pop/components/businesses.py
@@ -7,7 +7,6 @@ from scipy import stats
 from vivarium.framework.engine import Builder
 from vivarium.framework.event import Event
 from vivarium.framework.population import SimulantData
-from vivarium.framework.randomness import RandomnessStream
 from vivarium.framework.time import get_time_stamp
 from vivarium_public_health import utilities
 
@@ -63,9 +62,8 @@ class Businesses:
         self.randomness = builder.randomness.get_stream(self.name)
         # create a randomness stream for business moves; use a common random number
         # for identical business move behavior across parallel sims
-        self.business_moves_randomness = RandomnessStream(
-            key="business_moves", clock=builder.time.clock(), seed=12345
-        )
+        self.business_moves_randomness = builder.randomness.get_stream("business_moves")
+        self.business_moves_randomness.seed = 12345
         self.state_puma_options = get_state_puma_options(builder)
         self.household_details = builder.value.get_value("household_details")
         self.employer_address_id_count = 0

--- a/src/vivarium_census_prl_synth_pop/components/businesses.py
+++ b/src/vivarium_census_prl_synth_pop/components/businesses.py
@@ -63,7 +63,7 @@ class Businesses:
         # create a randomness stream for business moves; use a common random number
         # for identical business move behavior across parallel sims
         self.business_moves_randomness = builder.randomness.get_stream("business_moves")
-        self.business_moves_randomness.seed = 12345
+        self.business_moves_randomness.seed = 12345  # overwrite seed with crn
         self.state_puma_options = get_state_puma_options(builder)
         self.household_details = builder.value.get_value("household_details")
         self.employer_address_id_count = 0
@@ -276,7 +276,7 @@ class Businesses:
         n_businesses = int(n_need_employers / data_values.EXPECTED_EMPLOYEES_PER_BUSINESS)
         random_employers_ids = np.arange(2, n_businesses + 2)
         employee_count_propensity = self.business_moves_randomness.get_draw(
-            random_employers_ids
+            pd.Index(random_employers_ids)
         )
         employee_counts = stats.lognorm.ppf(
             q=employee_count_propensity, s=1, scale=np.exp(4)

--- a/src/vivarium_census_prl_synth_pop/components/population.py
+++ b/src/vivarium_census_prl_synth_pop/components/population.py
@@ -40,9 +40,7 @@ class Population:
     def setup(self, builder: Builder):
         self.config = builder.configuration.population
         self.seed = builder.configuration.randomness.random_seed
-        self.randomness = builder.randomness.get_stream(
-            "household_sampling", initializes_crn_attributes=True
-        )
+        self.randomness = builder.randomness.get_stream("household_sampling")
         self.proportion_with_ssn = builder.lookup.build_table(
             data=data_values.PROPORTION_INITIALIZATION_WITH_SSN
         )

--- a/src/vivarium_census_prl_synth_pop/components/population.py
+++ b/src/vivarium_census_prl_synth_pop/components/population.py
@@ -41,7 +41,7 @@ class Population:
         self.config = builder.configuration.population
         self.seed = builder.configuration.randomness.random_seed
         self.randomness = builder.randomness.get_stream(
-            "household_sampling", for_initialization=True
+            "household_sampling", initializes_crn_attributes=True
         )
         self.proportion_with_ssn = builder.lookup.build_table(
             data=data_values.PROPORTION_INITIALIZATION_WITH_SSN

--- a/src/vivarium_census_prl_synth_pop/components/population.py
+++ b/src/vivarium_census_prl_synth_pop/components/population.py
@@ -71,7 +71,6 @@ class Population:
             "guardian_2",
             "born_in_us",
         ]
-        self.register_simulants = builder.randomness.register_simulants
         self.population_view = builder.population.get_view(
             self.columns_created + ["state_id_for_lookup"]
         )

--- a/src/vivarium_census_prl_synth_pop/model_specifications/model_spec.yaml
+++ b/src/vivarium_census_prl_synth_pop/model_specifications/model_spec.yaml
@@ -30,7 +30,7 @@ configuration:
         extrapolate: True
     randomness:
         map_size: 1_000_000
-        key_columns: ['entrance_time', 'age']
+        key_columns: []  # We do not utilize crn
         random_seed: 0
     time:
         start:

--- a/src/vivarium_census_prl_synth_pop/model_specifications/sample_data_model_spec.yaml
+++ b/src/vivarium_census_prl_synth_pop/model_specifications/sample_data_model_spec.yaml
@@ -30,7 +30,7 @@ configuration:
         extrapolate: True
     randomness:
         map_size: 1_000_000
-        key_columns: ['entrance_time', 'age']
+        key_columns: []  # We do not utilize crn
         random_seed: 0
     time:
         start:

--- a/src/vivarium_census_prl_synth_pop/results_processing/names.py
+++ b/src/vivarium_census_prl_synth_pop/results_processing/names.py
@@ -266,7 +266,7 @@ def get_employer_name_map(
     """
     column_name: Name of column that is being mapped - employer_id
     obs_data: Raw results from observer outputs
-    randomness: randomness stream used to assign names
+    artifact: Artifact used to load the business names
 
     Returns: Dict with key "employer_name" and value is series of names.
     Note:  For clarity on variable names, business names refers to the generated

--- a/src/vivarium_census_prl_synth_pop/tools/make_results.py
+++ b/src/vivarium_census_prl_synth_pop/tools/make_results.py
@@ -7,6 +7,7 @@ import pyarrow.parquet as pq
 from loguru import logger
 from vivarium import Artifact
 from vivarium.framework.randomness import RandomnessStream
+from vivarium.framework.randomness.index_map import IndexMap
 
 from vivarium_census_prl_synth_pop.constants import data_keys, metadata, paths
 from vivarium_census_prl_synth_pop.constants.metadata import SUPPORTED_EXTENSIONS
@@ -274,6 +275,7 @@ def perform_post_processing(
         key="post_processing_maps",
         clock=lambda: pd.Timestamp("2020-04-01"),
         seed=0,
+        index_map=IndexMap(),
     )
 
     processed_results = load_data(raw_output_dir, seed)

--- a/src/vivarium_census_prl_synth_pop/tools/make_results.py
+++ b/src/vivarium_census_prl_synth_pop/tools/make_results.py
@@ -271,11 +271,14 @@ def perform_post_processing(
     public_sample: bool,
 ) -> None:
     # Create RandomnessStream for post-processing
+    # NOTE: We use an IndexMap size of 15 million because that is a bit more than
+    # the length of all business_ids in the simulation which is expected to be
+    # the largest set of things to be mapped.
     randomness = RandomnessStream(
         key="post_processing_maps",
         clock=lambda: pd.Timestamp("2020-04-01"),
         seed=0,
-        index_map=IndexMap(),
+        index_map=IndexMap(size=15_000_000),
     )
 
     processed_results = load_data(raw_output_dir, seed)

--- a/src/vivarium_census_prl_synth_pop/utilities.py
+++ b/src/vivarium_census_prl_synth_pop/utilities.py
@@ -197,9 +197,8 @@ def vectorized_choice(
         # additional_key = f"{additional_key}_{random_seed}"
         # probs = random(str(additional_key), index)
         random_state = np.random.RandomState(seed=get_hash(f"{additional_key}_{random_seed}"))
-        sample_size = index.max() + 1
-        raw_draws = random_state.random_sample(sample_size)
-        probs = pd.Series(raw_draws[index], index=index)
+        raw_draws = random_state.random_sample(len(index))
+        probs = pd.Series(raw_draws, index=index)
     else:
         probs = randomness_stream.get_draw(index, additional_key=additional_key)
 

--- a/src/vivarium_census_prl_synth_pop/utilities.py
+++ b/src/vivarium_census_prl_synth_pop/utilities.py
@@ -194,8 +194,6 @@ def vectorized_choice(
     index = pd.Index(np.arange(n_to_choose))
     if randomness_stream is None:
         # Generate an additional_key on-the-fly and use that in randomness.random
-        # additional_key = f"{additional_key}_{random_seed}"
-        # probs = random(str(additional_key), index)
         random_state = np.random.RandomState(seed=get_hash(f"{additional_key}_{random_seed}"))
         raw_draws = random_state.random_sample(len(index))
         probs = pd.Series(raw_draws, index=index)

--- a/tests/test_synthetic_pii.py
+++ b/tests/test_synthetic_pii.py
@@ -5,6 +5,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from vivarium.framework.randomness import RandomnessStream
+from vivarium.framework.randomness.index_map import IndexMap
 
 from vivarium_census_prl_synth_pop.constants import data_keys, data_values
 from vivarium_census_prl_synth_pop.results_processing.addresses import (
@@ -26,7 +27,7 @@ from vivarium_census_prl_synth_pop.results_processing.ssn_and_itin import (
 key = "test_synthetic_data_generation"
 clock = lambda: pd.Timestamp("2020-09-01")
 seed = 0
-randomness = RandomnessStream(key=key, clock=clock, seed=seed)
+randomness = RandomnessStream(key=key, clock=clock, seed=seed, index_map=IndexMap())
 
 
 def get_draw(self, index, additional_key=None) -> pd.Series:


### PR DESCRIPTION
## Title: Implement vivarium v1.1.0

### Description
- *Category*: other
- *JIRA issue*: [MIC-4067](https://jira.ihme.washington.edu/browse/MIC-4067)
- *Research reference*: na

### Changes and notes
Primary changes:
- We lost randomness::random and so I had to implement that functionality
  in `vectorized_choice`
- No more randomness Array either.
- Instead of side-instantiating a randomness stream for business moves, we
  are now generating one properly through builder. To maintain a crn strictly
  for business move dynamics, we overwrite the seed in-code.
- We started getting errors because simulants were not being registered to the
  randomness stream which resulted in the IndexMap not properly updating. We
  chose to solve this be removing the key_columns from the config files (and just
  deleting the unused self.register_updates). This works because if key_columns
  is empty the IndexMap gets instantiated w/ `_use_crn == False` which in turn
  has the IndexMap getter return index.values rather than a map. It's confusing.

### Verification and Testing
pytests pass.

I also confirmed that the manual overwrite of random_seed is working by
running two simulations in interactive mode with different model-spec seeds
and checking that the business details are identical.

