### PR TITLE
resolve symlinks; add a second one at parent dir

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+**1.4.2 - 07/28/23**
+
+ - Resolve symlinks
+ - Generate second symlinks at location-level directory
+
 **1.4.1 - 07/27/23**
 
  - Update Tax 1040 observer to apply 65.5% probability of filing

--- a/src/vivarium_census_prl_synth_pop/tools/cli_utils.py
+++ b/src/vivarium_census_prl_synth_pop/tools/cli_utils.py
@@ -94,11 +94,13 @@ def finish_post_processing(final_output_dir: Path, test_run: bool, mark_best: bo
 
 
 def _create_results_link(output_dir: Path, link_name: Path) -> None:
+    output_dir = output_dir.resolve()
+    final_results_dir = output_dir.parent.parent
+    parent_dir = final_results_dir.parent.parent
     logger.info(f"Marking results as '{link_name}': {str(output_dir)}.")
-    link_dir = (
-        Path(str(output_dir).split(str(paths.FINAL_RESULTS_DIR_NAME))[0])
-        / paths.FINAL_RESULTS_DIR_NAME
-        / link_name
-    )
-    link_dir.unlink(missing_ok=True)
-    link_dir.symlink_to(output_dir, target_is_directory=True)
+    link_dir_final_results = final_results_dir / link_name
+    link_dir_parent = parent_dir / link_name
+    link_dir_final_results.unlink(missing_ok=True)
+    link_dir_final_results.symlink_to(output_dir, target_is_directory=True)
+    link_dir_parent.unlink(missing_ok=True)
+    link_dir_parent.symlink_to(output_dir, target_is_directory=True)


### PR DESCRIPTION
## Resolve symlinks and add a higher-level one
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, data artifact, implementation, observers,
                   post-processing, refactor, revert, test, release, other/misc --> bugfix
- *JIRA issue*: [MIC-4296](https://jira.ihme.washington.edu/browse/MIC-4296)
- *Research reference*: <!--Link to research documentation for code --> na

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
The symlinks (latest and best) are not currently resolved. This fixes that and
also adds a second set of symlinks at the parent location level, i.e. 
`.../united_states_of_america/latest`

### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
--> checked symlinks on a short sim

