### PR TITLE
Mic 4385/port 1040 formatting

### DIFF
--- a/src/vivarium_census_prl_synth_pop/results_processing/formatter.py
+++ b/src/vivarium_census_prl_synth_pop/results_processing/formatter.py
@@ -162,3 +162,111 @@ def format_data_for_mapping(
     data = data[output_columns].set_index(index_name)
 
     return data
+
+
+def format_1040_dataset(processed_results: Dict[str, pd.Series]) -> pd.DataFrame:
+    # Function that loads all tax datasets and formats them to the DATASET.1040 schema
+
+    # Load data
+    df_1040 = processed_results[metadata.DatasetNames.TAXES_1040]
+    df_dependents = processed_results[metadata.DatasetNames.TAXES_DEPENDENTS]
+    # Combine ssn and itin columns
+    df_1040 = combine_ssn_and_itin_columns(df_1040)
+    df_dependents = combine_ssn_and_itin_columns(df_dependents)
+
+    # Get wide format of dependents - metadata for each guardian's dependents
+    dependents_wide = flatten_data(
+        data=df_dependents,
+        index_cols=["guardian_id", "tax_year"],
+        rank_col="simulant_id",
+        value_cols=[
+            "simulant_id",
+            "first_name",
+            "last_name",
+            "ssn",
+            "copy_ssn",
+        ],
+    )
+    # Rename tax_dependents columns
+    dependents_wide = dependents_wide.add_prefix("dependent_").reset_index()
+    # Make sure we have all dependent columns if data does not have a guardian with 4 dependents
+    for i in range(2, 5):
+        if f"dependent_{i}_first_name" not in dependents_wide.columns:
+            dependents_cols = ["first_name", "last_name", "ssn", "copy_ssn"]
+            for column in dependents_cols:
+                dependents_wide[f"dependent_{i}_{column}"] = np.nan
+
+    # Widen 1040 data (make one row for spouses that are joint filing)
+    df_joint_1040 = combine_joint_filers(df_1040)
+    # Merge tax dependents onto their guardians - we must do it twice, merge onto each spouse if joint filing
+    tax_1040_w_dependents = df_joint_1040.merge(
+        dependents_wide,
+        how="left",
+        left_on=["simulant_id", "tax_year"],
+        right_on=["guardian_id", "tax_year"],
+    )
+    # TODO: uncomment with mic-4244. Handle columns with dependents for both guardians
+    # tax_1040_w_dependents = tax_1040_w_dependents.merge(
+    #   dependents_wide, how="left",
+    #   left_on=["COLUMNS.spouse_simulant_id.name", "COLUMNS.tax_year.name"],
+    #   right_on=["COLUMNS.guardian_id.name", "COLUMNS.tax_year.name"])
+    return tax_1040_w_dependents
+
+
+def flatten_data(
+    data: pd.DataFrame,
+    index_cols: str,
+    rank_col: str,
+    value_cols: List[str],
+    ascending: bool = False,
+) -> pd.DataFrame:
+    # Function that takes a dataset and widens (pivots) it to capture multiple metadata columns
+    # Example: simulant_id, dependdent_1, dependent_2, dependent_1_name, dependent_2_name, etc...
+    data = data.copy()
+    # fixme: find a better solution than the following call since applying lambda functions is slow
+    data["rank"] = (
+        data.groupby(index_cols, group_keys=False)[rank_col]
+        .apply(lambda x: x.rank(method="first", ascending=ascending))
+        .astype(int)
+    )
+    # TODO: Improve via mic-4244 for random sampling of dependents
+    # Choose 4 dependents
+    data = data.loc[data["rank"] < 5]
+    data["rank"] = data["rank"].astype(str)
+    flat = data.pivot(columns="rank", index=index_cols, values=value_cols)
+    flat.columns = ["_".join([pair[1], pair[0]]) for pair in flat.columns]
+
+    return flat
+
+
+def combine_joint_filers(data: pd.DataFrame) -> pd.DataFrame:
+    # Get groups
+    joint_filers = data.loc[data["joint_filer"] == True]
+    reference_persons = data.loc[
+        data["relationship_to_reference_person"] == "Reference person"
+    ]
+    independent_filers_index = data.index.difference(
+        joint_filers.index.union(reference_persons.index)
+    )
+    # This is a dataframe with all independent filing individuals that are not a reference person
+    independent_filers = data.loc[independent_filers_index]
+
+    joint_filers = joint_filers.add_prefix("spouse_")
+    # Merge spouses
+    reference_persons_wide = reference_persons.merge(
+        joint_filers,
+        how="left",
+        left_on=["household_id", "tax_year"],
+        right_on=["spouse_household_id", "spouse_tax_year"],
+    )
+    joint_1040 = pd.concat([reference_persons_wide, independent_filers])
+
+    return joint_1040
+
+
+def combine_ssn_and_itin_columns(data: pd.DataFrame) -> pd.DataFrame:
+    # This combines the ssn and itin columns into the ssn column.
+    # Simulants can either have an ssn or an itin so we will replace
+    # the nans in the ssn column with that rows corresponding itin value
+    data["ssn"] = np.where(data["ssn"].notna(), data["ssn"], data["itin"])
+    return data

--- a/src/vivarium_census_prl_synth_pop/tools/make_results.py
+++ b/src/vivarium_census_prl_synth_pop/tools/make_results.py
@@ -371,7 +371,9 @@ def perform_post_processing(
                 obs_data[col] = obs_data[col].astype(
                     pd.CategoricalDtype(categories=state_categories)
                 )
+    # TODO: Format 1040 data by combining with tax dependents
 
+    # TODO: make new for loop to write out files except tax dependents
         logger.info(f"Writing final {observer} results.")
         obs_dir = build_output_dir(final_output_dir, subdir=observer)
         seed_ext = f"_{seed}" if seed != "" else ""

--- a/src/vivarium_census_prl_synth_pop/tools/make_results.py
+++ b/src/vivarium_census_prl_synth_pop/tools/make_results.py
@@ -204,7 +204,6 @@ FINAL_OBSERVERS = {
         "joint_filer",
         "ssn",
         "copy_ssn",
-        "itin",
         "tax_year",
         "relationship_to_reference_person",
     },

--- a/src/vivarium_census_prl_synth_pop/tools/make_results.py
+++ b/src/vivarium_census_prl_synth_pop/tools/make_results.py
@@ -202,7 +202,7 @@ FINAL_OBSERVERS = {
         "mailing_address_po_box",
         "housing_type",
         "joint_filer",
-        "ssn",
+        "ssn_itin",
         "copy_ssn",
         "tax_year",
         "relationship_to_reference_person",
@@ -228,14 +228,23 @@ FINAL_OBSERVERS = {
         "mailing_address_state",
         "mailing_address_po_box",
         "sex",
-        "ssn",
+        "ssn_itin",
         "copy_ssn",
-        "itin",
         "guardian_id",
         "housing_type",
         "tax_year",
     },
 }
+
+OUTPUT_DATASETS = [
+    metadata.DatasetNames.ACS,
+    metadata.DatasetNames.CENSUS,
+    metadata.DatasetNames.CPS,
+    metadata.DatasetNames.SSA,
+    metadata.DatasetNames.WIC,
+    metadata.DatasetNames.TAXES_W2_1099,
+    metadata.DatasetNames.TAXES_1040,
+]
 
 PUBLIC_SAMPLE_PUMA_PROPORTION = 0.5
 
@@ -379,7 +388,7 @@ def perform_post_processing(
     # Write results for each dataset - we do not need to write out tax dependents now that we format
     # the 1040 dataset above
     for observer in FINAL_OBSERVERS:
-        if observer != metadata.DatasetNames.TAXES_DEPENDENTS:
+        if observer in OUTPUT_DATASETS:
             obs_data = processed_results[observer]
             logger.info(f"Writing final {observer} results.")
             obs_dir = build_output_dir(final_output_dir, subdir=observer)


### PR DESCRIPTION
## Mic-4385/port 1040 formatting

### Moves 1040 dataset formatting to post-processing
- *Category*: Post-processing
- *JIRA issue*: [MIC-4385](https://jira.ihme.washington.edu/browse/MIC-4385)
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
-moves 1040 data formatting to post-processing
-updates get_itin_map to get ssn_itin_map to combine ssn and itin columns for 1040
-no longer writes tax dependents dataset to file since it is no longer needed for pseudopeople

### Verification and Testing
Successfully ran make results and saw expected columns.

