### PR TITLE
fix broken test due to population_view setter restrictions

### DIFF
--- a/tests/components/test_population.py
+++ b/tests/components/test_population.py
@@ -201,7 +201,7 @@ def test_update_to_reference_person_and_relationships(mocker, fake_population):
 
     # Setup class methods we need to update fake state table
     pop_component.start_time = pd.Timestamp("2020-04-01 00:00:00")
-    pop_component.population_view = mocker.MagicMock()
+    pop_component._population_view = mocker.MagicMock()
     pop_component.population_view.get = lambda idx, query: fake_population.loc[idx]
 
     # This is a series with household_id as the index and the new reference person as the value


### PR DESCRIPTION
## Fix broken test due to population_view setter restrictions
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: bugfix
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5329
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
Properly set mock population view in test 

### Verification and Testing
Tests pass
