### PR TITLE
Mic-4382/lint-before-tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,12 +74,11 @@ jobs:
       - name: Install dependencies
         run: |
           pip install .[test]
-      - name: Test
-        run: |
-          pytest ./tests
-
       - name: Lint
         run: |
           pip install black==22.3.0 isort
           black . --check -v
           isort . --check -v
+      - name: Test
+        run: |
+          pytest ./tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,11 +74,11 @@ jobs:
       - name: Install dependencies
         run: |
           pip install .[test]
-      - name: Test
-        run: |
-          pytest ./tests
       - name: Lint
         run: |
           pip install black==22.3.0 isort
           black . --check --diff
           isort . --check --verbose --only-modified --diff
+      - name: Test
+        run: |
+          pytest ./tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,8 +77,8 @@ jobs:
       - name: Lint
         run: |
           pip install black==22.3.0 isort
-          black . --check -v
-          isort . --check -v
+          black . --check --diff
+          isort . --check --verbose --only-modified --diff
       - name: Test
         run: |
           pytest ./tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,11 +74,11 @@ jobs:
       - name: Install dependencies
         run: |
           pip install .[test]
+      - name: Test
+        run: |
+          pytest ./tests
       - name: Lint
         run: |
           pip install black==22.3.0 isort
           black . --check --diff
           isort . --check --verbose --only-modified --diff
-      - name: Test
-        run: |
-          pytest ./tests


### PR DESCRIPTION
## Mic-4382/lint-before-tests

### Moves linting before tests for builds.
- *Category*: Other
- *JIRA issue*: [MIC-4382](https://jira.ihme.washington.edu/browse/MIC-4382)
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
-moves linting before tests in builds

### Verification and Testing
All tests pass.

