### PR TITLE
set SSA event date to dob for all simulants

### DIFF
--- a/src/vivarium_census_prl_synth_pop/components/observers.py
+++ b/src/vivarium_census_prl_synth_pop/components/observers.py
@@ -563,11 +563,7 @@ class SocialSecurityObserver(BaseObserver):
 
         df_creation = pop.copy()
         df_creation["event_type"] = "creation"
-        df_creation["event_date"] = np.where(
-            pop["entrance_time"] <= self.start_time,
-            pop["date_of_birth"],
-            pop["entrance_time"],
-        )
+        df_creation["event_date"] = pop["date_of_birth"]
 
         df_death = pop[pop["alive"] == "dead"]
         df_death["event_type"] = "death"


### PR DESCRIPTION
## Set SSA event date as DOB
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: bugfix
- *JIRA issue*: [MIC-3988](https://jira.ihme.washington.edu/browse/MIC-3988)
- *Research reference*: <!--Link to research documentation for code -->na

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
The observer uses date of birth as the SSA event date for all simulants
except for those that were born before the sim start (in which case it
uses the start date as SSA event date). This fixes that so it just
uses date of birth for everyone.

### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->
Ran a test sim to confirm that no birth dates occur after creation event dates.
All pytests pass.

