### PR TITLE
Bugfix/empty series dtype change

### DIFF
--- a/src/vivarium_census_prl_synth_pop/utilities.py
+++ b/src/vivarium_census_prl_synth_pop/utilities.py
@@ -521,32 +521,32 @@ def copy_from_household_member(
             households = pop.groupby("household_id").apply(lambda df_g: list(df_g.index))
         # Drop GQ and households with single member
         households = households[households.apply(len) > 1]
-        if households.empty:
+        if not households.empty:
+            households = households.loc[
+                households.index.difference(data_values.GQ_HOUSING_TYPE_MAP.keys())
+            ]
+            simulants_and_household_members = pop["household_id"].map(households).dropna()
+            # Note the following call results in a dataframe if 'simulants_and_household_members' is empty
+            # and is handled above
+            simulant_ids_to_copy = simulants_and_household_members.reset_index().apply(
+                lambda row: [
+                    household
+                    for household in row.loc["household_id"]
+                    if household != row.loc["index"]
+                ],
+                axis=1,
+            )
+            simulant_ids_to_copy.index = simulants_and_household_members.index
+            seed = get_hash(randomness_stream._key(additional_key=col))
+            copy_ids = simulant_ids_to_copy.map(np.random.default_rng(seed).choice)
+            if col == "has_ssn":
+                pop.loc[copy_ids.index, copy_cols[col]] = copy_ids
+            else:
+                pop.loc[copy_ids.index, copy_cols[col]] = copy_ids.map(
+                    pop.loc[copy_ids.index, col]
+                )
+        else:
             # Save as object type - current pandas defaults to dtype float with future warning
             pop[copy_cols[col]] = pd.Series(np.nan, index=pop.index, dtype=object)
-            continue
-        households = households.loc[
-            households.index.difference(data_values.GQ_HOUSING_TYPE_MAP.keys())
-        ]
-        simulants_and_household_members = pop["household_id"].map(households).dropna()
-        # Note the following call results in a dataframe if 'simulants_and_household_members' is empty
-        # and is handled above
-        simulant_ids_to_copy = simulants_and_household_members.reset_index().apply(
-            lambda row: [
-                household
-                for household in row.loc["household_id"]
-                if household != row.loc["index"]
-            ],
-            axis=1,
-        )  
-        simulant_ids_to_copy.index = simulants_and_household_members.index
-        seed = get_hash(randomness_stream._key(additional_key=col))
-        copy_ids = simulant_ids_to_copy.map(np.random.default_rng(seed).choice)
-        if col == "has_ssn":
-            pop.loc[copy_ids.index, copy_cols[col]] = copy_ids
-        else:
-            pop.loc[copy_ids.index, copy_cols[col]] = copy_ids.map(
-                pop.loc[copy_ids.index, col]
-            )
 
     return pop

--- a/src/vivarium_census_prl_synth_pop/utilities.py
+++ b/src/vivarium_census_prl_synth_pop/utilities.py
@@ -524,7 +524,7 @@ def copy_from_household_member(
         if households.empty:
             # Save as object type - current pandas defaults to dtype float with future warning
             pop[copy_cols[col]] = pd.Series(np.nan, index=pop.index, dtype=object)
-            return pop
+            continue
         households = households.loc[
             households.index.difference(data_values.GQ_HOUSING_TYPE_MAP.keys())
         ]

--- a/src/vivarium_census_prl_synth_pop/utilities.py
+++ b/src/vivarium_census_prl_synth_pop/utilities.py
@@ -521,10 +521,10 @@ def copy_from_household_member(
             households = pop.groupby("household_id").apply(lambda df_g: list(df_g.index))
         # Drop GQ and households with single member
         households = households[households.apply(len) > 1]
+        households = households.loc[
+            households.index.difference(data_values.GQ_HOUSING_TYPE_MAP.keys())
+        ]
         if not households.empty:
-            households = households.loc[
-                households.index.difference(data_values.GQ_HOUSING_TYPE_MAP.keys())
-            ]
             simulants_and_household_members = pop["household_id"].map(households).dropna()
             # Note the following call results in a dataframe if 'simulants_and_household_members' is empty
             # and is handled above

--- a/src/vivarium_census_prl_synth_pop/utilities.py
+++ b/src/vivarium_census_prl_synth_pop/utilities.py
@@ -521,10 +521,16 @@ def copy_from_household_member(
             households = pop.groupby("household_id").apply(lambda df_g: list(df_g.index))
         # Drop GQ and households with single member
         households = households[households.apply(len) > 1]
+        if households.empty:
+            # Save as object type - current pandas defaults to dtype float with future warning
+            pop[copy_cols[col]] = pd.Series(np.nan, index=pop.index, dtype=object)
+            return pop
         households = households.loc[
             households.index.difference(data_values.GQ_HOUSING_TYPE_MAP.keys())
         ]
         simulants_and_household_members = pop["household_id"].map(households).dropna()
+        # Note the following call results in a dataframe if 'simulants_and_household_members' is empty
+        # and is handled above
         simulant_ids_to_copy = simulants_and_household_members.reset_index().apply(
             lambda row: [
                 household
@@ -532,7 +538,7 @@ def copy_from_household_member(
                 if household != row.loc["index"]
             ],
             axis=1,
-        )
+        )  
         simulant_ids_to_copy.index = simulants_and_household_members.index
         seed = get_hash(randomness_stream._key(additional_key=col))
         copy_ids = simulant_ids_to_copy.map(np.random.default_rng(seed).choice)


### PR DESCRIPTION
## Fix bug with empty series cause object to be dataframe instead of index.

### Fixes bug that where applying a lambda function on an empty series returns the dataframe instead of a series.
- *Category*: Bugfix
- *JIRA issue*: [MIC-4132](https://jira.ihme.washington.edu/browse/MIC-4132)
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
-handles empty dataframe in utils function

### Verification and Testing
Successfully ran simulation.

