### PR TITLE
Mic 4277/update 1040 obs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+**1.5.0 - 07/27/23**
+
+ - Update Tax 1040 observer to apply 65.5% probability of filing
+ - Fixes bug in Tax 1040 observer for joint filing eligibility
+
 **1.4.0 - 07/25/23**
 
  - Change "relation_to_reference_person" column to "relationship_to_reference_person"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,4 @@
-**1.5.0 - 07/27/23**
+**1.4.1 - 07/27/23**
 
  - Update Tax 1040 observer to apply 65.5% probability of filing
  - Fixes bug in Tax 1040 observer for joint filing eligibility

--- a/src/vivarium_census_prl_synth_pop/components/observers.py
+++ b/src/vivarium_census_prl_synth_pop/components/observers.py
@@ -1073,8 +1073,12 @@ class Tax1040Observer(BaseObserver):
             "Same-sex spouse",
         ]
         # Get partners of reference members who filed taxes
+        hh_ids_with_filing_ref_persons = pop.loc[
+            pop["relationship_to_reference_person"] == "Reference person", "household_id"
+        ]
         partners_of_household_head_idx = pop.index[
-            pop["relationship_to_reference_person"].isin(partners)
+            (pop["household_id"].isin(hh_ids_with_filing_ref_persons))
+            & (pop["relationship_to_reference_person"].isin(partners))
         ]
         pop["joint_filer"] = False
         pop.loc[partners_of_household_head_idx, "joint_filer"] = self.randomness.choice(

--- a/src/vivarium_census_prl_synth_pop/components/observers.py
+++ b/src/vivarium_census_prl_synth_pop/components/observers.py
@@ -1076,13 +1076,13 @@ class Tax1040Observer(BaseObserver):
         hh_ids_with_filing_ref_persons = pop.loc[
             pop["relationship_to_reference_person"] == "Reference person", "household_id"
         ]
-        partners_of_household_head_idx = pop.index[
+        partners_of_reference_person_idx = pop.index[
             (pop["household_id"].isin(hh_ids_with_filing_ref_persons))
             & (pop["relationship_to_reference_person"].isin(partners))
         ]
         pop["joint_filer"] = False
-        pop.loc[partners_of_household_head_idx, "joint_filer"] = self.randomness.choice(
-            index=partners_of_household_head_idx,
+        pop.loc[partners_of_reference_person_idx, "joint_filer"] = self.randomness.choice(
+            index=partners_of_reference_person_idx,
             choices=[True, False],
             p=[
                 data_values.Taxes.PROBABILITY_OF_JOINT_FILER,

--- a/src/vivarium_census_prl_synth_pop/components/observers.py
+++ b/src/vivarium_census_prl_synth_pop/components/observers.py
@@ -1057,7 +1057,9 @@ class Tax1040Observer(BaseObserver):
         # Sample who files taxes
         # TODO: Update with income sampling
         tax_filers_idx = self.randomness.filter_for_probability(
-            pop.index, data_values.Taxes.PROBABILITY_OF_FILING_TAXES, "1040_filing_sample",
+            pop.index,
+            data_values.Taxes.PROBABILITY_OF_FILING_TAXES,
+            "1040_filing_sample",
         )
         pop = pop.loc[tax_filers_idx]
         # copy from household member for relevant columns

--- a/src/vivarium_census_prl_synth_pop/components/observers.py
+++ b/src/vivarium_census_prl_synth_pop/components/observers.py
@@ -1054,6 +1054,12 @@ class Tax1040Observer(BaseObserver):
 
     def get_observation(self, event: Event) -> pd.DataFrame:
         pop = self.population_view.get(event.index)
+        # Sample who files taxes
+        # TODO: Update with income sampling
+        tax_filers_idx = self.randomness.filter_for_probability(
+            pop.index, data_values.Taxes.PROBABILITY_OF_FILING_TAXES, "1040_filing_sample",
+        )
+        pop = pop.loc[tax_filers_idx]
         # copy from household member for relevant columns
         pop = utilities.copy_from_household_member(pop, self.randomness)
         pop = self.add_address(pop)
@@ -1064,6 +1070,7 @@ class Tax1040Observer(BaseObserver):
             "Opp-sex spouse",
             "Same-sex spouse",
         ]
+        # Get partners of reference members who filed taxes
         partners_of_household_head_idx = pop.index[
             pop["relationship_to_reference_person"].isin(partners)
         ]

--- a/src/vivarium_census_prl_synth_pop/constants/data_values.py
+++ b/src/vivarium_census_prl_synth_pop/constants/data_values.py
@@ -142,6 +142,7 @@ class Taxes(NamedTuple):
     PERCENT_W2_RECEIVED = 0.9465
     PERCENT_1099_RECEIVED = 0.0535
     PROBABILITY_OF_JOINT_FILER = 0.95
+    PROBABILITY_OF_FILING_TAXES = 0.655
 
 
 # Needed to allow HDFs to be filtered on these columns


### PR DESCRIPTION
## Mic-4277/update 1040 obs

### Updates 1040 observer to fix sampling bugs.
- *Category*: Bugfix
- *JIRA issue*: [MIC-4277](https://jira.ihme.washington.edu/browse/MIC-4277)
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
-Adds sampling to replace income sampling at flat rate
-Fixes bug with joint filing eligibility.

### Verification and Testing
Successfully ran simulation.

