### PR TITLE
Mic-4373/add ITIN column to tax dependents outputs

### DIFF
--- a/src/vivarium_census_prl_synth_pop/tools/make_results.py
+++ b/src/vivarium_census_prl_synth_pop/tools/make_results.py
@@ -205,7 +205,6 @@ FINAL_OBSERVERS = {
         "ssn",
         "copy_ssn",
         "itin",
-        # todo: add copy itin
         "tax_year",
         "relationship_to_reference_person",
     },
@@ -232,6 +231,7 @@ FINAL_OBSERVERS = {
         "sex",
         "ssn",
         "copy_ssn",
+        "itin",
         "guardian_id",
         "housing_type",
         "tax_year",


### PR DESCRIPTION
## Mic-4373/add ITIN column to tax dependents outputs

### Adds ITIN column to tax dependents outputs.
- *Category*: Post-processing
- *JIRA issue*: [MIC-4373](https://jira.ihme.washington.edu/browse/MIC-4373)
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
-adds ITIN column to tax dependents outputs

### Verification and Testing
Ran make_results for sample data and saw ITIN in outputs.

