### PR TITLE
Mic-4382/lint-before-tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,12 +74,12 @@ jobs:
       - name: Install dependencies
         run: |
           pip install .[test]
-      - name: Test
-        run: |
-          pytest ./tests
 
       - name: Lint
         run: |
           pip install black==22.3.0 isort
           black . --check -v
           isort . --check -v
+      - name: Test
+        run: |
+          pytest ./tests


### PR DESCRIPTION
## Mic-4382/lint-before-tests

### Runs linting before tests in build.
- *Category*: Other
- *JIRA issue*: [MIC-4382](https://jira.ihme.washington.edu/browse/MIC-4382)
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
-swaps order of linting and tests in build.

### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->

