### PR TITLE
Feature/sbachmei/mic 4200 relationship to reference person columns

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+**1.4.0 - 07/25/23**
+
+ - Change "relation_to_reference_person" column to "relationship_to_reference_person"
+ - Add "relationship_to_reference_person" column to ACS dataset output
+
 **1.3.1 - 07/21/23**
 
  - Add more status logs in post-processing

--- a/integration_tests/test_domestic_migration.py
+++ b/integration_tests/test_domestic_migration.py
@@ -30,7 +30,7 @@ def test_individuals_move_into_new_households(simulants_on_adjacent_timesteps):
         assert movers_into_new_households.any()
 
         assert (
-            after[movers_into_new_households]["relation_to_reference_person"]
+            after[movers_into_new_households]["relationship_to_reference_person"]
             # Handling the non-reference-person movers described above.
             .isin(["Reference person", "Other nonrelative"]).all()
         )
@@ -38,7 +38,7 @@ def test_individuals_move_into_new_households(simulants_on_adjacent_timesteps):
         # These are the true new-household movers, as that term is used in the
         # migration component: the movers who establish a new household.
         new_household_movers = movers_into_new_households & (
-            after["relation_to_reference_person"] == "Reference person"
+            after["relationship_to_reference_person"] == "Reference person"
         )
         assert new_household_movers.any()
         # There is exactly one new-household mover for each new household.
@@ -73,14 +73,14 @@ def test_individuals_move_into_group_quarters(simulants_on_adjacent_timesteps):
         assert (before[gq_movers]["household_details.housing_type"] == "Standard").any()
         assert after[gq_movers]["household_id"].isin(data_values.GQ_HOUSING_TYPE_MAP).all()
         assert (
-            after[gq_movers]["relation_to_reference_person"]
+            after[gq_movers]["relationship_to_reference_person"]
             .isin(["Institutionalized GQ pop", "Noninstitutionalized GQ pop"])
             .all()
         )
 
 
 def get_households_with_stable_reference_person(after, before):
-    reference_persons = before["relation_to_reference_person"] == "Reference person"
+    reference_persons = before["relationship_to_reference_person"] == "Reference person"
     movers = before["household_id"] != after["household_id"]
     deaths = before["alive"] != after["alive"]
     emigrants = before["in_united_states"] & ~after["in_united_states"]
@@ -114,7 +114,7 @@ def test_individual_movers_have_correct_relationship(simulants_on_adjacent_times
         )
         assert (
             after.loc[
-                mover_to_household_with_reference_person, "relation_to_reference_person"
+                mover_to_household_with_reference_person, "relationship_to_reference_person"
             ]
             == "Other nonrelative"
         ).all()
@@ -124,7 +124,8 @@ def test_individual_movers_have_correct_relationship(simulants_on_adjacent_times
         )
         assert (
             after.loc[
-                mover_to_household_without_reference_person, "relation_to_reference_person"
+                mover_to_household_without_reference_person,
+                "relationship_to_reference_person",
             ].isin(["Other nonrelative", "Reference person", "Roommate"])
         ).all()
 
@@ -142,8 +143,8 @@ def test_households_move(simulants_on_adjacent_timesteps):
         )
         movers_with_reference_person = household_movers & in_household_with_reference_person
         assert (
-            before[movers_with_reference_person]["relation_to_reference_person"]
-            == after[movers_with_reference_person]["relation_to_reference_person"]
+            before[movers_with_reference_person]["relationship_to_reference_person"]
+            == after[movers_with_reference_person]["relationship_to_reference_person"]
         ).all()
         assert (
             before[movers_with_reference_person]["household_details.housing_type"]

--- a/integration_tests/test_emigration.py
+++ b/integration_tests/test_emigration.py
@@ -26,8 +26,8 @@ def test_there_is_emigration(simulants_on_adjacent_timesteps):
         == emigrants["household_details.housing_type_after"]
     ).all()
     assert (
-        emigrants["relation_to_reference_person_before"]
-        == emigrants["relation_to_reference_person_after"]
+        emigrants["relationship_to_reference_person_before"]
+        == emigrants["relationship_to_reference_person_after"]
     ).all()
 
     # VERY conservative upper bound on how often this should be occurring, as a proportion
@@ -56,7 +56,7 @@ def test_non_gq_individuals_emigrate(simulants_on_adjacent_timesteps):
     )
 
     emigrants = all_simulant_links[all_non_gq_emigration_status]
-    assert (emigrants["relation_to_reference_person_before"] != "Reference person").all()
+    assert (emigrants["relationship_to_reference_person_before"] != "Reference person").all()
 
     assert 0 < all_non_gq_emigration_status.mean() < 0.1
 

--- a/integration_tests/test_group_quarters.py
+++ b/integration_tests/test_group_quarters.py
@@ -23,13 +23,13 @@ def test_gq_relationship_column(tracked_live_populations):
         # All people in institutional GQ have the correct "relation to household head"
         assert (
             (pop["household_id"].isin(data_values.INSTITUTIONAL_GROUP_QUARTER_IDS.values()))
-            == (pop["relation_to_reference_person"] == "Institutionalized GQ pop")
+            == (pop["relationship_to_reference_person"] == "Institutionalized GQ pop")
         ).all()
 
     # All people in non-institutional GQ have the correct "relation to household head"
     assert (
         (pop.household_id.isin(data_values.NONINSTITUTIONAL_GROUP_QUARTER_IDS.values()))
-        == (pop["relation_to_reference_person"] == "Noninstitutionalized GQ pop")
+        == (pop["relationship_to_reference_person"] == "Noninstitutionalized GQ pop")
     ).all()
 
 
@@ -53,7 +53,7 @@ def test_gq_address_columns(tracked_live_populations, time_step):
                 data_values.INSTITUTIONAL_GROUP_QUARTER_IDS.keys()
             )
         )
-        == (pop["relation_to_reference_person"] == "Institutionalized GQ pop")
+        == (pop["relationship_to_reference_person"] == "Institutionalized GQ pop")
     ).all()
 
     # All people in non-institutional GQ have a correct housing type
@@ -63,14 +63,14 @@ def test_gq_address_columns(tracked_live_populations, time_step):
                 data_values.NONINSTITUTIONAL_GROUP_QUARTER_IDS.keys()
             )
         )
-        == (pop["relation_to_reference_person"] == "Noninstitutionalized GQ pop")
+        == (pop["relationship_to_reference_person"] == "Noninstitutionalized GQ pop")
     ).all()
 
     # All non-GQ people have standard housing type
     assert (
         (pop["household_details.housing_type"] == "Standard")
         == (
-            ~pop["relation_to_reference_person"].isin(
+            ~pop["relationship_to_reference_person"].isin(
                 ["Institutionalized GQ pop", "Noninstitutionalized GQ pop"]
             )
         )

--- a/integration_tests/test_household_structure.py
+++ b/integration_tests/test_household_structure.py
@@ -17,7 +17,7 @@ def test_housing_type_is_categorical(tracked_live_populations):
 
 def test_relationship_is_categorical(tracked_live_populations):
     for pop in tracked_live_populations:
-        relationship = pop["relation_to_reference_person"]
+        relationship = pop["relationship_to_reference_person"]
 
         # Assert the dtype is correct and that there are no NaNs
         assert relationship.dtype == pd.CategoricalDtype(categories=metadata.RELATIONSHIPS)
@@ -30,7 +30,7 @@ def test_all_households_have_reference_person(tracked_live_populations):
             ~pop["household_id"].isin(data_values.GQ_HOUSING_TYPE_MAP)
         ]["household_id"].unique()
         reference_person_household_ids = pop.loc[
-            pop["relation_to_reference_person"] == "Reference person", "household_id"
+            pop["relationship_to_reference_person"] == "Reference person", "household_id"
         ].values
 
         # Assert these two sets are identical
@@ -62,10 +62,10 @@ def test_household_id_and_address_id_correspond(tracked_live_populations):
 def test_new_reference_person_is_oldest_household_member(simulants_on_adjacent_timesteps):
     for before, after in simulants_on_adjacent_timesteps:
         before_reference_person_idx = before.index[
-            before["relation_to_reference_person"] == "Reference person"
+            before["relationship_to_reference_person"] == "Reference person"
         ]
         after_reference_person_idx = after.index[
-            (after["relation_to_reference_person"] == "Reference person")
+            (after["relationship_to_reference_person"] == "Reference person")
             & (after["household_id"].isin(before["household_id"]))
         ]
         new_reference_person_idx = np.setdiff1d(
@@ -92,7 +92,7 @@ def test_new_reference_person_is_oldest_household_member(simulants_on_adjacent_t
 def test_households_only_have_one_reference_person(tracked_live_populations):
     for pop in tracked_live_populations:
         household_ids = pop.loc[
-            pop["relation_to_reference_person"] == "Reference person", "household_id"
+            pop["relationship_to_reference_person"] == "Reference person", "household_id"
         ]
 
         assert len(household_ids) == len(household_ids.unique())
@@ -101,7 +101,7 @@ def test_households_only_have_one_reference_person(tracked_live_populations):
 def test_households_only_have_one_parter_or_spouse(tracked_live_populations):
     for pop in tracked_live_populations:
         household_ids = pop.loc[
-            pop["relation_to_reference_person"].isin(
+            pop["relationship_to_reference_person"].isin(
                 [
                     "Opp-sex spouse",
                     "Opp-sex partner",

--- a/integration_tests/test_immigration.py
+++ b/integration_tests/test_immigration.py
@@ -56,7 +56,7 @@ def test_immigration_into_existing_households(immigrants_by_timestep, sim):
 
         # These will all be non-reference-person immigrants, who cannot have certain relationships
         expected_relationship = ~existing_household_immigrants[
-            "relation_to_reference_person"
+            "relationship_to_reference_person"
         ].isin(
             [
                 "Reference person",
@@ -98,7 +98,7 @@ def test_immigration_into_new_households(immigrants_by_timestep, sim):
         ]
 
         households_established_by_domestic_migration = after[
-            (after["relation_to_reference_person"] == "Reference person")
+            (after["relationship_to_reference_person"] == "Reference person")
             & (~after.index.isin(immigrants.index))
             & (~after["household_id"].isin(existing_households))
         ]["household_id"].unique()
@@ -111,7 +111,7 @@ def test_immigration_into_new_households(immigrants_by_timestep, sim):
         ]
 
         expected_relationship = ~non_reference_person_immigrants[
-            "relation_to_reference_person"
+            "relationship_to_reference_person"
         ].isin(
             [
                 "Reference person",

--- a/src/vivarium_census_prl_synth_pop/components/household_emigration.py
+++ b/src/vivarium_census_prl_synth_pop/components/household_emigration.py
@@ -48,7 +48,7 @@ class HouseholdEmigration:
         self.population_view = builder.population.get_view(
             [
                 "household_id",
-                "relation_to_reference_person",
+                "relationship_to_reference_person",
                 "in_united_states",
                 "exit_time",
                 "tracked",
@@ -85,7 +85,7 @@ class HouseholdEmigration:
             event.index,
             query="alive == 'alive' and in_united_states == True and tracked == True",
         )
-        reference_people = pop[pop["relation_to_reference_person"] == "Reference person"]
+        reference_people = pop[pop["relationship_to_reference_person"] == "Reference person"]
 
         emigrating_reference_people = self.randomness.filter_for_rate(
             reference_people,

--- a/src/vivarium_census_prl_synth_pop/components/household_migration.py
+++ b/src/vivarium_census_prl_synth_pop/components/household_migration.py
@@ -50,7 +50,7 @@ class HouseholdMigration:
         self.randomness = builder.randomness.get_stream(self.name)
         self.columns_used = [
             "household_id",
-            "relation_to_reference_person",
+            "relationship_to_reference_person",
         ]
 
         self.population_view = builder.population.get_view(self.columns_used)
@@ -71,7 +71,7 @@ class HouseholdMigration:
         move those households to a new address
         """
         pop = self.population_view.get(event.index, query="alive == 'alive'")
-        reference_people = pop[pop["relation_to_reference_person"] == "Reference person"]
+        reference_people = pop[pop["relationship_to_reference_person"] == "Reference person"]
 
         household_sizes = pop.groupby("household_id").size()
 

--- a/src/vivarium_census_prl_synth_pop/components/immigration.py
+++ b/src/vivarium_census_prl_synth_pop/components/immigration.py
@@ -53,7 +53,7 @@ class Immigration:
 
         non_gq_immigrants = immigrants[~is_gq]
         immigrant_reference_people = non_gq_immigrants[
-            non_gq_immigrants["relation_to_reference_person"] == "Reference person"
+            non_gq_immigrants["relationship_to_reference_person"] == "Reference person"
         ]
 
         is_household_immigrant = non_gq_immigrants["census_household_id"].isin(

--- a/src/vivarium_census_prl_synth_pop/components/mortality.py
+++ b/src/vivarium_census_prl_synth_pop/components/mortality.py
@@ -7,8 +7,8 @@ from vivarium_public_health.population import Mortality as _Mortality
 class Mortality(_Mortality):
     def setup(self, builder: Builder) -> None:
         super().setup(builder)
-        self.updated_relation_to_reference_person = builder.value.get_value(
-            "updated_relation_to_reference_person"
+        self.updated_relationship_to_reference_person = builder.value.get_value(
+            "updated_relationship_to_reference_person"
         )
 
     def _get_population_view(self, builder: Builder) -> PopulationView:
@@ -20,12 +20,14 @@ class Mortality(_Mortality):
                 "exit_time",
                 "age",
                 "sex",
-                "relation_to_reference_person",
+                "relationship_to_reference_person",
             ]
         )
 
     def on_time_step(self, event: Event) -> None:
         super().on_time_step(event)
 
-        new_relation_to_ref_person = self.updated_relation_to_reference_person(event.index)
-        self.population_view.update(new_relation_to_ref_person)
+        new_relationship_to_reference_person = self.updated_relationship_to_reference_person(
+            event.index
+        )
+        self.population_view.update(new_relationship_to_reference_person)

--- a/src/vivarium_census_prl_synth_pop/components/observers.py
+++ b/src/vivarium_census_prl_synth_pop/components/observers.py
@@ -293,9 +293,9 @@ class DecennialCensusObserver(BaseObserver):
     """
 
     INPUT_VALUES = ["household_details"]
-    ADDITIONAL_INPUT_COLUMNS = ["relation_to_reference_person"]
+    ADDITIONAL_INPUT_COLUMNS = ["relationship_to_reference_person"]
     ADDITIONAL_OUTPUT_COLUMNS = [
-        "relation_to_reference_person",
+        "relationship_to_reference_person",
         "year",
         "housing_type",
     ]
@@ -354,12 +354,12 @@ class WICObserver(BaseObserver):
 
     INPUT_VALUES = ["income", "household_details"]
     ADDITIONAL_INPUT_COLUMNS = [
-        "relation_to_reference_person",
+        "relationship_to_reference_person",
     ]
     ADDITIONAL_OUTPUT_COLUMNS = [
         "year",
         "housing_type",
-        "relation_to_reference_person",
+        "relationship_to_reference_person",
     ]
     WIC_BASELINE_SALARY = 16_410
     WIC_SALARY_PER_HOUSEHOLD_MEMBER = 8_732
@@ -975,7 +975,7 @@ class Tax1040Observer(BaseObserver):
         "in_united_states",
         "tracked",
         "has_ssn",
-        "relation_to_reference_person",
+        "relationship_to_reference_person",
     ]
     OUTPUT_COLUMNS = [
         "household_id",
@@ -994,7 +994,7 @@ class Tax1040Observer(BaseObserver):
         "state_id",
         "puma",
         "race_ethnicity",
-        "relation_to_reference_person",  # needed to identify couples filing jointly
+        "relationship_to_reference_person",  # needed to identify couples filing jointly
         "housing_type",
         "tax_year",
         "alive",
@@ -1052,7 +1052,7 @@ class Tax1040Observer(BaseObserver):
             "Same-sex spouse",
         ]
         partners_of_household_head_idx = pop.index[
-            pop["relation_to_reference_person"].isin(partners)
+            pop["relationship_to_reference_person"].isin(partners)
         ]
         pop["joint_filer"] = False
         pop.loc[partners_of_household_head_idx, "joint_filer"] = self.randomness.choice(

--- a/src/vivarium_census_prl_synth_pop/components/observers.py
+++ b/src/vivarium_census_prl_synth_pop/components/observers.py
@@ -195,13 +195,26 @@ class BaseObserver(ABC):
 
 class HouseholdSurveyObserver(BaseObserver):
     INPUT_VALUES = ["household_details"]
-    ADDITIONAL_INPUT_COLUMNS = [
-        "alive",
-    ]
-    ADDITIONAL_OUTPUT_COLUMNS = [
-        "survey_date",
-        "housing_type",
-    ]
+    ADDITIONAL_INPUT_COLUMNS = {
+        "acs": [
+            "alive",
+            "relationship_to_reference_person",
+        ],
+        "cps": ["alive"],
+    }
+
+    ADDITIONAL_OUTPUT_COLUMNS = {
+        "acs": [
+            "survey_date",
+            "housing_type",
+            "relationship_to_reference_person",
+        ],
+        "cps": [
+            "survey_date",
+            "housing_type",
+        ],
+    }
+
     SAMPLING_RATE_PER_MONTH = {
         "acs": 12000,
         "cps": 60000,
@@ -229,11 +242,11 @@ class HouseholdSurveyObserver(BaseObserver):
 
     @property
     def input_columns(self):
-        return self.DEFAULT_INPUT_COLUMNS + self.ADDITIONAL_INPUT_COLUMNS
+        return self.DEFAULT_INPUT_COLUMNS + self.ADDITIONAL_INPUT_COLUMNS[self.survey]
 
     @property
     def output_columns(self):
-        return self.DEFAULT_OUTPUT_COLUMNS + self.ADDITIONAL_OUTPUT_COLUMNS
+        return self.DEFAULT_OUTPUT_COLUMNS + self.ADDITIONAL_OUTPUT_COLUMNS[self.survey]
 
     @property
     def output_name(self) -> str:

--- a/src/vivarium_census_prl_synth_pop/components/person_emigration.py
+++ b/src/vivarium_census_prl_synth_pop/components/person_emigration.py
@@ -41,15 +41,15 @@ class PersonEmigration:
         self.randomness = builder.randomness.get_stream(self.name)
         self.household_details = builder.value.get_value("household_details")
         self.columns_needed = [
-            "relation_to_reference_person",
+            "relationship_to_reference_person",
             "in_united_states",
             "exit_time",
             "tracked",
             "state_id_for_lookup",
         ]
         self.population_view = builder.population.get_view(self.columns_needed)
-        self.updated_relation_to_reference_person = builder.value.get_value(
-            "updated_relation_to_reference_person"
+        self.updated_relationship_to_reference_person = builder.value.get_value(
+            "updated_relationship_to_reference_person"
         )
 
         non_reference_person_move_rates_lookup_table = builder.lookup.build_table(
@@ -124,7 +124,7 @@ class PersonEmigration:
         household_details = self.household_details(pop.index)
         non_reference_people_idx = pop.index[
             (household_details["housing_type"] == "Standard")
-            & (pop["relation_to_reference_person"] != "Reference person")
+            & (pop["relationship_to_reference_person"] != "Reference person")
         ]
         non_reference_person_movers_idx = self.randomness.filter_for_rate(
             non_reference_people_idx,
@@ -146,5 +146,7 @@ class PersonEmigration:
 
         self.population_view.update(pop)
 
-        new_relation_to_ref_person = self.updated_relation_to_reference_person(event.index)
-        self.population_view.update(new_relation_to_ref_person)
+        new_relationship_to_reference_person = self.updated_relationship_to_reference_person(
+            event.index
+        )
+        self.population_view.update(new_relationship_to_reference_person)

--- a/src/vivarium_census_prl_synth_pop/components/person_migration.py
+++ b/src/vivarium_census_prl_synth_pop/components/person_migration.py
@@ -45,12 +45,12 @@ class PersonMigration:
         self.household_details = builder.value.get_value("household_details")
         self.columns_needed = [
             "household_id",
-            "relation_to_reference_person",
+            "relationship_to_reference_person",
             "previous_timestep_address_id",
         ]
         self.population_view = builder.population.get_view(self.columns_needed)
-        self.updated_relation_to_reference_person = builder.value.get_value(
-            "updated_relation_to_reference_person"
+        self.updated_relationship_to_reference_person = builder.value.get_value(
+            "updated_relationship_to_reference_person"
         )
 
         move_rates_data = pd.read_csv(
@@ -143,8 +143,10 @@ class PersonMigration:
 
         self.population_view.update(pop)
 
-        new_relation_to_ref_person = self.updated_relation_to_reference_person(event.index)
-        self.population_view.update(new_relation_to_ref_person)
+        new_relationship_to_reference_person = self.updated_relationship_to_reference_person(
+            event.index
+        )
+        self.population_view.update(new_relationship_to_reference_person)
 
     ##################
     # Helper methods #
@@ -160,7 +162,7 @@ class PersonMigration:
 
         # update pop table
         pop.loc[movers, "household_id"] = new_household_ids
-        pop.loc[movers, "relation_to_reference_person"] = "Reference person"
+        pop.loc[movers, "relationship_to_reference_person"] = "Reference person"
 
         return pop
 
@@ -172,7 +174,7 @@ class PersonMigration:
             return pop
 
         # The two GQ housing type categories (institutional, non-institutional) are
-        # tracked in the "relation_to_reference_person" column, even though
+        # tracked in the "relationship_to_reference_person" column, even though
         # that column name doesn't really make sense in a GQ setting.
         categories = list(data_values.GROUP_QUARTER_IDS.keys())
         housing_type_category_values = self.randomness.choice(
@@ -180,11 +182,11 @@ class PersonMigration:
             choices=categories,
             additional_key="gq_person_move_housing_type_categories",
         )
-        pop.loc[movers, "relation_to_reference_person"] = housing_type_category_values
+        pop.loc[movers, "relationship_to_reference_person"] = housing_type_category_values
 
         for category, housing_types in data_values.GROUP_QUARTER_IDS.items():
             movers_in_category = movers.intersection(
-                pop.index[pop["relation_to_reference_person"] == category]
+                pop.index[pop["relationship_to_reference_person"] == category]
             )
             if len(movers_in_category) == 0:
                 continue
@@ -248,6 +250,6 @@ class PersonMigration:
             )
 
         pop.loc[movers, "household_id"] = household_id_values
-        pop.loc[movers, "relation_to_reference_person"] = "Other nonrelative"
+        pop.loc[movers, "relationship_to_reference_person"] = "Other nonrelative"
 
         return pop

--- a/src/vivarium_census_prl_synth_pop/components/population.py
+++ b/src/vivarium_census_prl_synth_pop/components/population.py
@@ -53,7 +53,7 @@ class Population:
 
         self.columns_created = [
             "household_id",
-            "relation_to_reference_person",
+            "relationship_to_reference_person",
             "sex",
             "age",
             "date_of_birth",
@@ -78,11 +78,11 @@ class Population:
         # however, we only use it while creating the initial population.
         self.population_data = self._load_population_data(builder)
 
-        self.updated_relation_to_reference_person = builder.value.register_value_producer(
-            "updated_relation_to_reference_person",
-            source=self.get_updated_relation_to_reference_person,
+        self.updated_relationship_to_reference_person = builder.value.register_value_producer(
+            "updated_relationship_to_reference_person",
+            source=self.get_updated_relationship_to_reference_person,
             requires_columns=[
-                "relation_to_reference_person",
+                "relationship_to_reference_person",
                 "household_id",
                 "date_of_birth",
                 "guardian_1",
@@ -209,10 +209,10 @@ class Population:
         self.perturb_individual_age(new_simulants)
 
         noninstitutionalized = new_simulants.loc[
-            new_simulants["relation_to_reference_person"] == "Noninstitutionalized GQ pop"
+            new_simulants["relationship_to_reference_person"] == "Noninstitutionalized GQ pop"
         ].copy()
         institutionalized = new_simulants.loc[
-            new_simulants["relation_to_reference_person"] == "Institutionalized GQ pop"
+            new_simulants["relationship_to_reference_person"] == "Institutionalized GQ pop"
         ].copy()
 
         noninstitutionalized_gq_types = vectorized_choice(
@@ -239,7 +239,7 @@ class Population:
         pop_index = pop_data.user_data["current_population_index"]
         mothers = self.population_view.get(parent_ids_idx.unique())
         households = self.population_view.subview(
-            ["household_id", "relation_to_reference_person"]
+            ["household_id", "relationship_to_reference_person"]
         ).get(pop_index)
         new_births = pd.DataFrame(data={"parent_id": parent_ids_idx}, index=pop_data.index)
         new_births = self.initialize_new_simulants(new_births, pop_data)
@@ -247,7 +247,7 @@ class Population:
         inherited_traits = [
             "household_id",
             "race_ethnicity",
-            "relation_to_reference_person",
+            "relationship_to_reference_person",
             "last_name_id",
         ]
 
@@ -255,10 +255,10 @@ class Population:
         new_births = new_births.merge(
             mothers[inherited_traits], left_on="parent_id", right_index=True
         )
-        new_births["relation_to_reference_person"] = (
-            new_births["relation_to_reference_person"]
-            .map(metadata.NEWBORNS_RELATION_TO_REFERENCE_PERSON_MAP)
-            .astype(new_births["relation_to_reference_person"].dtype)
+        new_births["relationship_to_reference_person"] = (
+            new_births["relationship_to_reference_person"]
+            .map(metadata.NEWBORNS_RELATIONSHIP_TO_REFERENCE_PERSON_MAP)
+            .astype(new_births["relationship_to_reference_person"].dtype)
         )
 
         # birthday map between parent_ids and DOB (so twins get same bday)
@@ -374,7 +374,7 @@ class Population:
                 num_households=len(new_simulants),
             )
             new_simulants["household_id"] = household_ids
-            new_simulants["relation_to_reference_person"] = "Reference person"
+            new_simulants["relationship_to_reference_person"] = "Reference person"
         else:
             # TODO: For now, we do a simple random sample of households.
             # As part of future PUMA perturbation work, we plan to actually use
@@ -389,8 +389,8 @@ class Population:
         # We avoid non-reference-person immigrants having these relationships, because
         # otherwise they may cause there to be an impossible number of said relationships
         # within a household, i.e. >2 parents or >1 spouse/partner
-        new_simulants["relation_to_reference_person"] = (
-            new_simulants["relation_to_reference_person"]
+        new_simulants["relationship_to_reference_person"] = (
+            new_simulants["relationship_to_reference_person"]
             .replace(
                 {
                     "Parent": "Other relative",
@@ -401,7 +401,7 @@ class Population:
                     "Same-sex partner": "Other nonrelative",
                 }
             )
-            .astype(existing_simulants["relation_to_reference_person"].dtype)
+            .astype(existing_simulants["relationship_to_reference_person"].dtype)
         )
 
         new_simulants = self.initialize_simulant_link_columns(
@@ -578,7 +578,7 @@ class Population:
 
         columns_needed_for_linking = [
             "household_id",
-            "relation_to_reference_person",
+            "relationship_to_reference_person",
             "sex",
             "age",
             "race_ethnicity",
@@ -631,11 +631,11 @@ class Population:
         ]
         new_column_names = {
             "age_x": "child_age",
-            "relation_to_reference_person_x": "child_relation_to_reference_person",
+            "relationship_to_reference_person_x": "child_relationship_to_reference_person",
             "age_y": "member_age",
-            "relation_to_reference_person_y": "member_relation_to_reference_person",
+            "relationship_to_reference_person_y": "member_relationship_to_reference_person",
         }
-        key_cols = ["household_id", "relation_to_reference_person", "age"]
+        key_cols = ["household_id", "relationship_to_reference_person", "age"]
 
         child_households = self.get_household_structure(
             gen_population,
@@ -652,40 +652,42 @@ class Population:
         # Children helper index groups
         # Ref_person = "Reference person"
         child_of_ref_person_idx = child_households.loc[
-            child_households["child_relation_to_reference_person"].isin(CHILDREN)
+            child_households["child_relationship_to_reference_person"].isin(CHILDREN)
         ].index
         child_relative_of_ref_person_idx = child_households.loc[
-            child_households["child_relation_to_reference_person"].isin(CHILDREN_RELATIVES)
+            child_households["child_relationship_to_reference_person"].isin(
+                CHILDREN_RELATIVES
+            )
         ].index
         child_non_relative_of_ref_person_idx = child_households.loc[
-            child_households["child_relation_to_reference_person"].isin(NON_RELATIVES)
+            child_households["child_relationship_to_reference_person"].isin(NON_RELATIVES)
         ].index
         child_ref_person_idx = child_households.loc[
-            child_households["child_relation_to_reference_person"] == "Reference person"
+            child_households["child_relationship_to_reference_person"] == "Reference person"
         ].index
 
         # Potential guardian/household member index groups
         relatives_of_ref_person_idx = child_households.loc[
-            ~child_households["member_relation_to_reference_person"].isin(
+            ~child_households["member_relationship_to_reference_person"].isin(
                 NON_RELATIVES + PARTNERS + ["Reference person"]
             )
         ].index
         non_relatives_of_ref_person_idx = child_households.loc[
-            child_households["member_relation_to_reference_person"].isin(NON_RELATIVES)
+            child_households["member_relationship_to_reference_person"].isin(NON_RELATIVES)
         ].index
         age_bound_idx = child_households.loc[
             (child_households["age_difference"] >= 18)
             & (child_households["age_difference"] < 46)
         ].index
         parents_of_ref_person_idx = child_households.loc[
-            child_households["member_relation_to_reference_person"].isin(PARENTS)
+            child_households["member_relationship_to_reference_person"].isin(PARENTS)
         ].index
         over_18_idx = child_households.loc[child_households["member_age"] >= 18].index
         ref_person_idx = child_households.loc[
-            child_households["member_relation_to_reference_person"] == "Reference person"
+            child_households["member_relationship_to_reference_person"] == "Reference person"
         ].index
         partners_of_ref_person_idx = child_households.loc[
-            child_households["member_relation_to_reference_person"].isin(PARTNERS)
+            child_households["member_relationship_to_reference_person"].isin(PARTNERS)
         ].index
 
         # Assign guardians across groups
@@ -836,7 +838,7 @@ class Population:
         ----------
         new_births: pd.DataFrame of new births on this time step
         households: pd.DataFrame of the entire state table for the two columns of household_id
-          and relation_to_reference_person.
+          and relationship_to_reference_person.
 
         Returns
         -------
@@ -844,10 +846,10 @@ class Population:
         """
         # Setup
         new_births["guardian_2"] = data_values.UNKNOWN_GUARDIAN_IDX
-        key_cols = ["household_id", "relation_to_reference_person"]
+        key_cols = ["household_id", "relationship_to_reference_person"]
         new_column_names = {
-            "relation_to_reference_person_x": "mother_relation_to_reference_person",
-            "relation_to_reference_person_y": "member_relation_to_reference_person",
+            "relationship_to_reference_person_x": "mother_relationship_to_reference_person",
+            "relationship_to_reference_person_y": "member_relationship_to_reference_person",
         }
         mothers_households = self.get_household_structure(
             households,
@@ -860,17 +862,19 @@ class Population:
         # Index helpers
         # Mother index groups
         mother_ref_person_idx = mothers_households.loc[
-            mothers_households["mother_relation_to_reference_person"] == "Reference person"
+            mothers_households["mother_relationship_to_reference_person"]
+            == "Reference person"
         ].index
         mother_partner_idx = mothers_households.loc[
-            mothers_households["mother_relation_to_reference_person"].isin(PARTNERS)
+            mothers_households["mother_relationship_to_reference_person"].isin(PARTNERS)
         ].index
         # Potential partner index groups
         partners_idx = mothers_households.loc[
-            mothers_households["member_relation_to_reference_person"].isin(PARTNERS)
+            mothers_households["member_relationship_to_reference_person"].isin(PARTNERS)
         ].index
         ref_person_idx = mothers_households.loc[
-            mothers_households["member_relation_to_reference_person"] == "Reference person"
+            mothers_households["member_relationship_to_reference_person"]
+            == "Reference person"
         ].index
 
         # Assign second guardian to random partner of mothers
@@ -926,7 +930,7 @@ class Population:
         #  for easier lookups
         reference_persons = (
             pop.loc[
-                (pop["relation_to_reference_person"] == "Reference person")
+                (pop["relationship_to_reference_person"] == "Reference person")
                 & (pop["age"] >= 35)
                 & (pop["age"] < 66),
                 ["household_id", "sex", "race_ethnicity"],
@@ -936,7 +940,7 @@ class Population:
             .rename(columns={"index": "reference_person_id"})
         )
         partners_of_reference_persons = (
-            pop.loc[pop["relation_to_reference_person"].isin(PARTNERS), ["household_id"]]
+            pop.loc[pop["relationship_to_reference_person"].isin(PARTNERS), ["household_id"]]
             .reset_index()
             .rename(columns={"index": "partner_id"})
             .groupby("household_id")["partner_id"]
@@ -1091,7 +1095,7 @@ class Population:
         The following example is how we will construct a dataframe for children under 18.
         # Columns will contain data for child alongside each household member
         # This will allow us to do lookups related to both a child and other household members.
-        pd.Dataframe = child_age | child_relation_to_reference_person | member_age | member_relation_to_reference_person
+        pd.Dataframe = child_age | child_relationship_to_reference_person | member_age | member_relationship_to_reference_person
         child_id person_id|
             0        0    |  11              "Biological child               11            "Biological child
             0        1    |  11              "Biological child               35            "Reference person"
@@ -1135,7 +1139,8 @@ class Population:
     def perturb_household_age(self, simulants: pd.DataFrame) -> None:
         # Takes dataframe of households and returns a series with an applied age shift for each household.
         household_ids = simulants.loc[
-            simulants["relation_to_reference_person"] == "Reference person", "household_id"
+            simulants["relationship_to_reference_person"] == "Reference person",
+            "household_id",
         ]  # Series with index for each reference person and value is household id
         # Flip index and values to map age shift later
         reference_person_ids = pd.Series(data=household_ids.index, index=household_ids)
@@ -1222,7 +1227,7 @@ class Population:
         simulants_to_assign
             Dataframe of simulants who may be assigned a linked last name ID.
             This dataframe should already include a last_name_id column, which will not be changed if no link is made.
-            It should also include household_id and relation_to_reference_person columns.
+            It should also include household_id and relationship_to_reference_person columns.
         pop
             Dataframe of full population, which includes all reference people the last_name_id may be linked to.
 
@@ -1234,7 +1239,7 @@ class Population:
         # Match last names for relatives of reference person
         relatives_idx = simulants_to_assign.index[
             (
-                ~simulants_to_assign["relation_to_reference_person"].isin(
+                ~simulants_to_assign["relationship_to_reference_person"].isin(
                     NON_RELATIVES + ["Reference person"]
                 )
             )
@@ -1243,13 +1248,13 @@ class Population:
 
         # Get mapping from household_id to current reference person last_name_id
         reference_person_last_name_ids = pop.loc[
-            pop["relation_to_reference_person"] == "Reference person",
+            pop["relationship_to_reference_person"] == "Reference person",
             ["household_id", "last_name_id"],
         ].set_index("household_id")["last_name_id"]
 
         # NOTE: Because we are mutating the very value we are linking to, it would break if
         # a simulants_to_assign row were both linked *to* and linked *from* here!
-        # That only one or the other occurs is guaranteed by our relation_to_reference_person
+        # That only one or the other occurs is guaranteed by our relationship_to_reference_person
         # criteria above.
         # We have to set the type because it will have become a float with the addition of
         # NaNs.
@@ -1261,10 +1266,10 @@ class Population:
 
         return simulants_to_assign
 
-    def get_updated_relation_to_reference_person(self, idx: pd.Index) -> pd.Series:
+    def get_updated_relationship_to_reference_person(self, idx: pd.Index) -> pd.Series:
         """
         Chooses the oldest member of all households that lack a reference person
-        and assigns them as the reference person. Updates all other relations to
+        and assigns them as the reference person. Updates all other relationships to
         be relative to this new reference person.
         """
         population = self.population_view.get(
@@ -1273,7 +1278,8 @@ class Population:
 
         # Find standard households that do not have a reference person
         household_ids_with_reference_person = population.loc[
-            population["relation_to_reference_person"] == "Reference person", "household_id"
+            population["relationship_to_reference_person"] == "Reference person",
+            "household_id",
         ]
         standard_household_ids = population.loc[
             ~population["household_id"].isin(data_values.GQ_HOUSING_TYPE_MAP), "household_id"
@@ -1293,10 +1299,10 @@ class Population:
         # Preserve old relationship of new reference person before assigning
         # them as new reference persons
         new_reference_person_prev_relationship = population.loc[
-            new_reference_persons, ["household_id", "relation_to_reference_person"]
+            new_reference_persons, ["household_id", "relationship_to_reference_person"]
         ]
         population.loc[
-            new_reference_persons, "relation_to_reference_person"
+            new_reference_persons, "relationship_to_reference_person"
         ] = "Reference person"
 
         # Update simulants born in simulation as biological children to their
@@ -1313,12 +1319,12 @@ class Population:
             )
         ].intersection(households_to_update_idx)
         population.loc[
-            biological_children_idx, "relation_to_reference_person"
+            biological_children_idx, "relationship_to_reference_person"
         ] = "Biological child"
 
         # Update other household members relationship to new reference person
         for relationship in new_reference_person_prev_relationship[
-            "relation_to_reference_person"
+            "relationship_to_reference_person"
         ].unique():
             relationship_map = data_values.REFERENCE_PERSON_UPDATE_RELATIONSHIPS_MAP.loc[
                 data_values.REFERENCE_PERSON_UPDATE_RELATIONSHIPS_MAP[
@@ -1328,7 +1334,7 @@ class Population:
             ].set_index("relationship_to_old_reference_person")
 
             household_ids_to_update = new_reference_person_prev_relationship.loc[
-                new_reference_person_prev_relationship["relation_to_reference_person"]
+                new_reference_person_prev_relationship["relationship_to_reference_person"]
                 == relationship,
                 "household_id",
             ]
@@ -1339,14 +1345,14 @@ class Population:
             )
             # Update relationships
             population.loc[
-                simulants_to_update_idx, "relation_to_reference_person"
-            ] = population["relation_to_reference_person"].map(
+                simulants_to_update_idx, "relationship_to_reference_person"
+            ] = population["relationship_to_reference_person"].map(
                 relationship_map["relationship_to_new_reference_person"]
             )
 
         # Handle extreme edge cases where there would not be a value to map to.
-        population.loc[households_to_update_idx, "relation_to_reference_person"].fillna(
+        population.loc[households_to_update_idx, "relationship_to_reference_person"].fillna(
             "Other nonrelative"
         )
 
-        return population["relation_to_reference_person"]
+        return population["relationship_to_reference_person"]

--- a/src/vivarium_census_prl_synth_pop/constants/metadata.py
+++ b/src/vivarium_census_prl_synth_pop/constants/metadata.py
@@ -44,7 +44,7 @@ HOUSEHOLD_TYPES = list(HOUSEHOLD_TYPE_MAP.values())
 PERSONS_COLUMNS_TO_INITIALIZE = [
     "census_household_id",
     "age",
-    "relation_to_reference_person",
+    "relationship_to_reference_person",
     "sex",
     "race_ethnicity",
     "born_in_us",
@@ -110,7 +110,7 @@ PERSONS_COLUMNS_MAP = {
     "ST": "state",
     "SERIALNO": "census_household_id",
     "AGEP": "age",
-    "RELSHIPP": "relation_to_reference_person",
+    "RELSHIPP": "relationship_to_reference_person",
     "SEX": "sex",
     "HISP": "latino",
     "RAC1P": "race",
@@ -169,7 +169,7 @@ RELATIONSHIP_TO_REFERENCE_PERSON_MAP = {
 }
 RELATIONSHIPS = list(RELATIONSHIP_TO_REFERENCE_PERSON_MAP.values())
 
-NEWBORNS_RELATION_TO_REFERENCE_PERSON_MAP = {
+NEWBORNS_RELATIONSHIP_TO_REFERENCE_PERSON_MAP = {
     "Reference person": "Biological child",
     "Opp-sex spouse": "Biological child",
     "Opp-sex partner": "Biological child",

--- a/src/vivarium_census_prl_synth_pop/data/loader.py
+++ b/src/vivarium_census_prl_synth_pop/data/loader.py
@@ -112,8 +112,8 @@ def load_persons(key: str, location: str) -> pd.DataFrame:
     )
 
     # map relationship to household head
-    data["relation_to_reference_person"] = (
-        data["relation_to_reference_person"]
+    data["relationship_to_reference_person"] = (
+        data["relationship_to_reference_person"]
         .map(metadata.RELATIONSHIP_TO_REFERENCE_PERSON_MAP)
         .astype(pd.CategoricalDtype(categories=metadata.RELATIONSHIPS))
     )

--- a/src/vivarium_census_prl_synth_pop/tools/make_results.py
+++ b/src/vivarium_census_prl_synth_pop/tools/make_results.py
@@ -50,7 +50,7 @@ FINAL_OBSERVERS = {
         "city",
         "zipcode",
         "state",
-        "relation_to_reference_person",
+        "relationship_to_reference_person",
         "sex",
         "race_ethnicity",
         "guardian_1",
@@ -127,7 +127,7 @@ FINAL_OBSERVERS = {
         "city",
         "zipcode",
         "state",
-        "relation_to_reference_person",
+        "relationship_to_reference_person",
         "sex",
         "race_ethnicity",
         "guardian_1",
@@ -205,7 +205,7 @@ FINAL_OBSERVERS = {
         "itin",
         # todo: add copy itin
         "tax_year",
-        "relation_to_reference_person",
+        "relationship_to_reference_person",
     },
     metadata.DatasetNames.TAXES_DEPENDENTS: {
         # Metadata is for a dependent.  This should capture each dependent/guardian pair.  Meaning that if a dependent

--- a/src/vivarium_census_prl_synth_pop/tools/make_results.py
+++ b/src/vivarium_census_prl_synth_pop/tools/make_results.py
@@ -71,6 +71,7 @@ FINAL_OBSERVERS = {
         "copy_age",
         "date_of_birth",
         "copy_date_of_birth",
+        "relationship_to_reference_person",
         "sex",
         "race_ethnicity",
         "street_number",

--- a/tests/components/test_population.py
+++ b/tests/components/test_population.py
@@ -19,7 +19,7 @@ fake_household_1 = pd.DataFrame(
         ],
         "age": [39, 8, 5, 7, 35],
         "guardian_1": [-1, 0, 300, -1, -1],
-        "relation_to_reference_person": [
+        "relationship_to_reference_person": [
             "Opp-sex spouse",
             "Stepchild",
             "Adopted child",
@@ -42,7 +42,7 @@ fake_household_2 = pd.DataFrame(
         ],
         "age": [68, 44, 7, 9, 38],
         "guardian_1": [-1, -1, 100, 100, -1],
-        "relation_to_reference_person": [
+        "relationship_to_reference_person": [
             "Parent-in-law",
             "Same-sex spouse",
             "Biological child",
@@ -65,7 +65,7 @@ fake_household_3 = pd.DataFrame(
         ],
         "age": [63, 27, 60, 23, 2],
         "guardian_1": [-1, -1, -1, -1, 35],
-        "relation_to_reference_person": [
+        "relationship_to_reference_person": [
             "Parent",
             "Sibling",
             "Parent",
@@ -88,7 +88,7 @@ fake_household_4 = pd.DataFrame(
         ],
         "age": [23, 22, 22, 21, 20],
         "guardian_1": [-1, -1, -1, -1, -1],
-        "relation_to_reference_person": [
+        "relationship_to_reference_person": [
             "Roommate",
             "Roommate",
             "Roommate",
@@ -111,7 +111,7 @@ fake_household_5 = pd.DataFrame(
         ],
         "age": [38, 5, 36, 34, 36],
         "guardian_1": [-1, 20, -1, 20, -1],
-        "relation_to_reference_person": [
+        "relationship_to_reference_person": [
             "Opp-sex spouse",
             "Other relative",
             "Roommate",
@@ -208,7 +208,7 @@ def test_update_to_reference_person_and_relationships(mocker, fake_population):
     expected_reference_person = (
         fake_population.loc[fake_population.index].groupby(["household_id"])["age"].idxmax()
     )
-    updated_relationships = pop_component.get_updated_relation_to_reference_person(
+    updated_relationships = pop_component.get_updated_relationship_to_reference_person(
         fake_population.index
     )
 


### PR DESCRIPTION
## Change relation col name and add to acs output
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, data artifact, implementation, observers,
                   post-processing, refactor, revert, test, release, other/misc --> feature
- *JIRA issue*: [MIC-4200](https://jira.ihme.washington.edu/browse/MIC-4200)
- *Research reference*: <!--Link to research documentation for code --> https://github.com/ihmeuw/pseudopeople/blob/develop/docs/source/noise/index.rst

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
This PR does two things:
1. First commit: changes all instances (including in artifact) of 'relation_to_reference_person'
  to 'relationship_to_reference_person'
2. Second commit: adds 'relationship_to_reference_person' to ACS output.

A followup PR (same ticket, MIC-4200) will happen on the pseudopeople side.

### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->
integration tests pass. Also ran one time step and saw the new col 
in ACS data.

