### PR TITLE
Mic-4733/Add guardian duplication proportions to metadata

### DIFF
--- a/src/vivarium_census_prl_synth_pop/tools/make_results.py
+++ b/src/vivarium_census_prl_synth_pop/tools/make_results.py
@@ -631,7 +631,7 @@ def write_shard_metadata(
         metadata.DatasetNames.ACS,
         metadata.DatasetNames.CPS,
     ]:
-        obs_data = merge_dependents_and_guardians(obs_data)
+        obs_data = merge_dependents_and_guardians(observer, obs_data)
     groupby_cols = year_col + [state_col]
     metadata_dfs = []
     for (year, location), group_data in obs_data.groupby(groupby_cols):

--- a/src/vivarium_census_prl_synth_pop/tools/make_results.py
+++ b/src/vivarium_census_prl_synth_pop/tools/make_results.py
@@ -587,13 +587,8 @@ def write_shard_metadata(
             metadata_df["row_noise.row_probability_in_households_under_18"] = len(
                 df.loc[(df["age"] < 18) & (df["housing_type"] == "Household")]
             )
-            metadata_df["row_noise.row_probability_in_households_18_to_23"] = len(
-                df.loc[
-                    (df["age"] >= 18) & (df["age"] < 24) & (df["housing_type"] == "Household")
-                ]
-            )
-            metadata_df["row_noise.row_probability_in_group_quarters_under_24"] = len(
-                df.loc[(df["age"] < 24) & (df["housing_type"] != "Household")]
+            metadata_df["row_noise.row_probability_in_college_group_quarters_under_24"] = len(
+                df.loc[(df["age"] < 24) & (df["housing_type"] == "College")]
             )
 
         for column_name in df.columns:

--- a/src/vivarium_census_prl_synth_pop/tools/make_results.py
+++ b/src/vivarium_census_prl_synth_pop/tools/make_results.py
@@ -640,11 +640,7 @@ def write_shard_metadata(
 
     # We need to also calculate guardian duplication at the national level here since
     # each shard should have all guardian dependent pair.
-    if observer in [
-        metadata.DatasetNames.CENSUS,
-        metadata.DatasetNames.ACS,
-        metadata.DatasetNames.CPS,
-    ]:
+    if observer == metadata.DatasetNames.CENSUS:
         for year in obs_data["year"].unique():
             national_metadata = pd.DataFrame(index=["USA"])
             national_metadata["year"] = year

--- a/src/vivarium_census_prl_synth_pop/tools/make_results.py
+++ b/src/vivarium_census_prl_synth_pop/tools/make_results.py
@@ -631,7 +631,7 @@ def write_shard_metadata(
         metadata.DatasetNames.ACS,
         metadata.DatasetNames.CPS,
     ]:
-        obs_data = merge_dependents_and_guardians(observer, obs_data)
+        obs_data = merge_dependents_and_guardians(obs_data)
     groupby_cols = year_col + [state_col]
     metadata_dfs = []
     for (year, location), group_data in obs_data.groupby(groupby_cols):

--- a/src/vivarium_census_prl_synth_pop/tools/make_results.py
+++ b/src/vivarium_census_prl_synth_pop/tools/make_results.py
@@ -584,7 +584,7 @@ def write_shard_metadata(
             metadata.DatasetNames.ACS,
             metadata.DatasetNames.CPS,
         ]:
-            df = calculate_guardian_duplication_metadata_proportions(metadata_df, df)
+            metadata_df = calculate_guardian_duplication_metadata_proportions(metadata_df, df)
 
         for column_name in df.columns:
             columns = [col.name for col in COLUMNS]

--- a/src/vivarium_census_prl_synth_pop/tools/make_results.py
+++ b/src/vivarium_census_prl_synth_pop/tools/make_results.py
@@ -6,8 +6,6 @@ from typing import Dict, List
 import pandas as pd
 import pyarrow.parquet as pq
 from loguru import logger
-from pseudopeople.constants.metadata import COPY_HOUSEHOLD_MEMBER_COLS
-from pseudopeople.schema_entities import COLUMNS
 from vivarium import Artifact
 from vivarium.framework.randomness import RandomnessStream
 from vivarium.framework.randomness.index_map import IndexMap
@@ -30,10 +28,10 @@ from vivarium_census_prl_synth_pop.results_processing.ssn_and_itin import (
     get_simulant_id_maps,
 )
 from vivarium_census_prl_synth_pop.utilities import (
+    _get_metadata_counts,
     build_output_dir,
-    calculate_guardian_duplication_metadata_proportions,
     get_all_simulation_seeds,
-    load_nicknames_data,
+    get_guardian_duplication_row_counts,
     merge_dependents_and_guardians,
     sanitize_location,
     write_to_disk,
@@ -569,46 +567,18 @@ def subset_results_by_state(processed_results_dir: str, state: str) -> None:
 def write_shard_metadata(
     observer: str, obs_data: pd.DataFrame, obs_dir: Path, seed_ext: str
 ) -> None:
-    # Writes metadata for each shard of data. This will be proportions available to noise
-    # for specific columns.
-
-    def _get_metadata_values(
-        observer: str, df: pd.DataFrame, location: str, year: int
-    ) -> pd.DataFrame:
-        metadata_df = pd.DataFrame(index=[location])
-        metadata_df["number_of_rows"] = len(df)
-        metadata_df["year"] = year
-
-        if observer in [
-            metadata.DatasetNames.CENSUS,
-            metadata.DatasetNames.ACS,
-            metadata.DatasetNames.CPS,
-        ]:
-            metadata_df = calculate_guardian_duplication_metadata_proportions(metadata_df, df)
-
-        for column_name in df.columns:
-            columns = [col.name for col in COLUMNS]
-            if column_name in columns:
-                column = COLUMNS.get_column(column_name)
-                noise_type_names = [noise_type.name for noise_type in column.noise_types]
-                if "copy_from_household_member" in noise_type_names:
-                    # Get number of rows that could potentially copy a household member
-                    metadata_df[f"{column_name}.copy_from_household_member"] = (
-                        df[COPY_HOUSEHOLD_MEMBER_COLS[column_name]].notna().sum()
-                    )
-                if "use_nickname" in noise_type_names:
-                    # Get number of rows eligible to be noised to a nickname
-                    nicknames = load_nicknames_data()
-                    metadata_df[f"{column_name}.use_nickname"] = (
-                        df[column_name].isin(nicknames.index).sum()
-                    )
-        return metadata_df
+    # Writes metadata for each shard of data. This will be used to aggregate metadata
+    # to calculate noise proportions at the end of post-processing.
 
     # Get year column to group by
     obs_data = obs_data.copy()
     date_columns = ["year", "tax_year", "event_date", "survey_date"]
     year_col = [col for col in obs_data.columns if col in date_columns]
-    state_col = "state" if "state" in obs_data.columns else "mailing_address_state"
+    state_col = (
+        "state"
+        if "state" in obs_data.columns or observer == metadata.DatasetNames.SSA
+        else "mailing_address_state"
+    )
     # For ACS, CPS, and SSA, we need to extract year from the year column because they are
     # currently dates
     if observer in [
@@ -621,7 +591,6 @@ def write_shard_metadata(
         year_col = ["year"]
     # Special case SSA dataset since that does not have a state column
     if observer == metadata.DatasetNames.SSA:
-        state_col = "state"
         obs_data[state_col] = "USA"
 
     # Merge dependents with their guardians. This is only implemented for census
@@ -632,26 +601,82 @@ def write_shard_metadata(
         metadata.DatasetNames.CPS,
     ]:
         obs_data = merge_dependents_and_guardians(obs_data)
-    groupby_cols = year_col + [state_col]
     metadata_dfs = []
-    for (year, location), group_data in obs_data.groupby(groupby_cols):
-        state_metadata = _get_metadata_values(observer, group_data, location, year)
+    # Get metadata for each year, location pair
+    for (year, location), group_data in obs_data.groupby(year_col + [state_col]):
+        state_metadata = _get_metadata_counts(observer, group_data, location, year)
         metadata_dfs.append(state_metadata)
 
     # We need to also calculate guardian duplication at the national level here since
     # each shard should have all guardian dependent pair.
-    if observer == metadata.DatasetNames.CENSUS:
-        for year in obs_data["year"].unique():
-            national_metadata = pd.DataFrame(index=["USA"])
-            national_metadata["year"] = year
-            national_metadata = calculate_guardian_duplication_metadata_proportions(
+    for year in obs_data["year"].unique():
+        national_metadata = pd.DataFrame(index=["USA"])
+        national_metadata["year"] = year
+        if observer in [
+            metadata.DatasetNames.CENSUS,
+            metadata.DatasetNames.ACS,
+            metadata.DatasetNames.CPS,
+        ]:
+            national_metadata = get_guardian_duplication_row_counts(
                 national_metadata, obs_data[obs_data["year"] == year]
             )
-            metadata_dfs.append(national_metadata)
+        metadata_dfs.append(national_metadata)
+    # Combined metadata for processing
+    shard_metadata = pd.concat(metadata_dfs).reset_index().rename(columns={"index": "state"})
 
-    shard_metadata = pd.concat(metadata_dfs)
-    shard_metadata["dataset"] = observer
+    # Aggregate count columns to get national counts for each year
+    location_aggregation_cols = [
+        col
+        for col in shard_metadata.columns
+        if col not in ["year", state_col] and "row_noise" not in col
+    ]
+    for year in shard_metadata["year"].unique():
+        shard_metadata.loc[
+            (shard_metadata["state"] == "USA") & (shard_metadata["year"] == year),
+            location_aggregation_cols,
+        ] = (
+            shard_metadata.loc[
+                (shard_metadata["state"] != "USA") & (shard_metadata["year"] == year),
+                location_aggregation_cols,
+            ]
+            .sum()
+            .values
+        )
+
+    # Aggregate location counts to get counts for ALL years. First, we need to add placeholder rows
+    # for each location and the aggregated year value
+    for location in shard_metadata["state"].unique():
+        year_aggregation_df = pd.DataFrame(
+            {"state": [location], "year": [metadata.YEAR_AGGREGATION_VALUE]}
+        )
+        shard_metadata = shard_metadata.concat([shard_metadata, year_aggregation_df])
+        shard_metadata.loc[
+            (shard_metadata["state"] == location)
+            & (shard_metadata["year"] == metadata.YEAR_AGGREGATION_VALUE),
+            [col for col in shard_metadata.columns if col not in ["year", state_col]],
+        ] = (
+            shard_metadata.loc[
+                (shard_metadata["state"] == location)
+                & (shard_metadata["year"] != metadata.YEAR_AGGREGATION_VALUE),
+                [col for col in shard_metadata.columns if col not in ["year", state_col]],
+            ]
+            .sum()
+            .values
+        )
+
+    # We must "weight" (cumulative sum) the SSA counts because when users query in pseudopeople user filters
+    # are the queried year AND all preceeding years.
+    if observer == metadata.DatasetNames.SSA:
+        shard_metadata = shard_metadata.sort_values("year")
+        shard_metadata = (
+            shard_metadata.groupby(["state", "year"])
+            .sum()
+            .groupby(level=0)
+            .cumsum()
+            .reset_index()
+        )
 
     # Write shard metadata
+    shard_metadata["dataset"] = observer
     shard_metadata_path = obs_dir / f"shard_metadata{seed_ext}.csv"
-    shard_metadata.to_csv(shard_metadata_path, index_label="state")
+    shard_metadata.to_csv(shard_metadata_path, index=False)

--- a/src/vivarium_census_prl_synth_pop/tools/make_results.py
+++ b/src/vivarium_census_prl_synth_pop/tools/make_results.py
@@ -649,7 +649,7 @@ def write_shard_metadata(
         year_aggregation_df = pd.DataFrame(
             {"state": [location], "year": [metadata.YEAR_AGGREGATION_VALUE]}
         )
-        shard_metadata = shard_metadata.concat([shard_metadata, year_aggregation_df])
+        shard_metadata = pd.concat([shard_metadata, year_aggregation_df])
         shard_metadata.loc[
             (shard_metadata["state"] == location)
             & (shard_metadata["year"] == metadata.YEAR_AGGREGATION_VALUE),

--- a/src/vivarium_census_prl_synth_pop/tools/make_results.py
+++ b/src/vivarium_census_prl_synth_pop/tools/make_results.py
@@ -646,6 +646,9 @@ def write_shard_metadata(
 
     # Aggregate location counts to get counts for ALL years. First, we need to add placeholder rows
     # for each location and the aggregated year value
+    year_aggregation_columns = [
+        col for col in shard_metadata.columns if col not in ["year", state_col]
+    ]
     for location in shard_metadata["state"].unique():
         year_aggregation_df = pd.DataFrame(
             {"state": [location], "year": [metadata.YEAR_AGGREGATION_VALUE]}
@@ -654,12 +657,12 @@ def write_shard_metadata(
         shard_metadata.loc[
             (shard_metadata["state"] == location)
             & (shard_metadata["year"] == metadata.YEAR_AGGREGATION_VALUE),
-            [col for col in shard_metadata.columns if col not in ["year", state_col]],
+            year_aggregation_columns,
         ] = (
             shard_metadata.loc[
                 (shard_metadata["state"] == location)
                 & (shard_metadata["year"] != metadata.YEAR_AGGREGATION_VALUE),
-                [col for col in shard_metadata.columns if col not in ["year", state_col]],
+                year_aggregation_columns,
             ]
             .sum()
             .values

--- a/src/vivarium_census_prl_synth_pop/tools/make_results.py
+++ b/src/vivarium_census_prl_synth_pop/tools/make_results.py
@@ -586,9 +586,20 @@ def write_shard_metadata(
         ]:
             metadata_df["row_noise.row_probability_in_households_under_18"] = len(
                 df.loc[(df["age"] < 18) & (df["housing_type"] == "Household")]
+            ) / len(
+                df.loc[
+                    (df["age"] < 18)
+                    & (df["housing_type"] == "Household")
+                    & (df["guardian_1"].notna())
+                ]
             )
             metadata_df["row_noise.row_probability_in_college_group_quarters_under_24"] = len(
                 df.loc[(df["age"] < 24) & (df["housing_type"] == "College")]
+            ) / len(
+                df.loc[
+                    df["age"]
+                    < 24 & (df["housing_type"] == "College") & (df["guardian_1"].notna())
+                ]
             )
 
         for column_name in df.columns:

--- a/src/vivarium_census_prl_synth_pop/tools/make_results.py
+++ b/src/vivarium_census_prl_synth_pop/tools/make_results.py
@@ -584,15 +584,15 @@ def write_shard_metadata(
             metadata.DatasetNames.ACS,
             metadata.DatasetNames.CPS,
         ]:
-            metadata_df["row_probability.row_probability_in_households_under_18"] = len(
+            metadata_df["row_noise.row_probability_in_households_under_18"] = len(
                 df.loc[(df["age"] < 18) & (df["housing_type"] == "Household")]
             )
-            metadata_df["row_probability.row_probability_in_households_18_to_23"] = len(
+            metadata_df["row_noise.row_probability_in_households_18_to_23"] = len(
                 df.loc[
                     (df["age"] >= 18) & (df["age"] < 24) & (df["housing_type"] == "Household")
                 ]
             )
-            metadata_df["row_probability.row_probability_in_group_quarters_under_24"] = len(
+            metadata_df["row_noise.row_probability_in_group_quarters_under_24"] = len(
                 df.loc[(df["age"] < 24) & (df["housing_type"] != "Household")]
             )
 

--- a/src/vivarium_census_prl_synth_pop/tools/make_results.py
+++ b/src/vivarium_census_prl_synth_pop/tools/make_results.py
@@ -607,9 +607,10 @@ def write_shard_metadata(
         state_metadata = _get_metadata_counts(observer, group_data, location, year)
         metadata_dfs.append(state_metadata)
 
-    # We need to also calculate guardian duplication at the national level here since
+    # We need to create a nation aggregation row to update later.
+    # We also need to also calculate guardian duplication at the national level here since
     # each shard should have all guardian dependent pair.
-    for year in obs_data["year"].unique():
+    for year in obs_data[year_col].squeeze().unique():
         national_metadata = pd.DataFrame(index=["USA"])
         national_metadata["year"] = year
         if observer in [

--- a/src/vivarium_census_prl_synth_pop/utilities.py
+++ b/src/vivarium_census_prl_synth_pop/utilities.py
@@ -583,10 +583,10 @@ def record_metadata_proportions(final_output_dir: Path) -> None:
         # we have in the metadata and value is that original columns value
         # Example age.copy_from_household_member is in variable.unique() and its "value"
         # is the number of non-null rows we recorded in the original shard metadata
-        # Schema entity is either a column name or row noise and noise entity is the column
+        # Column is either a column name or row noise and noise type is the column
         # or row noise type.
         melted_metadata["column"] = melted_metadata["variable"].str.split(".").str[0]
-        melted_metadata["noise_entity"] = melted_metadata["variable"].str.split(".").str[1]
+        melted_metadata["noise_type"] = melted_metadata["variable"].str.split(".").str[1]
         # Calculate noise proportions
         melted_metadata["proportion"] = (
             melted_metadata["value"] / melted_metadata["number_of_rows"]

--- a/src/vivarium_census_prl_synth_pop/utilities.py
+++ b/src/vivarium_census_prl_synth_pop/utilities.py
@@ -633,29 +633,30 @@ def record_metadata_proportions(final_output_dir: Path) -> None:
     metadata_final.to_csv(final_output_dir / "metadata_proportions.csv", index=False)
 
 
-def merge_dependents_and_guardians(data: pd.DataFrame) -> pd.DataFrame:
+def merge_dependents_and_guardians(dataset_name: str, data: pd.DataFrame) -> pd.DataFrame:
     # Merge dependents with their guardians. We have to merge twice to check
     # if either guardian is living at a separate location from the dependent.
+    dataset = DATASETS.get_dataset(dataset_name)
     guardian_1s = data.loc[
         data["simulant_id"].isin(data["guardian_1"]),
-        ["simulant_id", "household_id"],
+        ["simulant_id", "household_id", dataset.year_column],
     ].add_prefix("guardian_1_")
     dependents_and_guardians_df = data.merge(
         guardian_1s,
         how="left",
         left_on=["guardian_1", "year"],
-        right_on=["guardian_1_simulant_id", "guardian_1_year"],
+        right_on=["guardian_1_simulant_id", f"guardian_1_{dataset.year_column}"],
     )
     del guardian_1s
     guardian_2s = data.loc[
         data["simulant_id"].isin(data["guardian_2"]),
-        ["simulant_id", "household_id"],
+        ["simulant_id", "household_id", dataset.year_column],
     ].add_prefix("guardian_2_")
     dependents_and_guardians_df = dependents_and_guardians_df.merge(
         guardian_2s,
         how="left",
         left_on=["guardian_2", "year"],
-        right_on=["guardian_2_simulant_id", "guardian_2_year"],
+        right_on=["guardian_2_simulant_id", f"guardian_2_{dataset.year_column}"],
     )
     del guardian_2s
 

--- a/src/vivarium_census_prl_synth_pop/utilities.py
+++ b/src/vivarium_census_prl_synth_pop/utilities.py
@@ -608,10 +608,13 @@ def record_metadata_proportions(final_output_dir: Path) -> None:
         melted_metadata["schema_entity"] = melted_metadata["variable"].str.split(".").str[0]
         melted_metadata["noise_entity"] = melted_metadata["variable"].str.split(".").str[1]
         # Calculate proportions
-        melted_metadata["proportion"] = (
-            melted_metadata["value"] / melted_metadata["number_of_rows"]
+        # If schema entity is row noise we have already calculated the proportions
+        # so we only need to calculate the proportion for column noise
+        melted_metadata["proportion"] = np.where(
+            melted_metadata["schema_entity"] == "row_noise",
+            melted_metadata["value"],
+            (melted_metadata["value"] / melted_metadata["number_of_rows"]),
         )
-        # Drop unnecessary columns
         melted_metadata = melted_metadata.drop(columns=["variable", "value"])
         dataset_metadata_dfs.append(melted_metadata)
 

--- a/src/vivarium_census_prl_synth_pop/utilities.py
+++ b/src/vivarium_census_prl_synth_pop/utilities.py
@@ -563,6 +563,14 @@ def record_metadata_proportions(final_output_dir: Path) -> None:
             pd.read_csv(shard_metadata_file) for shard_metadata_file in shard_metadata_files
         ]
         dataset_metadata = pd.concat(metadata_dfs)
+        # Sum count values
+        groupby_cols = ["dataset", "state", "year"]
+        aggregate_count_cols = [
+            col for col in dataset_metadata.columns if col not in groupby_cols
+        ]
+        dataset_metadata = (
+            dataset_metadata.groupby(groupby_cols)[aggregate_count_cols].sum().reset_index()
+        )
 
         # Calculate proportions for each dataset's location, year combination.
         # Reshape metadata to have dataset, year, state, column, noise_type

--- a/src/vivarium_census_prl_synth_pop/utilities.py
+++ b/src/vivarium_census_prl_synth_pop/utilities.py
@@ -666,33 +666,39 @@ def calculate_guardian_duplication_metadata_proportions(
     metadata_df: pd.DataFrame, df: pd.DataFrame
 ) -> pd.DataFrame:
     # Get number of rows for each duplicate with guardian group
-    metadata_df["row_noise.row_probability_in_households_under_18"] = len(
-        df.loc[
-            (df["age"] < 18)
-            & (df["housing_type"] == "Household")
-            & (df["guardian_1"].notna())
-            & (
-                (df["household_id"] != df["guardian_1_household_id"])
-                | (
-                    (df["guardian_2"].notna())
-                    & (df["household_id"] != df["guardian_2_household_id"])
+    try:
+        metadata_df["row_noise.row_probability_in_households_under_18"] = len(
+            df.loc[
+                (df["age"] < 18)
+                & (df["housing_type"] == "Household")
+                & (df["guardian_1"].notna())
+                & (
+                    (df["household_id"] != df["guardian_1_household_id"])
+                    | (
+                        (df["guardian_2"].notna())
+                        & (df["household_id"] != df["guardian_2_household_id"])
+                    )
                 )
-            )
-        ]
-    ) / len(df.loc[(df["age"] < 18) & (df["housing_type"] == "Household")])
-    metadata_df["row_noise.row_probability_in_college_group_quarters_under_24"] = len(
-        df.loc[
-            (df["age"] < 24)
-            & (df["housing_type"] == "College")
-            & (df["guardian_1"].notna())
-            & (
-                (df["household_id"] != df["guardian_1_household_id"])
-                | (
-                    (df["guardian_2"].notna())
-                    & (df["household_id"] != df["guardian_2_household_id"])
+            ]
+        ) / len(df.loc[(df["age"] < 18) & (df["housing_type"] == "Household")])
+    except ZeroDivisionError:
+        metadata_df["row_noise.row_probability_in_households_under_18"] = 0.0
+    try:
+        metadata_df["row_noise.row_probability_in_college_group_quarters_under_24"] = len(
+            df.loc[
+                (df["age"] < 24)
+                & (df["housing_type"] == "College")
+                & (df["guardian_1"].notna())
+                & (
+                    (df["household_id"] != df["guardian_1_household_id"])
+                    | (
+                        (df["guardian_2"].notna())
+                        & (df["household_id"] != df["guardian_2_household_id"])
+                    )
                 )
-            )
-        ]
-    ) / len(df.loc[(df["age"] < 24) & (df["housing_type"] == "College")])
+            ]
+        ) / len(df.loc[(df["age"] < 24) & (df["housing_type"] == "College")])
+    except ZeroDivisionError:
+        metadata_df["row_noise.row_probability_in_college_group_quarters_under_24"] = 0.0
 
     return metadata_df

--- a/src/vivarium_census_prl_synth_pop/utilities.py
+++ b/src/vivarium_census_prl_synth_pop/utilities.py
@@ -603,8 +603,10 @@ def record_metadata_proportions(final_output_dir: Path) -> None:
         # we have in the metadata and value is that original columns value
         # Example age.copy_from_household_member is in variable.unique() and its "value"
         # is the number of non-null rows we recorded in the original shard metadata
-        melted_metadata["column"] = melted_metadata["variable"].str.split(".").str[0]
-        melted_metadata["noise_type"] = melted_metadata["variable"].str.split(".").str[1]
+        # Schema entity is either a column name or row noise and noise entity is the column
+        # or row noise type.
+        melted_metadata["schema_entity"] = melted_metadata["variable"].str.split(".").str[0]
+        melted_metadata["noise_entity"] = melted_metadata["variable"].str.split(".").str[1]
         # Calculate proportions
         melted_metadata["proportion"] = (
             melted_metadata["value"] / melted_metadata["number_of_rows"]

--- a/src/vivarium_census_prl_synth_pop/utilities.py
+++ b/src/vivarium_census_prl_synth_pop/utilities.py
@@ -633,30 +633,29 @@ def record_metadata_proportions(final_output_dir: Path) -> None:
     metadata_final.to_csv(final_output_dir / "metadata_proportions.csv", index=False)
 
 
-def merge_dependents_and_guardians(dataset_name: str, data: pd.DataFrame) -> pd.DataFrame:
+def merge_dependents_and_guardians(data: pd.DataFrame) -> pd.DataFrame:
     # Merge dependents with their guardians. We have to merge twice to check
     # if either guardian is living at a separate location from the dependent.
-    dataset = DATASETS.get_dataset(dataset_name)
     guardian_1s = data.loc[
         data["simulant_id"].isin(data["guardian_1"]),
-        ["simulant_id", "household_id", dataset.year_column],
+        ["simulant_id", "household_id", "year"],
     ].add_prefix("guardian_1_")
     dependents_and_guardians_df = data.merge(
         guardian_1s,
         how="left",
         left_on=["guardian_1", "year"],
-        right_on=["guardian_1_simulant_id", f"guardian_1_{dataset.year_column}"],
+        right_on=["guardian_1_simulant_id", "guardian_1_year"],
     )
     del guardian_1s
     guardian_2s = data.loc[
         data["simulant_id"].isin(data["guardian_2"]),
-        ["simulant_id", "household_id", dataset.year_column],
+        ["simulant_id", "household_id", "year"],
     ].add_prefix("guardian_2_")
     dependents_and_guardians_df = dependents_and_guardians_df.merge(
         guardian_2s,
         how="left",
         left_on=["guardian_2", "year"],
-        right_on=["guardian_2_simulant_id", f"guardian_2_{dataset.year_column}"],
+        right_on=["guardian_2_simulant_id", "guardian_2_year"],
     )
     del guardian_2s
 

--- a/src/vivarium_census_prl_synth_pop/utilities.py
+++ b/src/vivarium_census_prl_synth_pop/utilities.py
@@ -592,6 +592,7 @@ def record_metadata_proportions(final_output_dir: Path) -> None:
             dataset_metadata = dataset_metadata.drop(
                 columns=[col for col in dataset_metadata.columns if "row_noise" in col]
             )
+            aggregate_cols = [col for col in aggregate_cols if "row_noise" not in col]
             year_aggregated_metadata = (
                 dataset_metadata.groupby(by=["dataset", "year"])[aggregate_cols]
                 .sum()


### PR DESCRIPTION
## Mic-4733/Add guardian duplication proportions to metadata

### Adds guardian duplication noise proportions to metadata for user warnings.
- *Category*: Feature
- *JIRA issue*: [MIC-4733](https://jira.ihme.washington.edu/browse/MIC-4733)
- *Research reference*: https://vivarium-research.readthedocs.io/en/latest/models/concept_models/vivarium_census_synthdata/concept_model.html#id123

### Changes and notes
-adds guardian duplication to metadata proportions file

### Verification and Testing
All tests pass
