### PR TITLE
Mic 4575/optimize last name proportion test

### DIFF
--- a/src/vivarium_census_prl_synth_pop/results_processing/names.py
+++ b/src/vivarium_census_prl_synth_pop/results_processing/names.py
@@ -112,12 +112,13 @@ def get_last_name_map(
         obs_results=obs_data,
         output_columns=output_cols,
     )
-
     # Get oldest simulant for each existing last_name_id
-    name_data = name_data.groupby("last_name_id", group_keys=False).apply(
-        pd.DataFrame.sort_values, "date_of_birth"
+    oldest = (
+        name_data.sort_values("date_of_birth")
+        .reset_index()
+        .drop_duplicates("last_name_id")
+        .set_index("last_name_id")
     )
-    oldest = name_data.reset_index().drop_duplicates("last_name_id").set_index("last_name_id")
 
     last_names_map = pd.Series("", index=oldest.index)
     for race_eth, df_race_eth in oldest.groupby("race_ethnicity"):

--- a/tests/test_synthetic_pii.py
+++ b/tests/test_synthetic_pii.py
@@ -167,7 +167,6 @@ def test_first_and_middle_names(mocker, given_names, fake_obs_data):
     assert (first_names["first_name"] != middle_names["middle_name"]).any()
 
 
-@pytest.mark.slow
 def test_last_names_proportions(mocker, last_names, fake_obs_data):
     # This function tests that the sampling proportions are working as expected
     artifact = mocker.MagicMock()


### PR DESCRIPTION
## Mic 4575/optimize last name proportion test

### Optimizes last name proportion test.
- *Category*: Test
- *JIRA issue*: [MIC-4575](https://jira.ihme.washington.edu/browse/MIC-4575)
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
-updates test to not use groupby and apply on sort values. 

### Verification and Testing
Test passes in 2 seconds instead of 47 minutes.

