### PR TITLE
Mic-4304

### DIFF
--- a/src/vivarium_census_prl_synth_pop/tools/make_results.py
+++ b/src/vivarium_census_prl_synth_pop/tools/make_results.py
@@ -144,6 +144,7 @@ FINAL_OBSERVERS = {
         "first_name",
         "middle_initial",
         "last_name",
+        "sex",
         "date_of_birth",
         "copy_date_of_birth",
         "ssn",


### PR DESCRIPTION
## Mic-4304

### Adds the sex column to the Social Security dataset outputs.
- *Category*: Post-processing
- *JIRA issue*: [MIC-4304](https://jira.ihme.washington.edu/browse/MIC-4304)
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
-adds sex as output column for Social Security dataset

### Verification and Testing
Ran make_results and saw sex column in output.

