### PR TITLE
Mic-4484/fix empty strings in po box street details

### DIFF
--- a/src/vivarium_census_prl_synth_pop/results_processing/addresses.py
+++ b/src/vivarium_census_prl_synth_pop/results_processing/addresses.py
@@ -262,14 +262,14 @@ def get_mailing_address_map(
     must contain columns for physical address ["street_number", "street_name", etc].
     """
 
-    # Get address_ds that have a PO box
+    # Get address_ids that have a PO box
     po_box_address_ids = formatted_obs_data["po_box"] != data_values.NO_PO_BOX
     # Setup mailing address map
     mailing_address_map = {}
     # Copy address line one columns and blank out columns for PO box address_ids.
     for column in HOUSEHOLD_ADDRESS_COL_MAP.values():
         mailing_address_map[f"mailing_address_{column}"] = pd.Series(
-            "", index=formatted_obs_data.index
+            np.nan, index=formatted_obs_data.index
         )
         # Move over address details for non-PO box addresses
         mailing_address_map[f"mailing_address_{column}"][~po_box_address_ids] = maps[column][

--- a/tests/test_synthetic_pii.py
+++ b/tests/test_synthetic_pii.py
@@ -682,7 +682,7 @@ def test_mailing_address(mocker):
 
     for column in ["street_number", "street_name", "unit_number"]:
         column_name = f"mailing_address_{column}"
-        assert (mailing_map[column_name][po_box_mask] == "").all()
+        assert (mailing_map[column_name][po_box_mask].isna()).all()
         assert (
             mailing_map[column_name][~po_box_mask] == fake_maps[column][~po_box_mask]
         ).all()


### PR DESCRIPTION
## Mic-4484/fix empty strings in po box street details

### Changes empty strings to np.nan in street detail columns for address ids with po boxes.
- *Category*: Bugfix
- *JIRA issue*: [MIC-4484](https://jira.ihme.washington.edu/browse/MIC-4484)
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
-changes empty strings to np.nan for mailing address street details
-fixes typo in comment

### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->

