### PR TITLE
Increase randomness map size for businesses

### DIFF
--- a/src/vivarium_census_prl_synth_pop/model_specifications/model_spec.yaml
+++ b/src/vivarium_census_prl_synth_pop/model_specifications/model_spec.yaml
@@ -29,7 +29,8 @@ configuration:
         order: 0
         extrapolate: True
     randomness:
-        map_size: 1_000_000
+        # There are 1.75 million businesses for the full US population size
+        map_size: 2_000_000
         key_columns: []  # We do not utilize crn
         random_seed: 0
     time:


### PR DESCRIPTION
## Increase randomness map size for businesses

### Description
- *Category*: bugfix
- *JIRA issue*: none
- *Research reference*: none

### Changes and notes

It was not possible to run the simulation for a small simulated population (e.g. 20k) in a single shard without also decreasing the full population size (`us_population_size`). This was caused by the recent upgrade to Vivarium 1.1 and specifically that the business RandomnessStream now has the same map size as our simulation overall.

Here, I've increased the map_size in the config to be larger than the number of businesses generated by a full US population. This doesn't seem like a super elegant solution, but I did not see a way to get the old behavior (generating an map of any required size on the fly) after [this line of code](https://github.com/ihmeuw/vivarium/commit/986b19f24d03d10c608e3fd03d40155daaab3895#diff-323208dfd3a46a075d2b3bda501400291392beebc159c2b953888c05a6769963L312) went away and was not replaced.

### Verification and Testing

Ran integration tests with a population size of 20k.