### PR TITLE
remove household_id col from ssa datasets

### DIFF
--- a/src/vivarium_census_prl_synth_pop/components/observers.py
+++ b/src/vivarium_census_prl_synth_pop/components/observers.py
@@ -494,7 +494,6 @@ class SocialSecurityObserver(BaseObserver):
 
     ADDITIONAL_INPUT_COLUMNS = ["tracked", "alive", "entrance_time", "exit_time", "has_ssn"]
     OUTPUT_COLUMNS = [
-        "household_id",
         "first_name_id",
         "middle_name_id",
         "last_name_id",

--- a/src/vivarium_census_prl_synth_pop/tools/make_results.py
+++ b/src/vivarium_census_prl_synth_pop/tools/make_results.py
@@ -132,7 +132,6 @@ FINAL_OBSERVERS = {
     },
     metadata.DatasetNames.SSA: {
         "simulant_id",
-        "household_id",
         "first_name",
         "middle_initial",
         "last_name",


### PR DESCRIPTION
## Title: Do not include `household_id` in SSA dataset

### Description
- *Category*: other
- *JIRA issue*: na
- *Research reference*: na

### Changes and notes

household ID doesn't make sense in SSA.

### Verification and Testing
ran sample data and confirmed household_id exists in all datasets
except for SSA
